### PR TITLE
Fixed resulting pdf page size format

### DIFF
--- a/plugins/org.locationtech.udig.printing.ui/src/org/locationtech/udig/printing/ui/pdf/SivecoExportMapToImageWizard.java
+++ b/plugins/org.locationtech.udig.printing.ui/src/org/locationtech/udig/printing/ui/pdf/SivecoExportMapToImageWizard.java
@@ -199,8 +199,7 @@ public class SivecoExportMapToImageWizard extends Wizard implements IExportWizar
                         paper, 
                         10, /*top and bottom margin*/
                         10, /*left and right margin*/
-                        isLandscape,
-                        dpi);
+                        isLandscape);
 	    
         monitor.done();
         

--- a/plugins/org.locationtech.udig.printing.ui/src/org/locationtech/udig/printing/ui/pdf/SivecoExportMapToImageWizard.java
+++ b/plugins/org.locationtech.udig.printing.ui/src/org/locationtech/udig/printing/ui/pdf/SivecoExportMapToImageWizard.java
@@ -30,36 +30,10 @@ import java.util.Collection;
 import java.util.Iterator;
 import java.util.List;
 
-import org.locationtech.udig.catalog.CatalogPlugin;
-import org.locationtech.udig.catalog.ICatalog;
-import org.locationtech.udig.catalog.ID;
-import org.locationtech.udig.catalog.IGeoResource;
-import org.locationtech.udig.catalog.IService;
-import org.locationtech.udig.catalog.IServiceFactory;
-import org.locationtech.udig.core.internal.CorePlugin;
-import org.locationtech.udig.mapgraphic.style.LocationStyleContent;
-import org.locationtech.udig.project.IMap;
-import org.locationtech.udig.project.internal.Layer;
-import org.locationtech.udig.project.internal.LayerFactory;
-import org.locationtech.udig.project.internal.Map;
-import org.locationtech.udig.project.render.RenderException;
-import org.locationtech.udig.project.ui.ApplicationGIS;
-import org.locationtech.udig.project.ui.BoundsStrategy;
-import org.locationtech.udig.project.ui.SelectionStyle;
-import org.locationtech.udig.project.ui.ApplicationGIS.DrawMapParameter;
-import org.locationtech.udig.project.ui.internal.Messages;
-import org.locationtech.udig.project.ui.internal.ProjectUIPlugin;
-import org.locationtech.udig.project.ui.wizard.export.image.Image2Pdf;
-import org.locationtech.udig.project.ui.wizard.export.image.ImageExportPage;
-import org.locationtech.udig.project.ui.wizard.export.image.MapSelectorPageWithScaleColumn;
-import org.locationtech.udig.project.ui.wizard.export.image.PDFImageExportFormat;
-import org.locationtech.udig.project.ui.wizard.export.image.Paper;
-import org.locationtech.udig.project.ui.wizard.export.image.XAffineTransform;
-import org.locationtech.udig.style.sld.editor.DialogSettingsStyleContent;
-
 import org.eclipse.core.runtime.IProgressMonitor;
 import org.eclipse.core.runtime.NullProgressMonitor;
 import org.eclipse.core.runtime.SubProgressMonitor;
+import org.eclipse.draw2d.geometry.Insets;
 import org.eclipse.jface.dialogs.MessageDialog;
 import org.eclipse.jface.operation.IRunnableWithProgress;
 import org.eclipse.jface.viewers.IStructuredSelection;
@@ -74,9 +48,34 @@ import org.geotools.data.DataUtilities;
 import org.geotools.data.DefaultQuery;
 import org.geotools.data.FeatureSource;
 import org.geotools.data.Query;
-import org.geotools.factory.GeoTools;
 import org.geotools.feature.FeatureCollection;
 import org.geotools.feature.FeatureIterator;
+import org.locationtech.udig.catalog.CatalogPlugin;
+import org.locationtech.udig.catalog.ICatalog;
+import org.locationtech.udig.catalog.ID;
+import org.locationtech.udig.catalog.IGeoResource;
+import org.locationtech.udig.catalog.IService;
+import org.locationtech.udig.catalog.IServiceFactory;
+import org.locationtech.udig.core.internal.CorePlugin;
+import org.locationtech.udig.mapgraphic.style.LocationStyleContent;
+import org.locationtech.udig.project.IMap;
+import org.locationtech.udig.project.internal.Layer;
+import org.locationtech.udig.project.internal.LayerFactory;
+import org.locationtech.udig.project.internal.Map;
+import org.locationtech.udig.project.render.RenderException;
+import org.locationtech.udig.project.ui.ApplicationGIS;
+import org.locationtech.udig.project.ui.ApplicationGIS.DrawMapParameter;
+import org.locationtech.udig.project.ui.BoundsStrategy;
+import org.locationtech.udig.project.ui.SelectionStyle;
+import org.locationtech.udig.project.ui.internal.Messages;
+import org.locationtech.udig.project.ui.internal.ProjectUIPlugin;
+import org.locationtech.udig.project.ui.wizard.export.image.Image2Pdf;
+import org.locationtech.udig.project.ui.wizard.export.image.ImageExportPage;
+import org.locationtech.udig.project.ui.wizard.export.image.MapSelectorPageWithScaleColumn;
+import org.locationtech.udig.project.ui.wizard.export.image.PDFImageExportFormat;
+import org.locationtech.udig.project.ui.wizard.export.image.Paper;
+import org.locationtech.udig.project.ui.wizard.export.image.XAffineTransform;
+import org.locationtech.udig.style.sld.editor.DialogSettingsStyleContent;
 import org.opengis.feature.simple.SimpleFeature;
 import org.opengis.feature.simple.SimpleFeatureType;
 import org.opengis.filter.Filter;
@@ -196,9 +195,9 @@ public class SivecoExportMapToImageWizard extends Wizard implements IExportWizar
         
         Image2Pdf.write(image, 
                         dest.getAbsolutePath(), 
-                        paper, 
-                        10, /*top and bottom margin*/
-                        10, /*left and right margin*/
+                        paper,
+                        /* top, left, bottom and right margin*/
+                        new Insets(10, 10, 10, 10),
                         isLandscape);
 	    
         monitor.done();

--- a/plugins/org.locationtech.udig.project.ui/src/org/locationtech/udig/project/ui/wizard/export/image/Image2Pdf.java
+++ b/plugins/org.locationtech.udig.project.ui/src/org/locationtech/udig/project/ui/wizard/export/image/Image2Pdf.java
@@ -27,60 +27,68 @@ import com.lowagie.text.pdf.PdfWriter;
 
 /**
  * @author Andrea Antonello - www.hydrologis.com
+ * @author Frank Gasdorf
  */
 public class Image2Pdf {
 
-	/**
-	 * writes a buffered image to pdf at a given resolution
-	 *
-	 *
-	 * @param image
-	 *            the image to write
-	 * @param pdfPath
-	 *            the path to the pdf document to create
-	 * @param paper
-	 *            the paper type
-	 * @param widthBorder
-	 *            border in pixels to use on the x-axis
-	 * @param heightBorder
-	 *            border in pixels to use on the y-axis
-	 * @param lanscape
-	 *            true if the document should be in landscape mode
-	 */
-	public static void write(BufferedImage image, String pdfPath, Paper paper,
-			int widthBorder, int heightBorder, boolean landscape) {
-		Rectangle pageSizeInPixel = getPageSize(landscape, paper, widthBorder, heightBorder);
-        float pageSizeHeightInPixel = pageSizeInPixel.getHeight();
-        float pageSizeWidthInPixel = pageSizeInPixel.getWidth();
+    /**
+     * writes a buffered image to pdf at a given resolution
+     *
+     *
+     * @param image the image to write
+     * @param pdfPath the path to the pdf document to create
+     * @param paper the paper type
+     * @param widthMarginInPixel border in pixels to use on the x-axis
+     * @param heightMarginInPixel border in pixels to use on the y-axis
+     * @param lanscape true if the document should be in landscape mode
+     */
+    public static void write(BufferedImage image, String pdfPath, Paper paper,
+            int widthMarginInPixel, int heightMarginInPixel, boolean landscape) {
+
+        Rectangle documentPageSize = calculateSize(landscape, paper, 0, 0);
+        Rectangle imageSizeInPixel = calculateSize(landscape, paper, widthMarginInPixel,
+                heightMarginInPixel);
+
+        float imgHeightInPixel = imageSizeInPixel.getHeight();
+        float imgWidthInPixel = imageSizeInPixel.getWidth();
 
         final Document doc = new Document();
-		try {
+        try {
 
-	        PdfWriter.getInstance(doc, new FileOutputStream(pdfPath));
-	        doc.open();
+            PdfWriter.getInstance(doc, new FileOutputStream(pdfPath));
+            doc.open();
 
-	        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+            ByteArrayOutputStream baos = new ByteArrayOutputStream();
             ImageIO.write(image, "png", baos);
             Image iTextImage = Image.getInstance(baos.toByteArray());
 
-            doc.setPageSize(new Rectangle(pageSizeWidthInPixel + 2 * widthBorder, pageSizeHeightInPixel + 2 * heightBorder));
+            doc.setPageSize(documentPageSize);
             doc.newPage(); // not needed for page 1, needed for >1
 
+
             // high in itext is measured from lower left
-            iTextImage.setAbsolutePosition(widthBorder, heightBorder);
-            iTextImage.scaleAbsolute(pageSizeWidthInPixel, pageSizeHeightInPixel);
+            iTextImage.setAbsolutePosition(widthMarginInPixel, heightMarginInPixel);
+            iTextImage.scaleToFit(imgWidthInPixel, imgHeightInPixel);
             doc.add(iTextImage);
-		} catch (DocumentException de) {
-			System.err.println(de.getMessage());
-		} catch (IOException ioe) {
-			System.err.println(ioe.getMessage());
-		}
+        } catch (DocumentException de) {
+            System.err.println(de.getMessage());
+        } catch (IOException ioe) {
+            System.err.println(ioe.getMessage());
+        }
 
-		// step 5: we close the document
-		doc.close();
-	}
+        // step 5: we close the document
+        doc.close();
+    }
 
-    private static Rectangle getPageSize(boolean landscape, Paper paper, int widthBorderInPixel, int heightBorderinPixel) {
+    /**
+     * @param landscape if the image is in landscape format
+     * @param paper paper definition
+     * @param widthMarginInPixel right and left margin in pixel
+     * @param heightMarginInPixel top and bottom margin in pixel
+     * @return final image size to render
+     */
+    private static Rectangle calculateSize(boolean landscape, Paper paper, int widthMarginInPixel,
+            int heightMarginInPixel) {
         Rectangle rectangle = null;
         switch (paper) {
         case LETTER:
@@ -113,20 +121,20 @@ public class Image2Pdf {
         }
 
         // apply margins for the border
-
-        return new Rectangle(rectangle.getWidth() - (2 * widthBorderInPixel), rectangle.getHeight() - (2* heightBorderinPixel));
+        return new Rectangle(rectangle.getWidth() - (2 * widthMarginInPixel),
+                rectangle.getHeight() - (2 * heightMarginInPixel));
     }
 
-	public static void main(String[] args) {
+    public static void main(String[] args) {
 
-		String path = "/home/moovida/Desktop/screens/austrocontrol_2.png"; //$NON-NLS-1$
-		BufferedImage b = null;
-		try {
-			b = ImageIO.read(new File(path));
-		} catch (IOException e) {
-			e.printStackTrace();
-		}
-		write(b, path + ".pdf", Paper.A1, 10, 10, false); //$NON-NLS-1$
-		System.out.println("finished"); //$NON-NLS-1$
-	}
+        String path = "/home/moovida/Desktop/screens/austrocontrol_2.png"; //$NON-NLS-1$
+        BufferedImage b = null;
+        try {
+            b = ImageIO.read(new File(path));
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+        write(b, path + ".pdf", Paper.A1, 10, 10, false); //$NON-NLS-1$
+        System.out.println("finished"); //$NON-NLS-1$
+    }
 }

--- a/plugins/org.locationtech.udig.project.ui/src/org/locationtech/udig/project/ui/wizard/export/image/Image2Pdf.java
+++ b/plugins/org.locationtech.udig.project.ui/src/org/locationtech/udig/project/ui/wizard/export/image/Image2Pdf.java
@@ -18,6 +18,8 @@ import java.io.IOException;
 
 import javax.imageio.ImageIO;
 
+import org.eclipse.draw2d.geometry.Insets;
+
 import com.lowagie.text.Document;
 import com.lowagie.text.DocumentException;
 import com.lowagie.text.Image;
@@ -34,20 +36,16 @@ public class Image2Pdf {
     /**
      * writes a buffered image to pdf at a given resolution
      *
-     *
      * @param image the image to write
      * @param pdfPath the path to the pdf document to create
      * @param paper the paper type
-     * @param widthMarginInPixel border in pixels to use on the x-axis
-     * @param heightMarginInPixel border in pixels to use on the y-axis
+     * @param marginBorder margins for left, right, top and bottom
      * @param lanscape true if the document should be in landscape mode
      */
     public static void write(BufferedImage image, String pdfPath, Paper paper,
-            int widthMarginInPixel, int heightMarginInPixel, boolean landscape) {
-
-        Rectangle documentPageSize = calculateSize(landscape, paper, 0, 0);
-        Rectangle imageSizeInPixel = calculateSize(landscape, paper, widthMarginInPixel,
-                heightMarginInPixel);
+            Insets marginBorder, boolean landscape) {
+        Rectangle documentPageSize = calculateSize(landscape, paper, null);
+        Rectangle imageSizeInPixel = calculateSize(landscape, paper, marginBorder);
 
         float imgHeightInPixel = imageSizeInPixel.getHeight();
         float imgWidthInPixel = imageSizeInPixel.getWidth();
@@ -65,9 +63,11 @@ public class Image2Pdf {
             doc.setPageSize(documentPageSize);
             doc.newPage(); // not needed for page 1, needed for >1
 
-
             // high in itext is measured from lower left
-            iTextImage.setAbsolutePosition(widthMarginInPixel, heightMarginInPixel);
+            int absoluteX = (marginBorder != null ? marginBorder.left : 0);
+            int absoluteY = (marginBorder != null ? marginBorder.bottom : 0);
+
+            iTextImage.setAbsolutePosition(absoluteX, absoluteY);
             iTextImage.scaleToFit(imgWidthInPixel, imgHeightInPixel);
             doc.add(iTextImage);
         } catch (DocumentException de) {
@@ -83,12 +83,10 @@ public class Image2Pdf {
     /**
      * @param landscape if the image is in landscape format
      * @param paper paper definition
-     * @param widthMarginInPixel right and left margin in pixel
-     * @param heightMarginInPixel top and bottom margin in pixel
+     * @param marginBorder margins for left, right, top and bottom
      * @return final image size to render
      */
-    private static Rectangle calculateSize(boolean landscape, Paper paper, int widthMarginInPixel,
-            int heightMarginInPixel) {
+    private static Rectangle calculateSize(boolean landscape, Paper paper, Insets marginBorder) {
         Rectangle rectangle = null;
         switch (paper) {
         case LETTER:
@@ -121,8 +119,10 @@ public class Image2Pdf {
         }
 
         // apply margins for the border
-        return new Rectangle(rectangle.getWidth() - (2 * widthMarginInPixel),
-                rectangle.getHeight() - (2 * heightMarginInPixel));
+        int marginWidth = (marginBorder != null ? marginBorder.left + marginBorder.right : 0);
+        int marginHeigth = (marginBorder != null ? marginBorder.top + marginBorder.bottom : 0);
+        return new Rectangle(rectangle.getWidth() - marginWidth,
+                rectangle.getHeight() - marginHeigth);
     }
 
     public static void main(String[] args) {
@@ -134,7 +134,8 @@ public class Image2Pdf {
         } catch (IOException e) {
             e.printStackTrace();
         }
-        write(b, path + ".pdf", Paper.A1, 10, 10, false); //$NON-NLS-1$
+        write(b, path + ".pdf", Paper.A1, new Insets(10, 10, 10, 10), false); //$NON-NLS-1$
         System.out.println("finished"); //$NON-NLS-1$
     }
+
 }

--- a/plugins/org.locationtech.udig.project.ui/src/org/locationtech/udig/project/ui/wizard/export/image/PDFImageExportFormat.java
+++ b/plugins/org.locationtech.udig.project.ui/src/org/locationtech/udig/project/ui/wizard/export/image/PDFImageExportFormat.java
@@ -58,7 +58,7 @@ public class PDFImageExportFormat extends ImageExportFormat {
     public void write( IMap map, BufferedImage image, File destination ) {
         Image2Pdf.write(image, destination.getAbsolutePath(), paper(),
                 this.leftMarginSpinner.getSelection(),
-                this.topMarginSpinner.getSelection(), landscape(), getDPI());
+                this.topMarginSpinner.getSelection(), landscape());
     }
 
     @Override

--- a/plugins/org.locationtech.udig.project.ui/src/org/locationtech/udig/project/ui/wizard/export/image/PDFImageExportFormat.java
+++ b/plugins/org.locationtech.udig.project.ui/src/org/locationtech/udig/project/ui/wizard/export/image/PDFImageExportFormat.java
@@ -29,10 +29,13 @@ import org.eclipse.swt.widgets.Spinner;
  * A strategy for exporting to PDF
  *
  * @author jesse
+ * @author Frank Gasdorf
  * @since 1.1.0
  */
 public class PDFImageExportFormat extends ImageExportFormat {
 
+    private static final int PDF_DEFAULT_USER_UNIT = 72;
+    
     private Combo dpiCombo;
     private Spinner topMarginSpinner;
     private Spinner lowerMarginSpinner;
@@ -57,8 +60,8 @@ public class PDFImageExportFormat extends ImageExportFormat {
     @Override
     public void write( IMap map, BufferedImage image, File destination ) {
         Image2Pdf.write(image, destination.getAbsolutePath(), paper(),
-                this.leftMarginSpinner.getSelection(),
-                this.topMarginSpinner.getSelection(), landscape());
+                Paper.toPixels(this.leftMarginSpinner.getSelection(), PDF_DEFAULT_USER_UNIT),
+                Paper.toPixels(this.topMarginSpinner.getSelection(), PDF_DEFAULT_USER_UNIT), landscape());
     }
 
     @Override
@@ -171,18 +174,20 @@ public class PDFImageExportFormat extends ImageExportFormat {
 
     @Override
     public int getHeight( double mapwidth, double mapheight ) {
+        // ignore viewport size of the current map and use paper format instead
         int paperHeight = paper().getPixelHeight(landscape(), getDPI());
-        int topMargin = topMarginSpinner.getSelection();
-        int lowerMargin = lowerMarginSpinner.getSelection();
+        int topMargin = Paper.toPixels(topMarginSpinner.getSelection(), PDF_DEFAULT_USER_UNIT);
+        int lowerMargin = Paper.toPixels(lowerMarginSpinner.getSelection(), PDF_DEFAULT_USER_UNIT);
 
         return paperHeight - topMargin - lowerMargin;
     }
 
     @Override
     public int getWidth( double mapwidth, double mapheight ) {
+        // ignore viewport size of the current map and use paper format instead
         int paperWidth = paper().getPixelWidth(landscape(), getDPI());
-        int rightMargin = rightMarginSpinner.getSelection();
-        int leftMargin = leftMarginSpinner.getSelection();
+        int rightMargin = Paper.toPixels(rightMarginSpinner.getSelection(), PDF_DEFAULT_USER_UNIT);
+        int leftMargin = Paper.toPixels(leftMarginSpinner.getSelection(), PDF_DEFAULT_USER_UNIT);
 
         return paperWidth - rightMargin - leftMargin;
     }

--- a/plugins/org.locationtech.udig.project.ui/src/org/locationtech/udig/project/ui/wizard/export/image/PDFImageExportFormat.java
+++ b/plugins/org.locationtech.udig.project.ui/src/org/locationtech/udig/project/ui/wizard/export/image/PDFImageExportFormat.java
@@ -12,9 +12,7 @@ package org.locationtech.udig.project.ui.wizard.export.image;
 import java.awt.image.BufferedImage;
 import java.io.File;
 
-import org.locationtech.udig.project.IMap;
-import org.locationtech.udig.project.ui.internal.Messages;
-
+import org.eclipse.draw2d.geometry.Insets;
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.layout.GridData;
 import org.eclipse.swt.layout.GridLayout;
@@ -24,6 +22,8 @@ import org.eclipse.swt.widgets.Composite;
 import org.eclipse.swt.widgets.Group;
 import org.eclipse.swt.widgets.Label;
 import org.eclipse.swt.widgets.Spinner;
+import org.locationtech.udig.project.IMap;
+import org.locationtech.udig.project.ui.internal.Messages;
 
 /**
  * A strategy for exporting to PDF
@@ -60,8 +60,12 @@ public class PDFImageExportFormat extends ImageExportFormat {
     @Override
     public void write( IMap map, BufferedImage image, File destination ) {
         Image2Pdf.write(image, destination.getAbsolutePath(), paper(),
-                Paper.toPixels(this.leftMarginSpinner.getSelection(), PDF_DEFAULT_USER_UNIT),
-                Paper.toPixels(this.topMarginSpinner.getSelection(), PDF_DEFAULT_USER_UNIT), landscape());
+               new Insets(
+                       Paper.toPixels(this.topMarginSpinner.getSelection(), PDF_DEFAULT_USER_UNIT),
+                       Paper.toPixels(this.leftMarginSpinner.getSelection(), PDF_DEFAULT_USER_UNIT),
+                       Paper.toPixels(this.lowerMarginSpinner.getSelection(), PDF_DEFAULT_USER_UNIT),
+                       Paper.toPixels(this.rightMarginSpinner.getSelection(), PDF_DEFAULT_USER_UNIT)
+                       ), landscape());
     }
 
     @Override

--- a/plugins/org.locationtech.udig.project.ui/src/org/locationtech/udig/project/ui/wizard/export/image/Paper.java
+++ b/plugins/org.locationtech.udig.project.ui/src/org/locationtech/udig/project/ui/wizard/export/image/Paper.java
@@ -3,86 +3,93 @@
  */
 package org.locationtech.udig.project.ui.wizard.export.image;
 
-
 /**
- * The types of paper to export
+ * The types of paper to export, width and height have unit Millimeter
  *
  * @author Jesse
+ * @author Frank Gasdorf
  */
 public enum Paper {
 
-	LETTER(216,356), //in millimeters
-	LEGAL(216,279),
-	A0(841,1189),
-	A1(594,841),
-	A2(420,594),
-	A3(297, 420),
-	A4(210,297);
+    LETTER(216, 356), // in millimeters
+    LEGAL(216, 279), 
+    A0(841, 1189), 
+    A1(594, 841), 
+    A2(420, 594), 
+    A3(297, 420), 
+    A4(210, 297);
 
-	final double MILLIMETERS_PER_INCH = 25.4;
+    static final double MILLIMETERS_PER_INCH = 25.4;
 
-	private final int width;
-	private final int height;
+    private final int width;
 
-	/**
-	 *
-	 * @param width width in millimeters
-	 * @param height height in millimeters
-	 */
-	Paper(int width, int height){
-		this.width = width;
-		this.height = height;
-	}
+    private final int height;
 
+    /**
+     *
+     * @param width width in millimeters
+     * @param height height in millimeters
+     */
+    Paper(int width, int height) {
+        this.width = width;
+        this.height = height;
+    }
 
-	/**
-	 * gets the page width in millimeters
-	 *
-	 * @return width
-	 */
-	public int getWidth() {
-	    return width;
-	}
+    /**
+     * gets the page width in millimeters
+     *
+     * @return width
+     */
+    public int getWidth() {
+        return width;
+    }
 
-	/**
-	 * gets the page height in millimeters
-	 *
-	 * @return height
-	 */
-	public int getHeight() {
-	    return height;
-	}
+    /**
+     * gets the page height in millimeters
+     *
+     * @return height
+     */
+    public int getHeight() {
+        return height;
+    }
 
-	private int toPixels(int width2, double dpi) {
-		return (int) ((width2/MILLIMETERS_PER_INCH)*dpi);
-	}
+    /**
+     * Calculates the pixels for the given width in Millimeter and Resolution in dots per inch (dpi)
+     * 
+     * @param widthInMillimeter width in Millimeter (mm)
+     * @param dpi resolution in dots per inch (dpi)
+     * @return width in pixel
+     */
+    public static int toPixels(int widthInMillimeter, double dpi) {
+        double size = (widthInMillimeter / MILLIMETERS_PER_INCH) * dpi;
+        return (int) (Math.floor(Math.round(size)));
+    }
 
-	/**
-	 * get paper width in pixels
-	 *
-	 * @param landscape is landscape?
-	 * @return paper width in pixels
-	 */
-	public int getPixelWidth(boolean landscape, int dpi) {
-	    if( landscape ){
-	        return toPixels(height, dpi);
-	    }
+    /**
+     * get paper width in pixels
+     *
+     * @param landscape is landscape?
+     * @return paper width in pixels
+     */
+    public int getPixelWidth(boolean landscape, int dpi) {
+        if (landscape) {
+            return toPixels(height, dpi);
+        }
 
-	 	return toPixels(width, dpi);
-	}
+        return toPixels(width, dpi);
+    }
 
-	/**
-	 * get paper height in pixels
-	 *
-	 * @param landscape is landscape?
-	 * @return paper height in pixels
-	 */
-	public int getPixelHeight(boolean landscape, int dpi) {
-        if( landscape ){
+    /**
+     * get paper height in pixels
+     *
+     * @param landscape is landscape?
+     * @return paper height in pixels
+     */
+    public int getPixelHeight(boolean landscape, int dpi) {
+        if (landscape) {
             return toPixels(width, dpi);
         }
-		return toPixels(height, dpi);
-	}
-
+        return toPixels(height, dpi);
+    }
 
 }


### PR DESCRIPTION
The resulting PDF page format scaled up and it depends from the selected DPI value. For 72dpi the page size was almost correct, if a user selected 144 DPI the page size doubled up and so on.

The fix is to respect select paper size and scales the image down to the page, resolution is as selected. 
