### PR TITLE
Improvements related to bulk feature copy or move between layers

### DIFF
--- a/plugins/org.locationtech.udig.core.tests/fragment.xml
+++ b/plugins/org.locationtech.udig.core.tests/fragment.xml
@@ -1,4 +1,32 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <?eclipse version="3.2"?>
 <fragment>
+   <extension
+         point="org.eclipse.core.runtime.adapters">
+		<factory
+            adaptableType="java.lang.Number"
+            class="org.locationtech.udig.core.NumberAdaptableFactory">
+         <adapter
+               type="java.lang.Long">
+         </adapter>
+         <adapter
+               type="java.lang.Integer">
+         </adapter>
+         <adapter
+               type="java.lang.Short">
+         </adapter>
+         <adapter
+               type="java.lang.Double">
+         </adapter>
+         <adapter
+               type="java.lang.Float">
+         </adapter>
+         <adapter
+               type="java.lang.BigDecimal">
+         </adapter>
+         <adapter
+               type="java.lang.BigInteger">
+         </adapter>
+      </factory>
+   </extension>
 </fragment>

--- a/plugins/org.locationtech.udig.core.tests/fragment.xml
+++ b/plugins/org.locationtech.udig.core.tests/fragment.xml
@@ -22,10 +22,10 @@
                type="java.lang.Float">
          </adapter>
          <adapter
-               type="java.lang.BigDecimal">
+               type="java.math.BigDecimal">
          </adapter>
          <adapter
-               type="java.lang.BigInteger">
+               type="java.math.BigInteger">
          </adapter>
       </factory>
    </extension>

--- a/plugins/org.locationtech.udig.core.tests/src/org/locationtech/udig/core/AdapterUtilTest.java
+++ b/plugins/org.locationtech.udig.core.tests/src/org/locationtech/udig/core/AdapterUtilTest.java
@@ -1,6 +1,9 @@
 package org.locationtech.udig.core;
 
 import static org.junit.Assert.assertTrue;
+
+import java.math.BigDecimal;
+
 import static junit.framework.Assert.assertEquals;
 
 import org.eclipse.core.runtime.NullProgressMonitor;
@@ -38,4 +41,26 @@ public class AdapterUtilTest {
         boolean canAdaptTo = AdapterUtil.instance.canAdaptTo(String.class.getName(), testString, null);
     }
     
+    
+    @Test
+    public void testCanAdaptDoubleFromInteger() throws Exception {
+        Integer testVal = new Integer(2);
+		Double value = AdapterUtil.instance.adaptTo(Double.class, testVal, null);
+		assertEquals(value, 2.0);
+    }
+    
+    
+    @Test
+    public void testCanAdaptIntegerFromDouble() throws Exception {
+        Double testVal = new Double(2.2);
+		Integer value = AdapterUtil.instance.adaptTo(Integer.class, testVal, null);
+		assertEquals((int)value, 2);
+    }
+    
+    @Test
+    public void testCanAdaptBigDecimalFromDouble() throws Exception {
+        Double testVal = new Double(2.2);
+        BigDecimal value = AdapterUtil.instance.adaptTo(BigDecimal.class, testVal, null);
+		assertEquals((BigDecimal)value, new BigDecimal("2.2"));
+    }
 }

--- a/plugins/org.locationtech.udig.core.tests/src/org/locationtech/udig/core/DataUtilitiesTest.java
+++ b/plugins/org.locationtech.udig.core.tests/src/org/locationtech/udig/core/DataUtilitiesTest.java
@@ -1,0 +1,86 @@
+/* uDig - User Friendly Desktop Internet GIS client
+ * https://locationtech.org/projects/technology.udig
+ * (C) 2019, Eclipse Foundation
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * (http://www.eclipse.org/legal/epl-v10.html), and the Eclipse Distribution
+ * License v1.0 (http://www.eclipse.org/org/documents/edl-v10.html).
+ */
+package org.locationtech.udig.core;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+import java.math.BigDecimal;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Date;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+
+import org.geotools.data.DataUtilities;
+import org.geotools.factory.FactoryRegistryException;
+import org.geotools.feature.SchemaException;
+import org.geotools.feature.simple.SimpleFeatureBuilder;
+import org.geotools.geometry.jts.JTSFactoryFinder;
+import org.geotools.referencing.operation.transform.IdentityTransform;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.locationtech.udig.core.internal.FeatureUtils;
+import org.opengis.feature.simple.SimpleFeature;
+import org.opengis.feature.simple.SimpleFeatureType;
+
+import com.vividsolutions.jts.geom.Coordinate;
+import com.vividsolutions.jts.geom.GeometryFactory;
+
+public class DataUtilitiesTest {
+    
+    @Test
+    public void testCompareEquality() throws Exception{
+    	SimpleFeatureType featureType = DataUtilities.createType("testType",
+    			"geometry:Point,Name:String,timestamp:java.util.Date,val:Double");
+
+    	SimpleFeatureType targetFeatureType = DataUtilities.createType("testType",
+    			"geometry:Point,Name:String,timestamp:java.util.Date,val:Integer");
+
+    	int compare = DataUtilities.compare(featureType, targetFeatureType);
+    	
+    	assertEquals(0, compare);
+    }
+    
+    
+    @Test
+    public void testCompareEqualReorder() throws Exception{
+    	SimpleFeatureType featureType = DataUtilities.createType("testType",
+    			"geometry:Point,Name:String,val:Double,timestamp:java.util.Date");
+
+    	SimpleFeatureType targetFeatureType = DataUtilities.createType("testType",
+    			"geometry:Point,Name:String,timestamp:java.util.Date,val:Double");
+
+    	int compare = DataUtilities.compare(featureType, targetFeatureType);
+    	
+    	assertEquals(1, compare);
+    }
+    
+    
+    @Test
+    public void testCompareNotEqual2() throws Exception{
+       	SimpleFeatureType featureType = DataUtilities.createType("testType",
+    			"geometry:Point,Name:String,timestamp:java.util.Date,val:Double");
+
+    	SimpleFeatureType targetFeatureType = DataUtilities.createType("testType",
+    			"geometry:Point,Name:String,timestamp:java.util.Date,val1:Integer");
+
+    	int compare = DataUtilities.compare(featureType, targetFeatureType);
+    	
+    	assertEquals(-1, compare);
+    }
+    
+}

--- a/plugins/org.locationtech.udig.core.tests/src/org/locationtech/udig/core/FeatureUtilsTest.java
+++ b/plugins/org.locationtech.udig.core.tests/src/org/locationtech/udig/core/FeatureUtilsTest.java
@@ -2,18 +2,26 @@ package org.locationtech.udig.core;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
+import java.math.BigDecimal;
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.Date;
+import java.util.Iterator;
 import java.util.List;
+import java.util.Map;
 
 import org.geotools.data.DataUtilities;
+import org.geotools.factory.FactoryRegistryException;
 import org.geotools.feature.SchemaException;
 import org.geotools.feature.simple.SimpleFeatureBuilder;
 import org.geotools.geometry.jts.JTSFactoryFinder;
+import org.geotools.referencing.operation.transform.IdentityTransform;
 import org.junit.BeforeClass;
 import org.junit.Test;
 import org.locationtech.udig.core.internal.FeatureUtils;
@@ -100,5 +108,86 @@ public class FeatureUtilsTest {
         List<String> result = FeatureUtils.getActualPropertyName(featureType, propertyNames);
         assertFalse(result.contains("Whatever"));
         assertTrue(result.contains("name"));
+    }
+    
+    
+    @Test
+    public void testCopyFeatureDoubleToInt() throws Exception{
+    	SimpleFeatureType featureType = DataUtilities.createType("testType",
+    			"geometry:Point,Name:String,timestamp:java.util.Date,val:Double");
+
+    	SimpleFeatureType featureType2 = DataUtilities.createType("testType",
+    			"geometry:Point,Name:String,timestamp:java.util.Date,val:Integer");
+
+    	SimpleFeatureBuilder featureTypeBuilder = new SimpleFeatureBuilder(featureType);
+    	GeometryFactory geometryFactory = JTSFactoryFinder.getGeometryFactory();
+
+    	featureTypeBuilder.addAll(
+    			new Object[] { geometryFactory.createPoint(new Coordinate(10, 10)), "first",
+    			new Date(), new Double(2.2) });
+    	SimpleFeature feature = featureTypeBuilder.buildFeature("id");
+    	Map<String, String> attributeMap = FeatureUtils.createAttributeMapping(featureType, featureType2);
+    	Collection<SimpleFeature> result = FeatureUtils.copyFeature(feature, featureType2, attributeMap, IdentityTransform.create(1));
+    	for (SimpleFeature c : result) {
+    		assertNotNull(c.getAttribute("val"));
+    		assertEquals(new Integer(2), (Integer)c.getAttribute("val"));
+    		return;
+    	}
+    	fail("Copy feature failed. No feature in collection");
+
+    }
+    
+    
+    @Test
+    public void testCopyFeatureDouble2BigDecimal() throws Exception{
+    	SimpleFeatureType featureType = DataUtilities.createType("testType",
+    			"geometry:Point,Name:String,timestamp:java.util.Date,val:Double");
+
+    	SimpleFeatureType featureType2 = DataUtilities.createType("testType",
+    			"geometry:Point,Name:String,timestamp:java.util.Date,val:java.math.BigDecimal");
+    	
+    	SimpleFeatureBuilder featureTypeBuilder = new SimpleFeatureBuilder(featureType);
+    	GeometryFactory geometryFactory = JTSFactoryFinder.getGeometryFactory();
+
+    	featureTypeBuilder.addAll(
+    			new Object[] { geometryFactory.createPoint(new Coordinate(10, 10)), "first",
+    			new Date(), new Double(2.2) });
+    	SimpleFeature feature = featureTypeBuilder.buildFeature("id");
+    	
+    	Map<String, String> attributeMap = FeatureUtils.createAttributeMapping(featureType, featureType2);
+    	Collection<SimpleFeature> result = FeatureUtils.copyFeature(feature, featureType2, attributeMap, IdentityTransform.create(1));
+    	for (SimpleFeature c : result) {
+    		assertNotNull(c.getAttribute("val"));
+    		assertEquals(new BigDecimal("2.2"), (BigDecimal)c.getAttribute("val"));
+    		return;
+    	}
+    	fail("Copy feature failed. No feature in collection");
+
+    }
+    
+    
+    @Test
+    public void testCopyFeatureDouble2String() throws Exception{
+    	SimpleFeatureType featureType = DataUtilities.createType("testType",
+    			"geometry:Point,Name:String,timestamp:java.util.Date,val:Double");
+
+    	SimpleFeatureType featureType2 = DataUtilities.createType("testType",
+    			"geometry:Point,Name:String,timestamp:java.util.Date,val:String");
+
+    	SimpleFeatureBuilder featureTypeBuilder = new SimpleFeatureBuilder(featureType);
+    	GeometryFactory geometryFactory = JTSFactoryFinder.getGeometryFactory();
+
+    	featureTypeBuilder.addAll(
+    			new Object[] { geometryFactory.createPoint(new Coordinate(10, 10)), "first",
+    			new Date(), new Double(2.2) });
+    	SimpleFeature feature = featureTypeBuilder.buildFeature("id");
+    	Map<String, String> attributeMap = FeatureUtils.createAttributeMapping(featureType, featureType2);
+    	Collection<SimpleFeature> result = FeatureUtils.copyFeature(feature, featureType2, attributeMap, IdentityTransform.create(1));
+    	for (SimpleFeature c : result) {
+    		assertNull(c.getAttribute("val")); //null should be set in 'val' since no adaptation is possible and value is not copied
+    		return;
+    	}
+    	fail("Copy feature failed. No feature in collection");
+
     }
 }

--- a/plugins/org.locationtech.udig.core.tests/src/org/locationtech/udig/core/NumberAdaptableFactory.java
+++ b/plugins/org.locationtech.udig.core.tests/src/org/locationtech/udig/core/NumberAdaptableFactory.java
@@ -1,0 +1,52 @@
+package org.locationtech.udig.core;
+
+import java.math.BigDecimal;
+import java.math.BigInteger;
+import java.sql.Date;
+import java.sql.Timestamp;
+
+import org.eclipse.core.runtime.IAdapterFactory;
+
+public class NumberAdaptableFactory implements IAdapterFactory {
+	
+	@Override
+	public Object getAdapter(Object adaptableObject, Class adapterType) {
+
+		if (adaptableObject == null) {
+			return null;
+		}
+		
+		if (adaptableObject instanceof Number) {
+			if (adapterType==Long.class) {
+				//System.out.println("Adapting " + adaptableObject.getClass()  + " to Long. Rounding or truncation may occur");
+				return ((Number)adaptableObject).longValue();
+			} else if (adapterType==Integer.class) {
+				//System.out.println("Adapting " + adaptableObject.getClass()  + " to Integer. Rounding or truncation may occur");
+				return ((Number)adaptableObject).intValue();
+			} else if (adapterType==Double.class) {
+				//System.out.println("Adapting " + adaptableObject.getClass()  + " to Double. Rounding may occur");
+				return ((Number)adaptableObject).doubleValue();
+			} else if (adapterType==Short.class) {
+				//System.out.println("Adapting " + adaptableObject.getClass()  + " to Short. Rounding or truncation may occur");
+				return ((Number)adaptableObject).shortValue();
+			} else if (adapterType==Float.class) {
+				//System.out.println("Adapting " + adaptableObject.getClass()  + " to Long. Rounding may occur");
+				return ((Number)adaptableObject).floatValue();
+			} else if (adapterType==BigDecimal.class) {
+				//System.out.println("Adapting " + adaptableObject.getClass()  + " to BigDecimal");
+				return new BigDecimal(adaptableObject.toString());
+			} else if (adapterType==BigInteger.class) {
+				//System.out.println("Adapting " + adaptableObject.getClass()  + " to BigInteger. Rounding may occur");
+				return new BigDecimal(adaptableObject.toString()).toBigInteger();
+			}
+		}
+		
+		return null;
+	}
+
+	@Override
+	public Class[] getAdapterList() {
+		return new Class[]{Number.class};
+	}
+
+}

--- a/plugins/org.locationtech.udig.core.tests/src/org/locationtech/udig/core/NumberAdaptableFactory.java
+++ b/plugins/org.locationtech.udig.core.tests/src/org/locationtech/udig/core/NumberAdaptableFactory.java
@@ -2,8 +2,6 @@ package org.locationtech.udig.core;
 
 import java.math.BigDecimal;
 import java.math.BigInteger;
-import java.sql.Date;
-import java.sql.Timestamp;
 
 import org.eclipse.core.runtime.IAdapterFactory;
 

--- a/plugins/org.locationtech.udig.core/src/org/locationtech/udig/core/AdapterUtil.java
+++ b/plugins/org.locationtech.udig.core/src/org/locationtech/udig/core/AdapterUtil.java
@@ -83,6 +83,11 @@ public class AdapterUtil {
      * @return true if the object is an instanceof or can adapt to
      */
     public boolean canAdaptTo( Object obj, Class< ? > target ) {
+        
+        if (obj == null) {
+            return false;
+        }
+        
         //see if platform can adapt the object
         if (Platform.getAdapterManager().hasAdapter(obj, target.getName()) )
             return true;

--- a/plugins/org.locationtech.udig.core/src/org/locationtech/udig/core/internal/FeatureUtils.java
+++ b/plugins/org.locationtech.udig.core/src/org/locationtech/udig/core/internal/FeatureUtils.java
@@ -363,7 +363,7 @@ public class FeatureUtils {
                                     destSchema.getDescriptor(i).getType().getBinding(), 
                                     source.getAttribute(sourceAttributeName), mon);
                         } catch (Exception e) {
-                            e.printStackTrace();
+                        	CorePlugin.log("", e);
                         }
                     } else {
                         attributes[i] = destSchema.getDescriptor(i).getDefaultValue();

--- a/plugins/org.locationtech.udig.tools.jgrass/src/org/locationtech/udig/tools/jgrass/utils/OperationUtils.java
+++ b/plugins/org.locationtech.udig.tools.jgrass/src/org/locationtech/udig/tools/jgrass/utils/OperationUtils.java
@@ -95,11 +95,16 @@ public class OperationUtils {
         SimpleFeatureType toSchema = toLayer.getSchema();
         SimpleFeatureType selectedSchema = selectedLayer.getSchema();
         int compare = DataUtilities.compare(toSchema, selectedSchema);
-        if (compare != 0) {
+        boolean needsReOrder = false;
+        if (compare == -1) {
             showMessage(display,
                     Messages.getString("OperationUtils_warning"), Messages.getString("OperationUtils_sametypeproblem"), //$NON-NLS-1$ //$NON-NLS-2$
                     MSGTYPE.WARNING);
             return;
+        } else if (compare == 1){
+            showMessage(display,
+                    Messages.getString("OperationUtils_warning"), "featureType match but needs reordering", MSGTYPE.INFO); //$NON-NLS-1$ //$NON-NLS-2$
+                needsReOrder = true;
         }
 
         SimpleFeatureCollection featureCollection = featureSource.getFeatures(selectedLayer.getQuery(true));
@@ -117,7 +122,8 @@ public class OperationUtils {
         int count = 0;
         while( featureIterator.hasNext() ) {
             SimpleFeature feature = featureIterator.next();
-            UndoableMapCommand addFeatureCmd = cmdFactory.createAddFeatureCommand(feature, toLayer);
+            UndoableMapCommand addFeatureCmd = cmdFactory.createAddFeatureCommand(
+                    needsReOrder ? DataUtilities.reType(toSchema, feature, true) : feature, toLayer);
             copyOverList.add(addFeatureCmd);
             UndoableMapCommand deleteFeatureCmd = cmdFactory.createDeleteFeature(feature, selectedLayer);
             deleteOldList.add(deleteFeatureCmd);


### PR DESCRIPTION
Enhancements include:

1. allow move of features between layers even when there is no strict featureType match (i.e. reordered attribute fields exist). 
2. copy of an attribute field between 2 layers even if the target attribute type does not strictly match the source attribute type based on the existence of proper adapters. 
Included example shp files to test the behavior via the UI.
[test_shp_files.zip](https://github.com/locationtech/udig-platform/files/827288/test_shp_files.zip)


Signed-off-by: Nikolaos Pringouris <nprigour@gmail.com>