### PR TITLE
call activators of tools only once

### DIFF
--- a/plugins/org.locationtech.udig.project.ui/src/org/locationtech/udig/project/ui/internal/tool/display/ToolProxy.java
+++ b/plugins/org.locationtech.udig.project.ui/src/org/locationtech/udig/project/ui/internal/tool/display/ToolProxy.java
@@ -543,20 +543,23 @@ public class ToolProxy extends ModalItem implements ModalTool, ActionTool {
     	if (toolContext == null){
     		return; // cannot be active as the map is not ready yet
     	}
-    	setChecked(active); // will check this in each menu / toolbar contribution 
+    	setChecked(active); // will check this in each menu / toolbar contribution
     	
     	if (getTool() instanceof ModalTool) {
             if( isActive() != active ){
                 ModalTool modalTool = getModalTool();
-                modalTool.setActive(active);
                 if (active){
-                    // allow tool manager to update the activeTool cursor etc..
+                    // allow tool manager to update the activeTool cursor etc.. --> calls setActive()
                     toolManager.setActiveModalToolProxy(this);
 //                  String currentCursorID = modalTool.getCursorID();
 //                  toolContext.getViewportPane().setCursor(toolManager.findToolCursor(currentCursorID));
                 }
-    		}
+                else {
+                    modalTool.setActive(active); // only called when deactivated, because it gets also called by toolManager.setActiveModalToolProxy
+                }
+            }
     	}
+    	
     }
 
     /**


### PR DESCRIPTION
At the moment activators of tools are called twice upon activation, because the setActive(true)-method of the tool is called from the ToolProxy (setActive(true)) and from the ToolManager (setActiveModalTool(...)). 

Created a new pull request to have a signed commit.

Signed-off-by: HendrikPeilke <Hendrik.Peilke@ibykus.com>