### PR TITLE
Fix for ZoomSelection, if Query on FC returns empty Collection and therefore an invalid ReferenceEnvelope

### DIFF
--- a/plugins/net.refractions.udig.tool.select/src/net/refractions/udig/tool/select/internal/ZoomSelection.java
+++ b/plugins/net.refractions.udig.tool.select/src/net/refractions/udig/tool/select/internal/ZoomSelection.java
@@ -54,15 +54,18 @@ public class ZoomSelection extends AbstractActionTool {
                         bounds = new ReferencedEnvelope(envelope, layer.getCRS());
                     }
                 }
-                // If the selection is a single point the bounds will
-                // have height == 0 and width == 0. This will break
-                // in ScaleUtils:306. Adding 1 to the extent fixes the problem:
-                if (bounds.getHeight() <= 0 || bounds.getWidth() <= 0) {
-                    bounds.expandBy(1);
-                }
-                bounds = ScaleUtils.fitToMinAndMax(bounds, layer);
-
-                getContext().sendASyncCommand(new SetViewportBBoxCommand(bounds, layer.getCRS()));
+                
+                if (bounds != null && (bounds.getMaxX() > bounds.getMinX() && bounds.getMaxY() > bounds.getMinY())) {
+	                // If the selection is a single point the bounds will
+	                // have height == 0 and width == 0. This will break
+	                // in ScaleUtils:306. Adding 1 to the extent fixes the problem:
+	                if (bounds.getHeight() <= 0 || bounds.getWidth() <= 0) {
+	                    bounds.expandBy(1);
+	                }
+	                bounds = ScaleUtils.fitToMinAndMax(bounds, layer);
+	
+	                getContext().sendASyncCommand(new SetViewportBBoxCommand(bounds, layer.getCRS()));
+            	}
             } catch (IOException e) {
                 SelectPlugin.log("failed to obtain resource", e); //$NON-NLS-1$
             }


### PR DESCRIPTION
Hello developers,

I just run into troubles with the ZoomSelection Tool which should perform a zoom to the selection of the current selected layer. It works quite perfect if the Query-Filter matches any features and therefor a ReferencedEnvelope can be calculated from the (Sub)FeatureCollection.

To reproduce, I've done the following steps:

create a new map and add a shapefile per drag&drop
use the "Select rectangle Tool
define a rectangle in map in empty space (the tool "Zoom to selection" was disabled and changes to enabled)
use the "Zoom to selection" Tool and voila : the extend of the map changes although there is no feature selected!
And that's because of an empty ReferencedEnvelope with smaller values for the maxX/maxY values than the min-Values [0.0 : -1.0, 0.0 : -1.0]

Therefore I would like to apply a patch to check the min/max values and of course null bounds before perform the SetViewportBBoxCommand Task.

Frank
