### PR TITLE
fixed number formatting in CursorPosition tool

### DIFF
--- a/plugins/org.locationtech.udig.tool.default/src/org/locationtech/udig/tools/internal/CursorPosition.java
+++ b/plugins/org.locationtech.udig.tool.default/src/org/locationtech/udig/tools/internal/CursorPosition.java
@@ -157,7 +157,8 @@ public class CursorPosition extends AbstractTool {
             String string = format.format(value);
 
             String[] parts = string.split("\\.");
-            if(parts[0].length()>3){
+            int prefix = parts[0].startsWith("-") ? 1 : 0;
+            if(parts[0].length()>3+prefix){
             	string = parts[0];
             }
             return string;


### PR DESCRIPTION
This change takes care of a problem with the coordinate display on the Workbench status line. Formerly, in cases of negative longitudes of more than three integer digits, only the integer part of the number would be displayed, and the fractional part would be lopped off.

The cause was a test that failed to account for a minus sign. It would lop of the fractional part of the number if there were more than three characters before the decimal point. This would accommodate positive longitudes of three integer digits, but negative longitudes of only two integer digits (a problem for us North Americans).

I have left in the test that was causing the issue, but modified it to account for the minus sign.

I have attached before/after pictures in case it is not clear what I'm talking about.

![before](https://cloud.githubusercontent.com/assets/11726442/10323498/7a61cb0e-6c51-11e5-99bc-dc0f9dc94792.jpg)
![after](https://cloud.githubusercontent.com/assets/11726442/10323128/0a086b58-6c4f-11e5-8699-e469e0e872ab.jpg)
