### PR TITLE
fix for problem with feature flasher when muliple maps are open

### DIFF
--- a/plugins/net.refractions.udig.project.ui/src/net/refractions/udig/project/ui/AnimationUpdater.java
+++ b/plugins/net.refractions.udig.project.ui/src/net/refractions/udig/project/ui/AnimationUpdater.java
@@ -77,6 +77,7 @@ public class AnimationUpdater {
         }
     }
 
+    
     /**
      * Should only be used for testing
      */
@@ -132,8 +133,16 @@ public class AnimationUpdater {
             synchronized (AnimationUpdater.class) {
                 List<AnimationUpdater> updaters = displayToTaskMap.get(frameinterval);
                 for( AnimationUpdater updater : updaters ) {
-                    if (!updater.display.isDisposed() && updater.display.isVisible())
+                    if (!updater.display.isDisposed() && updater.display.isVisible()){
                         updater.run();
+                    }else{
+                    	//we want to remove this updater
+                    	for (IAnimation anim: updater.getAnimations()){
+                    		anim.setValid(false);
+                    		anim.dispose();
+                    	}
+                    	updater.remove(updater);
+                    }
                 }
             }
         }


### PR DESCRIPTION
this fixes a problem with the feature flasher when a map is hidden or disposed of in the middle of the animation.  see http://lists.refractions.net/pipermail/udig-devel/2012-December/022758.html
