### PR TITLE
fixed workspace and configuration defaults (install dir on windows is…

### DIFF
--- a/features/org.locationtech.udig-product/org.locationtech.udig-product.product
+++ b/features/org.locationtech.udig-product/org.locationtech.udig-product.product
@@ -79,7 +79,9 @@ Content and such source code may be obtained at http://github.com/udig .
       <plugin id="org.eclipse.equinox.ds" autoStart="true" startLevel="2" />
       <plugin id="org.eclipse.equinox.p2.reconciler.dropins" autoStart="true" startLevel="5" />
       <plugin id="org.eclipse.equinox.simpleconfigurator" autoStart="true" startLevel="1" />
-      <property name="org.eclipse.update.reconcile" value="false"/>  
+      <property name="org.eclipse.update.reconcile" value="false"/>
+      <property name="osgi.configuration.area.default" value="$LOCALAPPDATA$/uDig/configuration" os="win32" />
+      <property name="osgi.instance.area.default" value="$LOCALAPPDATA$/uDig/workspace" os="win32" />
    </configurations>
 
 </product>

--- a/plugins/org.locationtech.udig/udig.product
+++ b/plugins/org.locationtech.udig/udig.product
@@ -83,6 +83,8 @@ Content and such source code may be obtained at http://github.com/udig .
       <plugin id="org.eclipse.equinox.event" autoStart="true" startLevel="2" />
       <plugin id="org.eclipse.equinox.p2.reconciler.dropins" autoStart="true" startLevel="0" />
       <plugin id="org.eclipse.equinox.simpleconfigurator" autoStart="true" startLevel="1" />
+      <property name="osgi.configuration.area.default" value="$LOCALAPPDATA$/uDig/configuration" os="win32" />
+      <property name="osgi.instance.area.default" value="$LOCALAPPDATA$/uDig/workspace" os="win32" />
    </configurations>
 
 </product>


### PR DESCRIPTION
… read-only, using LOCALAPPDATA

Tested RC 2.0.0.RC1 Installer on Win x86_64 but uDig never started. The Install-Dir was read-only and therefore Eclipse Defaults doesn't make sense.

This fix sets workspace and configuration area to sub-directory in %LOCALAPPDATA% on Windows-platform only. 

Signed-off-by: Frank Gasdorf fgdrf@users.sourceforge.net
