### PR TITLE
Fix for UDIG-1877 (File Extension behavior on windows)

### DIFF
--- a/plugins/net.refractions.udig.catalog.shp/src/net/refractions/udig/catalog/internal/shp/ShpServiceExtension.java
+++ b/plugins/net.refractions.udig.catalog.shp/src/net/refractions/udig/catalog/internal/shp/ShpServiceExtension.java
@@ -59,7 +59,10 @@ public class ShpServiceExtension extends AbstractDataStoreServiceExtension imple
             // shapefile ...
 
             URL url = null;
-            if(params.get(ShapefileDataStoreFactory.URLP.key) instanceof URL){
+            if(params.get(ShapefileDataStoreFactory.URLP.key) == null) {
+            	return null;
+            } else if (params.get(ShapefileDataStoreFactory.URLP.key) instanceof URL){
+            
                 url = (URL)params.get(ShapefileDataStoreFactory.URLP.key);
             }else{
                 try {


### PR DESCRIPTION
changes Geotools extensions to correct file extensions for SWT
FileDialog. If the metadata for Extensions doesn't exist, a
DirectoryDialog will be opened instead of FileDialog
(DirectoryDatastores)
