### PR TITLE
Make mac deploy scripts "space in path" safe & add basic DMG builders

### DIFF
--- a/deploy/support_functions.sh
+++ b/deploy/support_functions.sh
@@ -70,10 +70,10 @@ function prepare_resources () {
          
          
     if [[ $PLATFORM == linux* ]] ; then
-        cp udig.sh ${BUILD}/${PLATFORM}/udig
-        chmod 755 ${BUILD}/${PLATFORM}/udig/udig_internal
-        cp udig-clean.sh ${BUILD}/${PLATFORM}/udig
-        cp udig-debug.sh ${BUILD}/${PLATFORM}/udig
+        cp udig.sh "${BUILD}/${PLATFORM}/udig"
+        chmod 755 "${BUILD}/${PLATFORM}/udig/udig_internal"
+        cp udig-clean.sh "${BUILD}/${PLATFORM}/udig"
+        cp udig-debug.sh "${BUILD}/${PLATFORM}/udig"
     fi
     if [[ $PLATFORM == win* ]] ; then
         cp *.bat ${BUILD}/${PLATFORM}/udig
@@ -84,16 +84,16 @@ function prepare_resources () {
     fi
     if [[ $PLATFORM == mac* ]] ; then
         HERE=`pwd`
-    
-        chmod 755 ${BUILD}/${PLATFORM}/udig/udig_internal.app/Contents/MacOS/udig_internal
-        mv ${BUILD}/${PLATFORM}/udig/udig_internal.app ${BUILD}/${PLATFORM}/udig/udig.app
-        rm ${BUILD}/${PLATFORM}/udig/udig_internal
-        cd  ${BUILD}/${PLATFORM}/udig/
-        ln -s udig.app/Contents/MacOS/udig_internal udig
-        cd ${HERE}
-        cp mac-udig-clean.sh ${BUILD}/${PLATFORM}/udig/udig-clean.sh
-        cp mac-udig-debug.sh ${BUILD}/${PLATFORM}/udig/udig-debug.sh
-        mv ${BUILD}/${PLATFORM}/udig/.options ${BUILD}/${PLATFORM}/udig/udig.app/Contents/MacOS/
+    	PLATFORMCONTENT="${HERE}/${BUILD}/${PLATFORM}"
+
+        chmod 755 "${PLATFORMCONTENT}/udig/udig_internal.app/Contents/MacOS/udig_internal"
+        mv "${PLATFORMCONTENT}/udig/udig_internal.app" "${PLATFORMCONTENT}/udig/udig.app"
+        rm "${PLATFORMCONTENT}/udig/udig_internal"
+        ln -s "${PLATFORMCONTENT}/udig/udig.app/Contents/MacOS/udig_internal" "${PLATFORMCONTENT}/udig/udig"
+        cp "${HERE}/mac-udig-clean.sh" "${PLATFORMCONTENT}/udig/udig-clean.sh"
+        cp "${HERE}/mac-udig-debug.sh" "${PLATFORMCONTENT}/udig/udig-debug.sh"
+        mv "${PLATFORMCONTENT}/udig/.options" "${PLATFORMCONTENT}/udig/udig.app/Contents/MacOS/"
+		make_dmg
     fi
 }
 
@@ -137,6 +137,20 @@ function windows_installer () {
         fi
     fi
 }
+
+
+function make_dmg () {
+	DMGTOOLS=`which hdiutil`
+	echo -n "Mac packaging utilities available... "
+    if [ $? == 0 ] ; then
+		echo "YES!"
+		echo -n "Building MacOS DMG for product"
+		hdiutil create -fs HFS+ -volname "udig-${VERSION}" -srcfolder "${PLATFORMCONTENT}" "${PLATFORMCONTENT}/../udig-${VERSION}.${EXT}.dmg"
+	else
+		echo "NO"
+	fi
+}
+
 
 function extract_jre () {
 

--- a/deploy/versions.sh
+++ b/deploy/versions.sh
@@ -5,17 +5,17 @@ export COPYFILE_DISABLE=true
 export BASE=`dirname $0`
 
 # Release Configuration
-export INSTALLER=${BASE}/installer
+export INSTALLER="${BASE}/installer"
 #export TARGET=${BASE}/target
 #export TARGET=${BASE}/../features/net.refractions.udig-product/target/products/
 export VERSION=1.3-SNAPSHOT
-export BUILD=${BASE}/build
+export BUILD="${BASE}/build"
 
 # Tycho Build
-export PRODUCT_TARGET=${BASE}/../features/net.refractions.udig-product/target/products
+export PRODUCT_TARGET="${BASE}/../features/net.refractions.udig-product/target/products"
 
 # Tycho SDK Build
-export PRODUCT_SDK_TARGET=${BASE}/../features/net.refractions.udig_sdk-product/target
+export PRODUCT_SDK_TARGET="${BASE}/../features/net.refractions.udig_sdk-product/target"
 
 # net.refractions.udig.libs "qualifier" for SDK (used to update libs source reference
 # example: TAG=1.3.2
@@ -23,7 +23,7 @@ export PRODUCT_SDK_TARGET=${BASE}/../features/net.refractions.udig_sdk-product/t
 export TAG=1.3.1
 
 # Build Resources
-export JRE=${BASE}/jre
+export JRE="${BASE}/jre"
 export JRE_WIN32=jre1.6.0_25.win32_gdal_ecw
 export JRE_WIN64=jre1.6.0.win64
 export JRE_LIN32=jre1.6.0_25.lin32_gdal_ecw


### PR DESCRIPTION
Paths in Mac deploy script could not deal with spaces in path names - fixed;
Simple DMG generation added to scripts. This could be updated to be more complex.
