### PR TITLE
fix for https://jira.codehaus.org/browse/UDIG-1786, Image Export of Map ...

### DIFF
--- a/plugins/net.refractions.udig.render.feature.basic/src/net/refractions/udig/render/internal/feature/basic/BasicFeatureRenderer.java
+++ b/plugins/net.refractions.udig.render.feature.basic/src/net/refractions/udig/render/internal/feature/basic/BasicFeatureRenderer.java
@@ -38,7 +38,6 @@ import net.refractions.udig.ui.ProgressManager;
 import org.eclipse.core.runtime.IProgressMonitor;
 import org.eclipse.core.runtime.SubProgressMonitor;
 import org.eclipse.jface.preference.IPreferenceStore;
-import org.geotools.data.DefaultQuery;
 import org.geotools.data.FeatureSource;
 import org.geotools.data.FeatureStore;
 import org.geotools.data.Query;
@@ -46,13 +45,9 @@ import org.geotools.data.crs.ForceCoordinateSystemFeatureResults;
 import org.geotools.feature.FeatureCollection;
 import org.geotools.feature.SchemaException;
 import org.geotools.geometry.jts.ReferencedEnvelope;
-import org.geotools.map.DefaultMapContext;
-import org.geotools.map.DefaultMapLayer;
 import org.geotools.map.FeatureLayer;
 import org.geotools.map.Layer;
 import org.geotools.map.MapContent;
-import org.geotools.map.MapContext;
-import org.geotools.map.MapLayer;
 import org.geotools.map.MapViewport;
 import org.geotools.renderer.GTRenderer;
 import org.geotools.renderer.RenderListener;
@@ -356,9 +351,6 @@ public class BasicFeatureRenderer extends RendererImpl {
             // lower right
             paintArea.add(  Math.max(min.x, max.x) + expandPaintAreaBy,
                             Math.max(min.y, max.y) + expandPaintAreaBy);
-
-            graphics.setBackground(new Color(0,0,0,0));
-            graphics.clearRect(paintArea.x, paintArea.y, paintArea.width, paintArea.height);
 
             validBounds=getContext().worldBounds(paintArea);
 


### PR DESCRIPTION
...if shapefile layer were on top of other layers (see https://jira.codehaus.org/browse/UDIG-1786).

I tested the changes with editing tools and several shapefile, wms and coverage layers, the Image Export (jpeg, png, pdf, etc) and the basic Renderer-System for the MapViewer still work correctly. I also tested the editing tools, especially the behavior for Points with bigger marker Styles (see https://jira.codehaus.org/browse/UDIG-1765).

I was wondering, why the Image Export worked in the past (prior 1.2.x releases) and was broken since 1.2.x. Were there any changes in the rendering subsystem since 1.1.x? I've seen the class ShapefileFeatureRenderer and I'm not sure where the renderer system decides which renderer (geotools Streaming- vs. ShapefileRenderer) to prefer to paint features.
