### PR TITLE
fix invalid xml error msg on xml page when leaving page with no changes

### DIFF
--- a/plugins/org.locationtech.udig.style.sld/src/org/locationtech/udig/style/sld/editor/StyleXMLPage.java
+++ b/plugins/org.locationtech.udig.style.sld/src/org/locationtech/udig/style/sld/editor/StyleXMLPage.java
@@ -152,7 +152,7 @@ public class StyleXMLPage extends StyleEditorPage {
     }
 
     public boolean okToLeave() {
-        boolean readyToLeave = false;
+        boolean readyToLeave = true;
         if (dirty) { //!dirty was a condition -- not required for the moment  
             readyToLeave = updateSLD();
         }


### PR DESCRIPTION
Signed-off-by: egouge <egouge@refractions.net>

This bug occurred when you started on one of the style pages, then went to the xml style page and tried to go back to the original style page without making any changes.  uDig would generate a warning message saying the xml is invalid (even though this is not the case).

If I should be making JIRA bug reports for things like this let me know.