### PR TITLE
Fix the WMS plugin after the changes introduced by GEOT-3860

### DIFF
--- a/plugins/net.refractions.udig.catalog.tests.wms/src/net/refractions/udig/catalog/wmsc/server/WMSCParserTest.java
+++ b/plugins/net.refractions.udig.catalog.tests.wms/src/net/refractions/udig/catalog/wmsc/server/WMSCParserTest.java
@@ -2,15 +2,52 @@ package net.refractions.udig.catalog.wmsc.server;
 
 import static org.junit.Assert.*;
 
+import java.io.IOException;
 import java.io.InputStream;
 import java.net.URL;
 import java.util.ArrayList;
 
+import org.geotools.data.ows.HTTPResponse;
 import org.geotools.data.ows.WMSCapabilities;
 import org.junit.Test;
 
 public class WMSCParserTest {
 
+    private static class MockHttpResponse implements HTTPResponse{
+
+        private final InputStream in;
+        private final String contentType;
+
+        public MockHttpResponse(final InputStream in, final String contentType){
+            this.in = in;
+            this.contentType = contentType;
+        }
+        
+        @Override
+        public void dispose() {
+            try{
+                in.close();
+            }catch(Exception e){
+                //ignore, dispose() could be called multiple times
+            }
+        }
+
+        @Override
+        public String getContentType() {
+            return contentType;
+        }
+
+        @Override
+        public String getResponseHeader( String arg0 ) {
+            return null;
+        }
+
+        @Override
+        public InputStream getResponseStream() throws IOException {
+            return in;
+        }
+        
+    }
     @Test
     public void testGeoWebCache() throws Exception {
         URL url = WMSCParserTest.class.getResource("wmscCapabilities3.xml");
@@ -20,7 +57,7 @@ public class WMSCParserTest {
         // InputStream is = new ByteArrayInputStream(caps_xml.getBytes());
         WMSCCapabilitiesResponse response;
 
-        response = new WMSCCapabilitiesResponse("txt/xml", stream); //$NON-NLS-1$
+        response = new WMSCCapabilitiesResponse(new MockHttpResponse(stream, "text/xml")); //$NON-NLS-1$
         WMSCCapabilities capabilities = (WMSCCapabilities) response.getCapabilities();
 
         assertNotNull(capabilities.getCapability().getVSCapabilities());
@@ -40,7 +77,7 @@ public class WMSCParserTest {
         // InputStream is = new ByteArrayInputStream(caps_xml.getBytes());
         WMSCCapabilitiesResponse response;
 
-        response = new WMSCCapabilitiesResponse("txt/xml", stream); //$NON-NLS-1$
+        response = new WMSCCapabilitiesResponse(new MockHttpResponse(stream, "text/xml")); //$NON-NLS-1$
         WMSCCapabilities capabilities = (WMSCCapabilities) response.getCapabilities();
 
         assertNotNull(capabilities.getCapability().getVSCapabilities());
@@ -70,7 +107,7 @@ public class WMSCParserTest {
         // InputStream is = new ByteArrayInputStream(caps_xml.getBytes());
         WMSCCapabilitiesResponse response;
 
-        response = new WMSCCapabilitiesResponse("txt/xml", stream); //$NON-NLS-1$
+        response = new WMSCCapabilitiesResponse(new MockHttpResponse(stream, "text/xml")); //$NON-NLS-1$
         WMSCCapabilities capabilities = (WMSCCapabilities) response.getCapabilities();
 
         assertNotNull(capabilities.getCapability().getVSCapabilities());
@@ -87,7 +124,7 @@ public class WMSCParserTest {
         // InputStream is = new ByteArrayInputStream(caps_xml.getBytes());
         WMSCCapabilitiesResponse response;
 
-        response = new WMSCCapabilitiesResponse("txt/xml", stream); //$NON-NLS-1$
+        response = new WMSCCapabilitiesResponse(new MockHttpResponse(stream, "text/xml")); //$NON-NLS-1$
         WMSCCapabilities capabilities = (WMSCCapabilities) response.getCapabilities();
 
         assertNotNull(capabilities.getCapability().getVSCapabilities());

--- a/plugins/net.refractions.udig.catalog.wms/src/net/refractions/udig/catalog/wmsc/server/WMSCCapabilitiesResponse.java
+++ b/plugins/net.refractions.udig.catalog.wms/src/net/refractions/udig/catalog/wmsc/server/WMSCCapabilitiesResponse.java
@@ -25,6 +25,7 @@ import java.util.logging.Level;
 
 import org.geotools.data.ows.Capabilities;
 import org.geotools.data.ows.GetCapabilitiesResponse;
+import org.geotools.data.ows.HTTPResponse;
 import org.geotools.ows.ServiceException;
 import org.geotools.xml.DocumentFactory;
 import org.geotools.xml.handlers.DocumentHandler;
@@ -51,14 +52,18 @@ public class WMSCCapabilitiesResponse extends GetCapabilitiesResponse {
      * @throws ServiceException
      * @throws IOException
      */
-    public WMSCCapabilitiesResponse( String contentType, InputStream inputStream )
+    public WMSCCapabilitiesResponse( HTTPResponse response )
             throws ServiceException, IOException {
-        super(contentType, inputStream);
+        super(response);
         
         // first store the getcaps as a string so we can persist it, then create a 
         // new inpuststream from it to convert into a getCaps object.
-        getCaps_xml = convertStreamToString(inputStream);
-        inputStream = new ByteArrayInputStream(getCaps_xml.getBytes());
+        try{
+        getCaps_xml = convertStreamToString(response.getResponseStream());
+        }finally{
+            response.dispose();
+        }
+        InputStream inputStream = new ByteArrayInputStream(getCaps_xml.getBytes());
         
         try {
             Map<String, Object> hints = new HashMap<String, Object>();

--- a/plugins/net.refractions.udig.catalog.wms/src/net/refractions/udig/catalog/wmsc/server/WMSTile.java
+++ b/plugins/net.refractions.udig.catalog.wms/src/net/refractions/udig/catalog/wmsc/server/WMSTile.java
@@ -29,6 +29,7 @@ import net.refractions.udig.catalog.internal.wms.WmsPlugin;
 
 import org.eclipse.core.runtime.IProgressMonitor;
 import org.geotools.data.ows.AbstractRequest;
+import org.geotools.data.ows.HTTPResponse;
 import org.geotools.data.ows.Response;
 import org.geotools.ows.ServiceException;
 
@@ -343,9 +344,9 @@ public class WMSTile implements Tile {
             super(url, null);
             this.url = url;
         }
-        public Response createResponse( String contentType, InputStream inputStream )
+        public Response createResponse( HTTPResponse response )
                 throws ServiceException, IOException {
-            return new Response(contentType, inputStream){
+            return new Response(response){
             };
         }
 


### PR DESCRIPTION
Adapt net.refractions.udig.catalog.wms to the geotools wms and ows API changes made by GEOT-3860.

This merely gets you going with no functional changes. If you want to take advantage of the commons-httpclient based HTTPClient implementation to support persistent and multiple connections per WMS(-C) backend you'll need to:
- create the org.geotools.data.wms.WebMapService with a MultithreadedHttpClient instead
- same thing for TiledWebMapServer

And it would be nice to have the corresponding wizards/properties allowing the configuration of HTTP auth username and password as well as max number of concurrent persistent connections to the backend.
