### PR TITLE
Fixed service sorting in catalog plugin on acquire

### DIFF
--- a/plugins/org.locationtech.udig.catalog.tests/plugin.xml
+++ b/plugins/org.locationtech.udig.catalog.tests/plugin.xml
@@ -12,6 +12,16 @@
             class="org.locationtech.udig.catalog.tests.DummyMultiResourceServiceExtension"
             id="MultiDummy"
             name="MultiDummy"/>
+      <service
+            class="org.locationtech.udig.catalog.tests.internal.LessInterestingService"
+            id="LessInterestingService"
+            name="LessInterestingService">
+      </service>
+      <service
+            class="org.locationtech.udig.catalog.tests.internal.MoreInterestingService"
+            id="MoreInterestingService"
+            name="MoreInterestingService">
+      </service>
    </extension>
     <extension
           point="org.locationtech.udig.catalog.resolvers">

--- a/plugins/org.locationtech.udig.catalog.tests/src/org/locationtech/udig/catalog/tests/internal/CatalogImplTest.java
+++ b/plugins/org.locationtech.udig.catalog.tests/src/org/locationtech/udig/catalog/tests/internal/CatalogImplTest.java
@@ -31,7 +31,7 @@ import org.locationtech.udig.catalog.URLUtils;
  */
 public class CatalogImplTest {
     
-    public static String TEST_URL = "http://www.randomurl.com"; //$NON-NLS-1$
+    public static String SERVICE_COMPARISON_TEST_URL = "http://www.randomurl.com"; //$NON-NLS-1$
 
     @Ignore
     @Test
@@ -66,7 +66,7 @@ public class CatalogImplTest {
     @Test
     public void testServiceComparison() throws Exception {
         ICatalog ci = CatalogPlugin.getDefault().getLocalCatalog();
-        IService service = ci.acquire(new URL(TEST_URL), new NullProgressMonitor());
+        IService service = ci.acquire(new URL(SERVICE_COMPARISON_TEST_URL), new NullProgressMonitor());
         assertTrue(service instanceof MoreInterestingService.MoreInterestingServiceImpl);
     }
 }

--- a/plugins/org.locationtech.udig.catalog.tests/src/org/locationtech/udig/catalog/tests/internal/CatalogImplTest.java
+++ b/plugins/org.locationtech.udig.catalog.tests/src/org/locationtech/udig/catalog/tests/internal/CatalogImplTest.java
@@ -12,13 +12,20 @@ package org.locationtech.udig.catalog.tests.internal;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
+import java.io.IOException;
+import java.net.MalformedURLException;
 import java.net.URL;
+import java.util.LinkedList;
+import java.util.List;
 
-import org.locationtech.udig.catalog.URLUtils;
-
+import org.eclipse.core.runtime.NullProgressMonitor;
 import org.eclipse.core.runtime.Platform;
 import org.junit.Ignore;
 import org.junit.Test;
+import org.locationtech.udig.catalog.CatalogPlugin;
+import org.locationtech.udig.catalog.ICatalog;
+import org.locationtech.udig.catalog.IService;
+import org.locationtech.udig.catalog.URLUtils;
 
 /**
  * Tests for the default catalog
@@ -56,5 +63,12 @@ public class CatalogImplTest {
     @Test
     public void testAquire() {
         
+    }
+    
+    @Test
+    public void testServiceComparison() throws Exception {
+        ICatalog ci = CatalogPlugin.getDefault().getLocalCatalog();
+        IService service = ci.acquire(new URL("http://www.randomurl.com"), new NullProgressMonitor()); //$NON-NLS-1$
+        assertTrue(service instanceof MoreInterestingService.MoreInterestingServiceImpl);
     }
 }

--- a/plugins/org.locationtech.udig.catalog.tests/src/org/locationtech/udig/catalog/tests/internal/CatalogImplTest.java
+++ b/plugins/org.locationtech.udig.catalog.tests/src/org/locationtech/udig/catalog/tests/internal/CatalogImplTest.java
@@ -12,11 +12,7 @@ package org.locationtech.udig.catalog.tests.internal;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
-import java.io.IOException;
-import java.net.MalformedURLException;
 import java.net.URL;
-import java.util.LinkedList;
-import java.util.List;
 
 import org.eclipse.core.runtime.NullProgressMonitor;
 import org.eclipse.core.runtime.Platform;
@@ -34,6 +30,8 @@ import org.locationtech.udig.catalog.URLUtils;
  * @since 1.1.0
  */
 public class CatalogImplTest {
+    
+    public static String TEST_URL = "http://www.randomurl.com"; //$NON-NLS-1$
 
     @Ignore
     @Test
@@ -68,7 +66,7 @@ public class CatalogImplTest {
     @Test
     public void testServiceComparison() throws Exception {
         ICatalog ci = CatalogPlugin.getDefault().getLocalCatalog();
-        IService service = ci.acquire(new URL("http://www.randomurl.com"), new NullProgressMonitor()); //$NON-NLS-1$
+        IService service = ci.acquire(new URL(TEST_URL), new NullProgressMonitor());
         assertTrue(service instanceof MoreInterestingService.MoreInterestingServiceImpl);
     }
 }

--- a/plugins/org.locationtech.udig.catalog.tests/src/org/locationtech/udig/catalog/tests/internal/LessInterestingService.java
+++ b/plugins/org.locationtech.udig.catalog.tests/src/org/locationtech/udig/catalog/tests/internal/LessInterestingService.java
@@ -71,7 +71,7 @@ public class LessInterestingService implements ServiceExtension {
     public Map<String, Serializable> createParams(URL url) {
         URL testURL = null;
         try {
-            testURL = new URL(CatalogImplTest.TEST_URL);
+            testURL = new URL(CatalogImplTest.SERVICE_COMPARISON_TEST_URL);
         }
         catch(Exception e) {}
                

--- a/plugins/org.locationtech.udig.catalog.tests/src/org/locationtech/udig/catalog/tests/internal/LessInterestingService.java
+++ b/plugins/org.locationtech.udig.catalog.tests/src/org/locationtech/udig/catalog/tests/internal/LessInterestingService.java
@@ -1,0 +1,77 @@
+package org.locationtech.udig.catalog.tests.internal;
+
+import java.io.IOException;
+import java.io.Serializable;
+import java.net.URL;
+import java.util.List;
+import java.util.Map;
+import java.util.TreeMap;
+
+import org.eclipse.core.runtime.IProgressMonitor;
+import org.locationtech.udig.catalog.IGeoResource;
+import org.locationtech.udig.catalog.IService;
+import org.locationtech.udig.catalog.IServiceInfo;
+import org.locationtech.udig.catalog.ServiceExtension;
+
+public class LessInterestingService implements ServiceExtension {
+
+    public class LessInterestingServiceImpl extends IService
+    {
+        private URL id;
+
+        public LessInterestingServiceImpl(URL id) {
+            this.id = id;
+        }
+
+        @Override
+        public Throwable getMessage() {
+            return null;
+        }
+
+        @Override
+        public URL getIdentifier() {
+            return id;
+        }
+
+        @Override
+        public List<? extends IGeoResource> resources(IProgressMonitor monitor)
+                throws IOException {
+            return null;
+        }
+
+        @Override
+        protected IServiceInfo createInfo(IProgressMonitor monitor) throws IOException {
+            return new IServiceInfo() {
+
+                @Override
+                public double getMetric() {
+                    return 0.0;
+                }
+                
+            };
+        }
+        
+        @Override
+        public IServiceInfo getInfo(IProgressMonitor monitor) throws IOException {
+            return createInfo(monitor);
+        }
+        
+        @Override
+        public Map<String, Serializable> getConnectionParams() {
+            return null;
+        }
+    }
+    
+    @Override
+    public IService createService(URL id, Map<String, Serializable> params) {
+        return new LessInterestingServiceImpl((URL) params.get("id")); //$NON-NLS-1$
+    }
+
+    @Override
+    public Map<String, Serializable> createParams(URL url) {
+        Map<String, Serializable> params = new TreeMap<String, Serializable>();
+        params.put("id",url); //$NON-NLS-1$
+        return params;
+    }
+
+}

--- a/plugins/org.locationtech.udig.catalog.tests/src/org/locationtech/udig/catalog/tests/internal/LessInterestingService.java
+++ b/plugins/org.locationtech.udig.catalog.tests/src/org/locationtech/udig/catalog/tests/internal/LessInterestingService.java
@@ -69,6 +69,16 @@ public class LessInterestingService implements ServiceExtension {
 
     @Override
     public Map<String, Serializable> createParams(URL url) {
+        URL testURL = null;
+        try {
+            testURL = new URL(CatalogImplTest.TEST_URL);
+        }
+        catch(Exception e) {}
+               
+        if (!url.equals(testURL)) {
+            return null;
+        }
+        
         Map<String, Serializable> params = new TreeMap<String, Serializable>();
         params.put("id",url); //$NON-NLS-1$
         return params;

--- a/plugins/org.locationtech.udig.catalog.tests/src/org/locationtech/udig/catalog/tests/internal/MoreInterestingService.java
+++ b/plugins/org.locationtech.udig.catalog.tests/src/org/locationtech/udig/catalog/tests/internal/MoreInterestingService.java
@@ -1,0 +1,77 @@
+package org.locationtech.udig.catalog.tests.internal;
+
+import java.io.IOException;
+import java.io.Serializable;
+import java.net.URL;
+import java.util.List;
+import java.util.Map;
+import java.util.TreeMap;
+
+import org.eclipse.core.runtime.IProgressMonitor;
+import org.locationtech.udig.catalog.IGeoResource;
+import org.locationtech.udig.catalog.IService;
+import org.locationtech.udig.catalog.IServiceInfo;
+import org.locationtech.udig.catalog.ServiceExtension;
+
+public class MoreInterestingService implements ServiceExtension {
+
+    public class MoreInterestingServiceImpl extends IService
+    {
+        private URL id;
+
+        public MoreInterestingServiceImpl(URL id) {
+            this.id = id;
+        }
+
+        @Override
+        public Throwable getMessage() {
+            return null;
+        }
+
+        @Override
+        public URL getIdentifier() {
+            return id;
+        }
+
+        @Override
+        public List<? extends IGeoResource> resources(IProgressMonitor monitor)
+                throws IOException {
+            return null;
+        }
+
+        @Override
+        protected IServiceInfo createInfo(IProgressMonitor monitor) throws IOException {
+            return new IServiceInfo() {
+
+                @Override
+                public double getMetric() {
+                    return 1.0;
+                }
+                
+            };
+        }
+
+        @Override
+        public IServiceInfo getInfo(IProgressMonitor monitor) throws IOException {
+            return createInfo(monitor);
+        }
+
+        @Override
+        public Map<String, Serializable> getConnectionParams() {
+            return null;
+        }
+    }
+    
+    @Override
+    public IService createService(URL id, Map<String, Serializable> params) {
+        return new MoreInterestingServiceImpl((URL) params.get("id")); //$NON-NLS-1$
+    }
+
+    @Override
+    public Map<String, Serializable> createParams(URL url) {
+        Map<String, Serializable> params = new TreeMap<String, Serializable>();
+        params.put("id",url); //$NON-NLS-1$
+        return params;
+    }
+
+}

--- a/plugins/org.locationtech.udig.catalog.tests/src/org/locationtech/udig/catalog/tests/internal/MoreInterestingService.java
+++ b/plugins/org.locationtech.udig.catalog.tests/src/org/locationtech/udig/catalog/tests/internal/MoreInterestingService.java
@@ -71,7 +71,7 @@ public class MoreInterestingService implements ServiceExtension {
     public Map<String, Serializable> createParams(URL url) {
         URL testURL = null;
         try {
-            testURL = new URL(CatalogImplTest.TEST_URL);
+            testURL = new URL(CatalogImplTest.SERVICE_COMPARISON_TEST_URL);
         }
         catch(Exception e) {}
                

--- a/plugins/org.locationtech.udig.catalog.tests/src/org/locationtech/udig/catalog/tests/internal/MoreInterestingService.java
+++ b/plugins/org.locationtech.udig.catalog.tests/src/org/locationtech/udig/catalog/tests/internal/MoreInterestingService.java
@@ -69,6 +69,16 @@ public class MoreInterestingService implements ServiceExtension {
 
     @Override
     public Map<String, Serializable> createParams(URL url) {
+        URL testURL = null;
+        try {
+            testURL = new URL(CatalogImplTest.TEST_URL);
+        }
+        catch(Exception e) {}
+               
+        if (!url.equals(testURL)) {
+            return null;
+        }
+        
         Map<String, Serializable> params = new TreeMap<String, Serializable>();
         params.put("id",url); //$NON-NLS-1$
         return params;

--- a/plugins/org.locationtech.udig.catalog/src/org/locationtech/udig/catalog/internal/CatalogImpl.java
+++ b/plugins/org.locationtech.udig.catalog/src/org/locationtech/udig/catalog/internal/CatalogImpl.java
@@ -1155,10 +1155,12 @@ public class CatalogImpl extends ICatalog {
                     double metric1 = info1.getMetric();
                     double metric2 = info2.getMetric();
                     
+                    // needs to be sorted in descending order, so that the most matching
+                    // is the first (callers of constructServices always choose the first)
                     if (metric1 > metric2) {
-                        return 1;
+                        return -1;
                     }else if(metric1 < metric2){
-                       return -1;
+                       return 1;
                     }else{
                        return 0;
                     }


### PR DESCRIPTION
This pull request fixes a mistake inside the catalog plugin making it choose the worst service out of the list of possible instead of the best. Also added a test.