### PR TITLE
Fix performance issues on layer refresh

### DIFF
--- a/plugins/org.locationtech.udig.catalog/src/org/locationtech/udig/catalog/internal/CatalogImpl.java
+++ b/plugins/org.locationtech.udig.catalog/src/org/locationtech/udig/catalog/internal/CatalogImpl.java
@@ -952,7 +952,7 @@ public class CatalogImpl extends ICatalog {
         for( IConfigurationElement element : list ) {
             try {
                 String attribute = element.getAttribute("descriptorClass"); //$NON-NLS-1$
-                Class< ? > c = descriptor.getClass().getClassLoader().loadClass(attribute);
+                Class< ? > c = Class.forName(attribute, true, descriptor.getClass().getClassLoader());
                 if (c.isAssignableFrom(descriptor.getClass())) {
                     TemporaryResourceFactory fac = (TemporaryResourceFactory) element
                             .createExecutableExtension("factory"); //$NON-NLS-1$

--- a/plugins/org.locationtech.udig.catalog/src/org/locationtech/udig/catalog/internal/ResolveManager.java
+++ b/plugins/org.locationtech.udig.catalog/src/org/locationtech/udig/catalog/internal/ResolveManager.java
@@ -159,7 +159,7 @@ public class ResolveManager implements IResolveManager {
 							// their XML resoleableType info?
 		}
         try {
-            Class< ? > clazz=resolve.getClass().getClassLoader().loadClass(requiredType);
+            Class< ? > clazz=Class.forName(requiredType, true, resolve.getClass().getClassLoader());
             return clazz.isAssignableFrom(resolve.getClass() );
         }
         catch (ClassNotFoundException huh){
@@ -189,7 +189,7 @@ public class ResolveManager implements IResolveManager {
                     if( classLoader==null ){
                         classLoader=ClassLoader.getSystemClassLoader();
                     }
-                    Class< ? > resolvedClass = classLoader.loadClass(resolveType);
+                    Class< ? > resolvedClass = Class.forName(resolveType, true, classLoader);
                     
                     if( target.isAssignableFrom(resolvedClass) ){
                         return true;
@@ -213,7 +213,7 @@ public class ResolveManager implements IResolveManager {
             	}
             	ClassLoader classLoader = factory.getClass().getClassLoader();
                 if( classLoader != null ){
-                	Class< ? > resolvedClass = classLoader.loadClass(resolveType);
+                	Class< ? > resolvedClass = Class.forName(resolveType, true,  classLoader);
                 	if( target.isAssignableFrom(resolvedClass) ){
                         return true;
                     }

--- a/plugins/org.locationtech.udig.catalog/src/org/locationtech/udig/catalog/internal/ResolveManager2.java
+++ b/plugins/org.locationtech.udig.catalog/src/org/locationtech/udig/catalog/internal/ResolveManager2.java
@@ -348,7 +348,7 @@ public class ResolveManager2 implements IResolveManager {
         }
         try {
             ClassLoader contextClassloader = factory.getClass().getClassLoader();
-            return contextClassloader.loadClass(className);
+            return Class.forName(className, true, contextClassloader);
         } catch (ClassNotFoundException notFound) {
             // check if the factory knows what to do - perhaps load via spring
             // or service provider interface

--- a/plugins/org.locationtech.udig.core/src/org/locationtech/udig/core/AdapterUtil.java
+++ b/plugins/org.locationtech.udig.core/src/org/locationtech/udig/core/AdapterUtil.java
@@ -12,7 +12,6 @@ package org.locationtech.udig.core;
 import java.io.IOException;
 
 import org.locationtech.udig.core.internal.CorePlugin;
-
 import org.eclipse.core.runtime.IAdaptable;
 import org.eclipse.core.runtime.IProgressMonitor;
 import org.eclipse.core.runtime.Platform;
@@ -63,7 +62,7 @@ public class AdapterUtil {
             classLoader = obj.getClass().getClassLoader();
         }
         try {
-            target = classLoader.loadClass(targetClass);
+            target = Class.forName(targetClass, true, classLoader);
         } catch (Throwable e) {
             //do nothing this is ok.
             return false;
@@ -149,7 +148,7 @@ public class AdapterUtil {
             return null;
         }
         try {
-            target=(Class<T>) obj.getClass().getClassLoader().loadClass(targetClass);
+            target=(Class<T>) Class.forName(targetClass,  true, obj.getClass().getClassLoader());
             return adaptTo(target, obj, monitor);
         } catch (ClassNotFoundException e) {
             //do nothing.

--- a/plugins/org.locationtech.udig.omsbox/src/org/locationtech/udig/omsbox/utils/ResourceFinder.java
+++ b/plugins/org.locationtech.udig.omsbox/src/org/locationtech/udig/omsbox/utils/ResourceFinder.java
@@ -314,7 +314,7 @@ public class ResourceFinder {
      */
     public Class findClass(String uri) throws IOException, ClassNotFoundException {
         String className = findString(uri);
-        return (Class) classLoader.loadClass(className);
+        return Class.forName(className, true, classLoader);
     }
 
     /**
@@ -332,7 +332,7 @@ public class ResourceFinder {
         List<Class> classes = new ArrayList<Class>();
         List<String> strings = findAllStrings(uri);
         for (String className : strings) {
-            Class clazz = classLoader.loadClass(className);
+            Class clazz = Class.forName(className, true, classLoader);
             classes.add(clazz);
         }
         return classes;
@@ -355,7 +355,7 @@ public class ResourceFinder {
         List<String> strings = findAvailableStrings(uri);
         for (String className : strings) {
             try {
-                Class clazz = classLoader.loadClass(className);
+                Class clazz = Class.forName(className, true, classLoader);
                 classes.add(clazz);
             } catch (Exception notAvailable) {
                 resourcesNotLoaded.add(className);
@@ -394,7 +394,7 @@ public class ResourceFinder {
             Map.Entry entry = (Map.Entry) iterator.next();
             String string = (String) entry.getKey();
             String className = (String) entry.getValue();
-            Class clazz = classLoader.loadClass(className);
+            Class clazz = Class.forName(className, true, classLoader);
             classes.put(string, clazz);
         }
         return classes;
@@ -470,7 +470,7 @@ public class ResourceFinder {
      */
     public Class findImplementation(Class interfase) throws IOException, ClassNotFoundException {
         String className = findString(interfase.getName());
-        Class impl = classLoader.loadClass(className);
+        Class impl = Class.forName(className, true, classLoader);
         if (!interfase.isAssignableFrom(impl)) {
             throw new ClassCastException("Class not of type: " + interfase.getName());
         }
@@ -506,7 +506,7 @@ public class ResourceFinder {
         List<Class> implementations = new ArrayList<Class>();
         List<String> strings = findAllStrings(interfase.getName());
         for (String className : strings) {
-            Class impl = classLoader.loadClass(className);
+            Class impl = Class.forName(className, true, classLoader);
             if (!interfase.isAssignableFrom(impl)) {
                 throw new ClassCastException("Class not of type: " + interfase.getName());
             }
@@ -544,7 +544,7 @@ public class ResourceFinder {
         List<String> strings = findAvailableStrings(interfase.getName());
         for (String className : strings) {
             try {
-                Class impl = classLoader.loadClass(className);
+                Class impl = Class.forName(className, true, classLoader);
                 if (interfase.isAssignableFrom(impl)) {
                     implementations.add(impl);
                 } else {
@@ -630,7 +630,7 @@ public class ResourceFinder {
             String string = (String) entry.getKey();
             String className = (String) entry.getValue();
             try {
-                Class impl = classLoader.loadClass(className);
+                Class impl = Class.forName(className, true, classLoader);
                 if (interfase.isAssignableFrom(impl)) {
                     implementations.put(string, impl);
                 } else {

--- a/plugins/org.locationtech.udig.project.ui/src/org/locationtech/udig/project/ui/internal/RenderManagerDynamic.java
+++ b/plugins/org.locationtech.udig.project.ui/src/org/locationtech/udig/project/ui/internal/RenderManagerDynamic.java
@@ -16,6 +16,12 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Set;
 
+import org.eclipse.emf.common.notify.Adapter;
+import org.eclipse.emf.common.notify.Notification;
+import org.eclipse.emf.common.notify.NotificationChain;
+import org.eclipse.emf.ecore.EObject;
+import org.eclipse.emf.ecore.impl.ENotificationImpl;
+import org.geotools.geometry.jts.ReferencedEnvelope;
 import org.locationtech.udig.project.ILayer;
 import org.locationtech.udig.project.internal.ContextModelListenerAdapter;
 import org.locationtech.udig.project.internal.Layer;
@@ -40,13 +46,6 @@ import org.locationtech.udig.project.render.IRenderer;
 import org.locationtech.udig.project.render.RenderException;
 import org.locationtech.udig.project.render.displayAdapter.IMapDisplay;
 import org.locationtech.udig.project.ui.render.displayAdapter.ViewportPane;
-
-import org.eclipse.emf.common.notify.Adapter;
-import org.eclipse.emf.common.notify.Notification;
-import org.eclipse.emf.common.notify.NotificationChain;
-import org.eclipse.emf.ecore.EObject;
-import org.eclipse.emf.ecore.impl.ENotificationImpl;
-import org.geotools.geometry.jts.ReferencedEnvelope;
 
 import com.vividsolutions.jts.geom.Envelope;
 
@@ -100,8 +99,7 @@ public class RenderManagerDynamic extends RenderManagerImpl {
      * 
      * @generated NOT
      */
-    @SuppressWarnings("unchecked")
-	public RenderManagerDynamic() {
+    public RenderManagerDynamic() {
 		super();
 		eAdapters().add(viewportModelChangeListener);
 	}
@@ -118,7 +116,7 @@ public class RenderManagerDynamic extends RenderManagerImpl {
 		if (getMapDisplay() == null || getRenderExecutor() == null) {
 			return; // we are not set up to renderer yet!
 		}
-		getRendererCreator().reset();
+
 		validateRendererConfiguration();
 		final SelectionLayer selectionLayer = getRendererCreator()
 				.findSelectionLayer(layer);
@@ -184,7 +182,6 @@ public class RenderManagerDynamic extends RenderManagerImpl {
 		if (selectionLayer == null)
 			return;
 
-		getRendererCreator().reset();
 		validateRendererConfiguration();
 
 		getRenderExecutor().visit(new ExecutorVisitor() {
@@ -253,7 +250,6 @@ public class RenderManagerDynamic extends RenderManagerImpl {
 	 * 
 	 * @generated NOT
 	 */
-	@SuppressWarnings("unchecked")
 	public void refresh(final Envelope bounds) {
 		checkState();
 		if (!renderingEnabled) {
@@ -266,7 +262,6 @@ public class RenderManagerDynamic extends RenderManagerImpl {
 		if (getMapDisplay().getWidth() < 1 || getMapDisplay().getHeight() < 1)
 			return;
 
-		getRendererCreator().reset();
 		validateRendererConfiguration();
 
 		if (!getMapInternal().getContextModel().eAdapters().contains(
@@ -299,7 +294,6 @@ public class RenderManagerDynamic extends RenderManagerImpl {
 	 * 
 	 * @generated NOT
 	 */
-	@SuppressWarnings("unchecked")
 	public void dispose() {
 		configuration = null;
 		Set<EObject> set = new HashSet<EObject>();
@@ -357,7 +351,6 @@ public class RenderManagerDynamic extends RenderManagerImpl {
 	/**
 	 * @see org.locationtech.udig.project.render.impl.RenderManagerImpl#setRenderExecutor(org.locationtech.udig.project.render.RenderExecutor)
 	 */
-	@SuppressWarnings("unchecked")
 	public void setRenderExecutor(RenderExecutor newRenderExecutor) {
 		checkState();
 		if (renderExecutor != null) {
@@ -377,7 +370,6 @@ public class RenderManagerDynamic extends RenderManagerImpl {
 	 * @see org.locationtech.udig.project.render.impl.RenderManagerImpl#basicSetMap(org.locationtech.udig.project.Map,
 	 *      org.eclipse.emf.common.notify.NotificationChain)
 	 */
-	@SuppressWarnings("unchecked")
 	public NotificationChain basicSetMapInternal(Map newMap,
 			NotificationChain msgs) {
 		if (getMapInternal() != null) {

--- a/plugins/org.locationtech.udig.project.ui/src/org/locationtech/udig/project/ui/internal/RenderManagerDynamic.java
+++ b/plugins/org.locationtech.udig.project.ui/src/org/locationtech/udig/project/ui/internal/RenderManagerDynamic.java
@@ -117,7 +117,10 @@ public class RenderManagerDynamic extends RenderManagerImpl {
 			return; // we are not set up to renderer yet!
 		}
 
+		getRendererCreator().reset();
+		
 		validateRendererConfiguration();
+
 		final SelectionLayer selectionLayer = getRendererCreator()
 				.findSelectionLayer(layer);
 
@@ -182,6 +185,8 @@ public class RenderManagerDynamic extends RenderManagerImpl {
 		if (selectionLayer == null)
 			return;
 
+		getRendererCreator().reset();
+		
 		validateRendererConfiguration();
 
 		getRenderExecutor().visit(new ExecutorVisitor() {
@@ -262,6 +267,8 @@ public class RenderManagerDynamic extends RenderManagerImpl {
 		if (getMapDisplay().getWidth() < 1 || getMapDisplay().getHeight() < 1)
 			return;
 
+		getRendererCreator().reset();
+		
 		validateRendererConfiguration();
 
 		if (!getMapInternal().getContextModel().eAdapters().contains(

--- a/plugins/org.locationtech.udig.project/src/org/locationtech/udig/project/internal/impl/BlackboardImpl.java
+++ b/plugins/org.locationtech.udig.project/src/org/locationtech/udig/project/internal/impl/BlackboardImpl.java
@@ -513,8 +513,9 @@ public class BlackboardImpl extends EObjectImpl implements Blackboard {
                 } else {
                     try {
                         ClassLoader classLoader = persistenceTarget.getClassLoader();
+                        
                         if (classLoader != null) {
-                            objectClass = classLoader.loadClass(className);
+                            objectClass = Class.forName(className, true, classLoader);
                         } else {
                             objectClass = Class.forName(className);
                         }

--- a/plugins/org.locationtech.udig.project/src/org/locationtech/udig/project/internal/impl/LayerResource.java
+++ b/plugins/org.locationtech.udig.project/src/org/locationtech/udig/project/internal/impl/LayerResource.java
@@ -33,7 +33,6 @@ import org.locationtech.udig.project.IResourceCachingInterceptor;
 import org.locationtech.udig.project.IResourceInterceptor;
 import org.locationtech.udig.project.internal.ProjectPlugin;
 import org.locationtech.udig.project.preferences.PreferenceConstants;
-
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.IConfigurationElement;
 import org.eclipse.core.runtime.IProgressMonitor;
@@ -258,8 +257,8 @@ public class LayerResource extends IGeoResource {
                 // its a library class so use normal class loader
                 classLoader = Thread.currentThread().getContextClassLoader();
             }
-            Class<T> loadClass = (Class<T>) classLoader.loadClass(attribute);
-            assignableFrom = (loadClass).isAssignableFrom(class1);
+            Class<T> clazz = (Class<T>) Class.forName(attribute, true, classLoader); 
+            assignableFrom = clazz.isAssignableFrom(class1);
         } catch (ClassNotFoundException e) {
             return false;
         }

--- a/plugins/org.locationtech.udig.project/src/org/locationtech/udig/project/internal/render/impl/RendererCreatorImpl.java
+++ b/plugins/org.locationtech.udig.project/src/org/locationtech/udig/project/internal/render/impl/RendererCreatorImpl.java
@@ -302,7 +302,7 @@ public class RendererCreatorImpl implements RendererCreator {
      */
     private void initRenderMetrics() {
         synchronized (this.layers){
-            for( Layer layer : getLayers() ) {
+            for( Layer layer : this.layers ) {
                 if (!layerToMetricsFactoryMap.containsKey(layer))
                     initFactories(layer);
             }
@@ -390,7 +390,7 @@ public class RendererCreatorImpl implements RendererCreator {
         	
             synchronized (layers) {
             	Collection<Layer> removedLayers = (Collection<Layer>) event.getOldValue();
-
+            	
                 for ( Iterator iter = layers.iterator(); iter.hasNext(); ) {
                     Layer l = (Layer) iter.next();
                     if( removedLayers.contains(l))
@@ -478,10 +478,12 @@ public class RendererCreatorImpl implements RendererCreator {
         } catch (IOException e) {
             return null;
         }
-        for( Layer layer : getLayers() )
-            if (layer instanceof SelectionLayer)
-                if (((SelectionLayer) layer).getWrappedLayer() == targetLayer)
-                    return (SelectionLayer) layer;
+        synchronized (this.layers) {
+            for( Layer layer : this.layers )
+                if (layer instanceof SelectionLayer)
+                    if (((SelectionLayer) layer).getWrappedLayer() == targetLayer)
+                        return (SelectionLayer) layer;
+        }
 
         return null;
     }

--- a/plugins/org.locationtech.udig.ui/src/org/locationtech/udig/internal/ui/UDIGDNDProcessor.java
+++ b/plugins/org.locationtech.udig.ui/src/org/locationtech/udig/internal/ui/UDIGDNDProcessor.java
@@ -233,13 +233,15 @@ public class UDIGDNDProcessor {
                 Object[] array = (Object[])data;
                 for( Object object : array ) {
                     Class< ? extends Object> c;
-                    c = getClassLoader(object).loadClass(clazz);
+                    ClassLoader classLoader = getClassLoader(object);
+                    c = Class.forName(clazz, true, classLoader);
                     if( c!=null )
                         return c;
                 }
                 return null;
             }else{
-                return getClassLoader(data).loadClass(clazz);
+                ClassLoader classLoader = getClassLoader(data);
+                return Class.forName(clazz, true, classLoader);
             }
         }
 
@@ -275,7 +277,7 @@ public class UDIGDNDProcessor {
                 
                 try {
                     String clazz = target.getAttribute("class"); //$NON-NLS-1$
-                    c = dloader.loadClass(clazz);
+                    c = Class.forName(clazz, true, dloader);
                     
                     if (c == null)
                         continue;

--- a/plugins/org.locationtech.udig.ui/src/org/locationtech/udig/ui/operations/OpFilterPropertyValueCondition.java
+++ b/plugins/org.locationtech.udig.ui/src/org/locationtech/udig/ui/operations/OpFilterPropertyValueCondition.java
@@ -112,7 +112,7 @@ class OpFilterPropertyValueCondition implements OpFilter {
 
         if (targetClass == null) {
             try {
-                targetClass = object.getClass().getClassLoader().loadClass(targetObject);
+                targetClass = Class.forName(targetObject, true, object.getClass().getClassLoader());
             } catch (ClassNotFoundException e) {
                 UiPlugin.log("",e); //$NON-NLS-1$
                 return null;


### PR DESCRIPTION
and avoid re-creation renderer configuration every time.

We have problems if layers having programatically a high refresh intervall. Because of resource changed events the refresh is triggered. Same for Selection Events. We set it programmatically as well to have selections in a table in synch with map selection.

Because of 
```
getRendererCreator().reset(); 
```
if forces to recreate context and configuration. Dependent from the layers are currently on the map it can take a while, especially if there are layers with remote services that responding badly.


Signed-off-by: Frank Gasdorf <fgdrf@users.sourceforge.net>