### PR TITLE
ClassCastException occured, if user opens Properties on Map Element 

### DIFF
--- a/plugins/net.refractions.udig.project.ui/plugin.xml
+++ b/plugins/net.refractions.udig.project.ui/plugin.xml
@@ -234,7 +234,8 @@
       <page
             class="net.refractions.udig.project.ui.internal.property.pages.LayerInteractionPropertyPage"
             id="net.refractions.udig.project.ui.property.layer.interaction"
-            name="Interaction">
+            name="Interaction"
+            objectClass="net.refractions.udig.project.internal.Layer">
       </page>
    </extension>
 


### PR DESCRIPTION
because of a cast from getElement() to Layer in net.refractions.udig.project.ui.internal.property.pages.LayerInteractionPropertyPage.createContent()
