### PR TITLE
fix render metric sorter comparison implementation

### DIFF
--- a/plugins/org.locationtech.udig.project.tests.ui/plugin.xml
+++ b/plugins/org.locationtech.udig.project.tests.ui/plugin.xml
@@ -148,4 +148,27 @@
                   value="org.locationtech.udig.project.ui.internal.tool.display.TestProperty"/>
          </object>
       </extension>
+      <extension
+            point="org.eclipse.ui.menus">
+         <menuContribution
+               allPopups="false"
+               locationURI="menu:org.eclipse.ui.main.menu?after=window">
+            <menu
+                  label="Renderer Testing">
+               <command
+                     commandId="org.locationtech.udig.project.tests.configurerenderers"
+                     label="configure renderers"
+                     style="push">
+               </command>
+            </menu>
+         </menuContribution>
+      </extension>
+      <extension
+            point="org.eclipse.ui.commands">
+         <command
+               defaultHandler="org.locationtech.udig.project.tests.ui.RendererSetterHandler"
+               id="org.locationtech.udig.project.tests.configurerenderers"
+               name="configure renderers">
+         </command>
+      </extension>
 </plugin>

--- a/plugins/org.locationtech.udig.project.tests.ui/src/org/locationtech/udig/project/tests/ui/RendererSetterHandler.java
+++ b/plugins/org.locationtech.udig.project.tests.ui/src/org/locationtech/udig/project/tests/ui/RendererSetterHandler.java
@@ -1,0 +1,509 @@
+/* uDig - User Friendly Desktop Internet GIS client
+ * https://locationtech.org/projects/technology.udig
+ * (C) 2017, Eclipse Foundation
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * (http://www.eclipse.org/legal/epl-v10.html), and the Eclipse Distribution
+ * License v1.0 (http://www.eclipse.org/org/documents/edl-v10.html).
+ */
+package org.locationtech.udig.project.tests.ui;
+
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+import org.eclipse.core.commands.AbstractHandler;
+import org.eclipse.core.commands.ExecutionEvent;
+import org.eclipse.core.commands.ExecutionException;
+import org.eclipse.jface.dialogs.MessageDialog;
+import org.eclipse.jface.dialogs.TitleAreaDialog;
+import org.eclipse.jface.viewers.ArrayContentProvider;
+import org.eclipse.jface.viewers.ComboViewer;
+import org.eclipse.jface.viewers.ISelectionChangedListener;
+import org.eclipse.jface.viewers.IStructuredSelection;
+import org.eclipse.jface.viewers.LabelProvider;
+import org.eclipse.jface.viewers.SelectionChangedEvent;
+import org.eclipse.jface.viewers.StructuredSelection;
+import org.eclipse.swt.SWT;
+import org.eclipse.swt.events.FocusAdapter;
+import org.eclipse.swt.events.FocusEvent;
+import org.eclipse.swt.events.SelectionEvent;
+import org.eclipse.swt.events.SelectionListener;
+import org.eclipse.swt.graphics.Point;
+import org.eclipse.swt.layout.GridData;
+import org.eclipse.swt.layout.GridLayout;
+import org.eclipse.swt.widgets.Button;
+import org.eclipse.swt.widgets.Composite;
+import org.eclipse.swt.widgets.Control;
+import org.eclipse.swt.widgets.Shell;
+import org.eclipse.swt.widgets.Text;
+import org.eclipse.ui.handlers.HandlerUtil;
+import org.geotools.util.Range;
+import org.locationtech.udig.project.ILayer;
+import org.locationtech.udig.project.IStyleBlackboard;
+import org.locationtech.udig.project.internal.Layer;
+import org.locationtech.udig.project.internal.render.MultiLayerRenderer;
+import org.locationtech.udig.project.internal.render.RenderContext;
+import org.locationtech.udig.project.internal.render.impl.RenderMetricsSorter;
+import org.locationtech.udig.project.internal.render.impl.RendererCreatorImpl;
+import org.locationtech.udig.project.render.AbstractRenderMetrics;
+import org.locationtech.udig.project.render.IRenderer;
+import org.locationtech.udig.project.ui.ApplicationGIS;
+import org.locationtech.udig.project.ui.internal.ApplicationGISInternal;
+
+
+/**
+ * Test handler that provides a way to check behavior of {@link RenderMetricsSorter}.
+ * 
+ * @author Nikolaos Pringouris <nprigour@gmail.com>
+ *
+ */
+public class RendererSetterHandler extends AbstractHandler {
+
+
+    /* (non-Javadoc)
+     * @see org.eclipse.core.commands.IHandler#execute(org.eclipse.core.commands.ExecutionEvent)
+     */
+    @Override
+    public Object execute(ExecutionEvent event) throws ExecutionException {
+
+
+        final Shell shell= HandlerUtil.getActiveShell(event);
+
+        final RendererControlDialog dialog = new RendererControlDialog(shell);
+
+        shell.getDisplay().asyncExec(new Runnable() {
+
+            @Override
+            public void run() {
+                dialog.open();
+            }
+
+        });
+
+        return null;
+    }
+
+    /**
+     * Helper class to compute rate of an {@link AbstractRenderMetrics} metric. 
+     * see also {@link RenderMetricsSorter}
+     * 
+     * @author Nikolaos Pringouris <nprigour@gmail.com>
+     *
+     */
+    private class RenderMetricsSorterExt extends RenderMetricsSorter {
+
+        public RenderMetricsSorterExt(List<Layer> layers) {
+            super(layers);
+            // TODO Auto-generated constructor stub
+        }
+
+        protected double rate( AbstractRenderMetrics metrics ) {
+            ILayer layer = metrics.getRenderContext().getLayer();
+            final IStyleBlackboard style = layer.getStyleBlackboard();
+
+            //render metrics - 
+            //guarenteed to be between 0 & 1 - higher better so we subtract one to get make lower better
+            double renderAppearanceMetric = 1 - metrics.getUserAppearanceMetric(style);
+            double userAppearanceMetric = 1 - metrics.getRenderAppearanceMetric(style);
+
+            double latencyMetric = metrics.getLatencyMetric();
+            latencyMetric = latencyMetric / MAXIMUM_LATENCY;
+
+            double drawingTimeMetric = metrics.getDrawingTimeMetric();
+            drawingTimeMetric = drawingTimeMetric / MAXIMUM_DRAWINGTIME;
+
+            // resolution metric - close to 1 the better
+            //worst case is the screen size
+            double width = metrics.getRenderContext().getMapDisplay().getWidth();
+            double resolutionMetric = metrics.getResolutionMetric();
+            double diff = Math.abs(resolutionMetric - 1);
+            if (diff == 0){
+                resolutionMetric = 0; //perfect match (lower is better)
+            }else{
+                resolutionMetric = (diff / width);  //lower number 
+            }
+
+            int multiLayerMetric = 1 - rateMultiLayerRenderer(metrics);
+            double scaleRangeMetric = 1 - rateScaleRange(metrics);
+
+            double rating = renderAppearanceMetric * WEIGHT_RENDER_APPEARANCE_METRIC;
+            rating += userAppearanceMetric * WEIGHT_USER_APPEARANCE_METRIC;
+            rating += latencyMetric * WEIGHT_LATENCY_METRIC;
+            rating += drawingTimeMetric * WEIGHT_DRAWING_TIME_METRIC;
+            rating += resolutionMetric * WEIGHT_RESOLUTION_METRIC;
+            rating += multiLayerMetric * WEIGHT_MULTILAYER_METRIC;
+            rating += scaleRangeMetric * WEIGHT_SCALERANGE_METRIC;
+
+            return rating;
+        }
+
+        private int rateScaleRange( AbstractRenderMetrics metrics ) {
+            Set<Range<Double>> scales =new HashSet<Range<Double>>(); 
+            try {
+                scales =metrics.getValidScaleRanges();
+            } catch (Exception e) {
+                //
+            }
+            for( Range<Double> range : scales ) {
+                if( range.contains(metrics.getRenderContext().getViewportModel().getScaleDenominator()) ){
+                    return 1;
+                }
+            }
+            return 0;
+        }
+
+        private int rateMultiLayerRenderer( AbstractRenderMetrics metrics ) {
+            if (MultiLayerRenderer.class.isAssignableFrom(metrics.getRenderMetricsFactory()
+                    .getRendererType())) {
+                int indexOf = getLayers().indexOf(metrics.getRenderContext().getLayer());
+                if( indexOf>0 )
+                    if( metrics.canAddLayer(getLayers().get(indexOf-1)) )
+                        return 1;
+                if( indexOf<getLayers().size()-1 )
+                    if( metrics.canAddLayer(getLayers().get(indexOf+1)) )
+                        return 1;
+            }
+            return 0;
+        }
+    }
+
+    /**
+     * Provides a Dialog that enables setting/resetting of preferred Renderer
+     * and displays info of available metrics ratings.
+     *  
+     * @author Nikolaos Pringouris <nprigour@gmail.com>
+     *
+     */
+    private class RendererControlDialog extends TitleAreaDialog {
+
+        private Text paramsHolder;
+
+        private ComboViewer layerCombo;
+        private ComboViewer rendererCombo;
+
+        private Button mapPreferredRendererButton;
+        private Button layerPreferredRendererButton;
+        private Button mapLastResortRendererButton;
+        private Button layerLastResortRendererButton;
+
+        private RenderMetricsSorterExt sorter;
+        private Text outputText;
+
+        /**
+         * @param parentShell
+         * @param emf 
+         */
+        protected RendererControlDialog(Shell parentShell) {
+            super(parentShell);
+            setShellStyle(SWT.RESIZE|SWT.DIALOG_TRIM|SWT.CLOSE);
+        }
+
+
+        /* (non-Javadoc)
+         * @see org.eclipse.jface.dialogs.Dialog#createDialogArea(org.eclipse.swt.widgets.Composite)
+         */
+        @Override
+        protected Control createDialogArea(Composite parent) {
+            Composite container = (Composite) super.createDialogArea(parent);
+            container.setLayout(new GridLayout(3, false));
+
+            //COMBO VIEWER for layers SELECTION
+            layerCombo = new ComboViewer(container, SWT.DROP_DOWN | SWT.BORDER | SWT.READ_ONLY);
+            layerCombo.setContentProvider(ArrayContentProvider.getInstance());
+
+            layerCombo.setInput(ApplicationGIS.getActiveMap().getMapLayers());
+            layerCombo.addSelectionChangedListener(new ISelectionChangedListener() {
+
+                @Override
+                public void selectionChanged(SelectionChangedEvent event) {
+                    Object selection = ((IStructuredSelection)event.getSelection()).getFirstElement();
+                    if (selection instanceof Layer) {
+                        Layer layer = (Layer)selection;
+                        sorter = new RenderMetricsSorterExt(Collections.singletonList(layer));
+                        outputText.setText(printRendererInfo(layer));	
+
+                        Collection<AbstractRenderMetrics> metrics = getApplicableRendererMetrics(layer);
+                        rendererCombo.setInput(metrics);
+                        
+                        RenderContext context = layer.getMapInternal().getRenderManagerInternal().getRendererCreator().getRenderContext(layer);
+                        IRenderer rend = layer.getMapInternal().getRenderManagerInternal().getRendererCreator().getRenderer(context);
+                        for (AbstractRenderMetrics metric : metrics) {
+                            if (metric.getRenderMetricsFactory().getRendererType() == rend.getClass()) {
+                                rendererCombo.setSelection(new StructuredSelection(metric));
+                            }
+                        }
+                    }
+                }
+            });
+            layerCombo.getControl().addFocusListener(new FocusAdapter() {
+
+                @Override
+                public void focusGained(FocusEvent e) {
+                    layerCombo.setInput(ApplicationGIS.getActiveMap().getMapLayers());
+                }
+
+            });
+            layerCombo.getControl().setLayoutData(new GridData(SWT.LEFT, SWT.TOP, true, false, 3, 1));
+
+
+            //COMBO VIEWER for renderer SELECTION
+            rendererCombo = new ComboViewer(container, SWT.DROP_DOWN | SWT.BORDER | SWT.READ_ONLY);
+            rendererCombo.setContentProvider(ArrayContentProvider.getInstance());
+            rendererCombo.addSelectionChangedListener(new ISelectionChangedListener() {
+
+                @Override
+                public void selectionChanged(SelectionChangedEvent event) {
+                    Layer layer = (Layer) ((IStructuredSelection)layerCombo.getSelection()).getFirstElement();
+                    AbstractRenderMetrics rendererMetric = (AbstractRenderMetrics) ((IStructuredSelection)rendererCombo.getSelection()).getFirstElement();
+
+                    if (layer != null) {
+                        /*
+						if (mapPreferredRendererButton.getSelection()) {
+							ApplicationGISInternal.getActiveMap().getBlackBoardInternal().putString(RendererCreatorImpl.PREFERRED_RENDERER_ID, rendererMetric.getId());
+						}
+						if (layerPreferredRendererButton.getSelection()) {
+							layer.getStyleBlackboard().putString(RendererCreatorImpl.PREFERRED_RENDERER_ID, rendererMetric.getId());
+						}
+                         */
+                        outputText.setText(printRendererInfo(layer));	
+                        RendererControlDialog.this.setMessage("A close and reopen of the Map is needed in order changes to apply", MessageDialog.WARNING);
+                    }
+
+                }
+            });
+            rendererCombo.getControl().setLayoutData(new GridData(SWT.LEFT, SWT.TOP, true, false, 3, 1));
+            ((GridData)rendererCombo.getControl().getLayoutData()).minimumWidth = 500;
+            rendererCombo.setLabelProvider(new LabelProvider() {
+
+                @Override
+                public String getText(Object element) {
+                    if (element instanceof AbstractRenderMetrics) {
+                        return ((AbstractRenderMetrics) element).getId();
+                    }
+                    return "";
+                }
+
+            });
+            mapPreferredRendererButton = new Button(container, SWT.CHECK|SWT.BORDER);
+            mapPreferredRendererButton.setText("set as Map preferred");
+            mapPreferredRendererButton.setLayoutData(new GridData(SWT.LEFT, SWT.TOP, true, false, 3, 1));
+            mapPreferredRendererButton.addSelectionListener(new SelectionListener() {
+
+                @Override
+                public void widgetSelected(SelectionEvent e) {
+                    Layer layer = (Layer) ((IStructuredSelection)layerCombo.getSelection()).getFirstElement();
+                    AbstractRenderMetrics rendererMetric = (AbstractRenderMetrics) ((IStructuredSelection)rendererCombo.getSelection()).getFirstElement();
+                    if (mapPreferredRendererButton.getSelection()) {
+                        ApplicationGISInternal.getActiveMap().getBlackBoardInternal().putString(RendererCreatorImpl.PREFERRED_RENDERER_ID, rendererMetric.getId());
+                    } else {
+                        ApplicationGISInternal.getActiveMap().getBlackBoardInternal().remove(RendererCreatorImpl.PREFERRED_RENDERER_ID);
+                    }
+                    RendererControlDialog.this.setErrorMessage("A close and reopen of the Map is needed in order changes to apply");
+                    outputText.setText(printRendererInfo(layer));	
+                }
+
+                @Override
+                public void widgetDefaultSelected(SelectionEvent e) {
+                    // TODO Auto-generated method stub
+
+                }
+
+            });
+
+            layerPreferredRendererButton = new Button(container, SWT.CHECK|SWT.BORDER);
+            layerPreferredRendererButton.setText("set as layer preferred");
+            layerPreferredRendererButton.setLayoutData(new GridData(SWT.LEFT, SWT.TOP, true, false, 3, 1));
+            layerPreferredRendererButton.addSelectionListener(new SelectionListener() {
+
+                @Override
+                public void widgetSelected(SelectionEvent e) {
+                    Layer layer = (Layer) ((IStructuredSelection)layerCombo.getSelection()).getFirstElement();
+                    AbstractRenderMetrics rendererMetric = (AbstractRenderMetrics) ((IStructuredSelection)rendererCombo.getSelection()).getFirstElement();
+                    if (layerPreferredRendererButton.getSelection()) {
+                        layer.getStyleBlackboard().putString(RendererCreatorImpl.PREFERRED_RENDERER_ID, rendererMetric.getId());
+                    } else {
+                        layer.getStyleBlackboard().remove(RendererCreatorImpl.PREFERRED_RENDERER_ID);
+                    }
+                    RendererControlDialog.this.setErrorMessage("A close and reopen of the Map is needed in order changes to apply");
+                    outputText.setText(printRendererInfo(layer));	
+                }
+
+                @Override
+                public void widgetDefaultSelected(SelectionEvent e) {
+                    // TODO Auto-generated method stub
+
+                }
+
+            });
+
+            mapLastResortRendererButton = new Button(container, SWT.CHECK|SWT.BORDER);
+            mapLastResortRendererButton.setText("set as Map last resort");
+            mapLastResortRendererButton.setLayoutData(new GridData(SWT.LEFT, SWT.TOP, true, false, 3, 1));
+            mapLastResortRendererButton.addSelectionListener(new SelectionListener() {
+
+                @Override
+                public void widgetSelected(SelectionEvent e) {
+                    Layer layer = (Layer) ((IStructuredSelection)layerCombo.getSelection()).getFirstElement();
+                    AbstractRenderMetrics rendererMetric = (AbstractRenderMetrics) ((IStructuredSelection)rendererCombo.getSelection()).getFirstElement();
+                    if (mapLastResortRendererButton.getSelection()) {
+                        ApplicationGISInternal.getActiveMap().getBlackBoardInternal().putString(RendererCreatorImpl.LAST_RESORT_RENDERER_ID, rendererMetric.getId());
+                    } else {
+                        ApplicationGISInternal.getActiveMap().getBlackBoardInternal().remove(RendererCreatorImpl.LAST_RESORT_RENDERER_ID);
+                    }
+                    RendererControlDialog.this.setErrorMessage("A close and reopen of the Map is needed in order changes to apply");
+                    outputText.setText(printRendererInfo(layer));	
+                }
+
+                @Override
+                public void widgetDefaultSelected(SelectionEvent e) {
+                    // TODO Auto-generated method stub
+
+                }
+
+            });
+
+            layerLastResortRendererButton = new Button(container, SWT.CHECK|SWT.BORDER);
+            layerLastResortRendererButton.setText("set as layer last resort");
+            layerLastResortRendererButton.setLayoutData(new GridData(SWT.LEFT, SWT.TOP, true, false, 3, 1));
+            layerLastResortRendererButton.addSelectionListener(new SelectionListener() {
+
+                @Override
+                public void widgetSelected(SelectionEvent e) {
+                    Layer layer = (Layer) ((IStructuredSelection)layerCombo.getSelection()).getFirstElement();
+                    AbstractRenderMetrics rendererMetric = (AbstractRenderMetrics) ((IStructuredSelection)rendererCombo.getSelection()).getFirstElement();
+                    if (layerLastResortRendererButton.getSelection()) {
+                        layer.getStyleBlackboard().putString(RendererCreatorImpl.LAST_RESORT_RENDERER_ID, rendererMetric.getId());
+                    } else {
+                        layer.getStyleBlackboard().remove(RendererCreatorImpl.LAST_RESORT_RENDERER_ID);
+                    }
+                    RendererControlDialog.this.setErrorMessage("A close and reopen of the Map is needed in order changes to apply");
+                    outputText.setText(printRendererInfo(layer));	
+                }
+
+                @Override
+                public void widgetDefaultSelected(SelectionEvent e) {
+                    // TODO Auto-generated method stub
+
+                }
+
+            });
+
+            Button clearButton = new Button(container, SWT.PUSH|SWT.BORDER);
+            clearButton.setText("clear blackboard values");
+            clearButton.setLayoutData(new GridData(SWT.LEFT, SWT.TOP, true, false, 3, 1));
+            clearButton.addSelectionListener(new SelectionListener() {
+
+                @Override
+                public void widgetSelected(SelectionEvent e) {
+                    Layer layer = (Layer) ((IStructuredSelection)layerCombo.getSelection()).getFirstElement();
+                    layer.getStyleBlackboard().remove(RendererCreatorImpl.LAST_RESORT_RENDERER_ID);
+                    layer.getStyleBlackboard().remove(RendererCreatorImpl.PREFERRED_RENDERER_ID);
+                    ApplicationGISInternal.getActiveMap().getBlackBoardInternal().remove(RendererCreatorImpl.LAST_RESORT_RENDERER_ID);
+                    ApplicationGISInternal.getActiveMap().getBlackBoardInternal().remove(RendererCreatorImpl.PREFERRED_RENDERER_ID);
+                    RendererControlDialog.this.setErrorMessage("A close and reopen of the Map is needed in order changes to apply");
+                    outputText.setText(printRendererInfo(layer));   
+                }
+
+                @Override
+                public void widgetDefaultSelected(SelectionEvent e) {
+                    // TODO Auto-generated method stub
+
+                }
+
+            });
+
+            outputText = new Text(container, SWT.BORDER|SWT.MULTI|SWT.WRAP | SWT.V_SCROLL | SWT.H_SCROLL);
+            outputText.setLayoutData(new GridData (SWT.FILL, SWT.FILL, true, true, 3, 1));
+            ((GridData)outputText.getLayoutData()).heightHint = 80;
+
+            return container;
+        }
+
+        /**
+         * Return the initial size of the dialog.
+         */
+        @Override
+        protected Point getInitialSize() {
+            return new Point(1000, 600);
+        }
+
+
+        private String printRendererInfo(Layer layer) {
+            if (layer == null) {
+                return "";
+            }
+            StringBuffer buf = new StringBuffer();
+            buf.append("MAP Blackboard-->" + RendererCreatorImpl.PREFERRED_RENDERER_ID + "= " + ApplicationGIS.getActiveMap().getBlackboard().get(RendererCreatorImpl.PREFERRED_RENDERER_ID)).append("\n");
+            buf.append("MAP Blackboard-->" + RendererCreatorImpl.LAST_RESORT_RENDERER_ID + "= " + ApplicationGIS.getActiveMap().getBlackboard().get(RendererCreatorImpl.LAST_RESORT_RENDERER_ID)).append("\n");
+            buf.append("\n");
+            buf.append("Render Info for Layer " + layer).append("\n");
+            buf.append("----------------------------------").append("\n");
+            buf.append("Layer Blackboard-->" + RendererCreatorImpl.PREFERRED_RENDERER_ID + ": " + layer.getStyleBlackboard().get(RendererCreatorImpl.PREFERRED_RENDERER_ID)).append("\n");
+            buf.append("Layer Blackboard-->" + RendererCreatorImpl.LAST_RESORT_RENDERER_ID + ": " + layer.getStyleBlackboard().get(RendererCreatorImpl.LAST_RESORT_RENDERER_ID)).append("\n");
+
+            RenderContext context = layer.getMapInternal().getRenderManagerInternal().getRendererCreator().getRenderContext(layer);
+            buf.append("Selected Renderer of layer: " + layer + " " +
+                    layer.getMapInternal().getRenderManagerInternal().getRendererCreator().getRenderer(context)).append("\n").append("\n");
+            buf.append("APPLICABLE RendererMetrics FOR LAYER :" + layer + ":\n ");
+            Collection<AbstractRenderMetrics>  metrics = getApplicableRendererMetrics(layer);
+            int order = 1;
+            for (AbstractRenderMetrics metric : metrics) {
+                buf.append(order++).append(".  ").append(metric).append(" --> (rate:").append(sorter.rate(metric)).append(")\n");
+            }
+            buf.append("----------------------------------").append("\n");
+            buf.append("\n Remaining RendererMetrics (NOT APPLICABLE for :" + layer + "):\n ");
+            metrics = getNotApplicableRendererMetrics(layer);
+            for (AbstractRenderMetrics metric : metrics) {
+                buf.append("-  ").append(metric).append(" --> (rate:").append(sorter.rate(metric)).append(")\n");
+            }
+            buf.append("----------------------------------").append("\n");
+            return buf.toString();
+        }
+        
+        /**
+         * 
+         * @param layer
+         */
+        private Collection<AbstractRenderMetrics> getApplicableRendererMetrics(Layer layer) {
+            return getRendererMetrics(layer, true);
+        }
+
+        /**
+         * 
+         * @param layer
+         */
+        private Collection<AbstractRenderMetrics> getNotApplicableRendererMetrics(Layer layer) {
+            return getRendererMetrics(layer, false);
+        }
+        
+        /**
+         * 
+         * @param layer
+         */
+        private Collection<AbstractRenderMetrics> getRendererMetrics(Layer layer, boolean applicable) {
+            Collection<AbstractRenderMetrics> result = new ArrayList<AbstractRenderMetrics>();
+            RenderContext context = layer.getMapInternal().getRenderManagerInternal().getRendererCreator().getRenderContext(layer);
+            
+            Collection<AbstractRenderMetrics>  metrics = layer.getMapInternal().getRenderManagerInternal().getRendererCreator().getAvailableRendererMetrics(layer);
+            int order = 1;
+            for (AbstractRenderMetrics metric : metrics) {
+                try {
+                    boolean canRender = metric.getRenderMetricsFactory().canRender(context);
+                    if (canRender == applicable) {
+                        result.add(metric);
+                    }
+                } catch (IOException e) {
+                    e.printStackTrace();
+                }
+            }
+            return result;
+        }
+    }
+}

--- a/plugins/org.locationtech.udig.project.tests/plugin.xml
+++ b/plugins/org.locationtech.udig.project.tests/plugin.xml
@@ -51,6 +51,16 @@
       <renderer
             class="org.locationtech.udig.project.internal.render.impl.renderercreator.BadRenderMetricsFactory"
             />
+      <renderer
+            class="org.locationtech.udig.project.internal.render.impl.renderercreator.HighLatencyFeatureRenderMetricsFactory"
+            id="rendererHighLatency"
+            name="rendererHighLatencyTest">
+      </renderer>
+      <renderer
+            class="org.locationtech.udig.project.internal.render.impl.renderercreator.LowLatencyFeatureRenderMetricsFactory"
+            id="rendererLowLatency"
+            name="rendererLowLatencyTest">
+      </renderer>
    </extension>
       <extension
             point="org.locationtech.udig.project.mapInterceptor">

--- a/plugins/org.locationtech.udig.project.tests/src/org/locationtech/udig/project/internal/render/impl/renderercreator/HighLatencyFeatureRenderMetricsFactory.java
+++ b/plugins/org.locationtech.udig.project.tests/src/org/locationtech/udig/project/internal/render/impl/renderercreator/HighLatencyFeatureRenderMetricsFactory.java
@@ -1,0 +1,107 @@
+/* uDig - User Friendly Desktop Internet GIS client
+ * https://locationtech.org/projects/technology.udig
+ * (C) 2017, Eclipse Foundation
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * (http://www.eclipse.org/legal/epl-v10.html), and the Eclipse Distribution
+ * License v1.0 (http://www.eclipse.org/org/documents/edl-v10.html).
+ */
+package org.locationtech.udig.project.internal.render.impl.renderercreator;
+
+import java.awt.Graphics2D;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.Set;
+
+import org.eclipse.core.runtime.IProgressMonitor;
+import org.geotools.data.FeatureSource;
+import org.geotools.util.Range;
+import org.locationtech.udig.project.ILayer;
+import org.locationtech.udig.project.internal.render.Renderer;
+import org.locationtech.udig.project.internal.render.impl.RendererImpl;
+import org.locationtech.udig.project.render.AbstractRenderMetrics;
+import org.locationtech.udig.project.render.IRenderContext;
+import org.locationtech.udig.project.render.IRenderMetricsFactory;
+import org.locationtech.udig.project.render.IRenderer;
+import org.locationtech.udig.project.render.RenderException;
+
+/**
+ * For testing.  Creates a normal Renderer.  Accepts resources that resolve to FeatureSource objects.
+ * 
+ * 
+ * @author Nikolaos Pringouris <nprigour@gmail.com>
+ */
+public class HighLatencyFeatureRenderMetricsFactory implements IRenderMetricsFactory {
+
+    /**
+     * Define an AbstractRenderMetrics instance with the following values:
+     * <ul>
+     * <li>latency metric -  200</li>
+     * <li>time to draw metric - 200</li>
+     * </ul>
+     * @author Nikolaos Pringouris <nprigour@gmail.com>
+     *
+     */
+    public class HighLatencyFeatureRendererMetrics extends AbstractRenderMetrics {
+
+        /**
+         * 
+         * @param context
+         * @param factory
+         */
+	public HighLatencyFeatureRendererMetrics( IRenderContext context, IRenderMetricsFactory factory ) {
+            super(context, factory, new ArrayList<String>());
+            latencyMetric =200;
+            timeToDrawMetric = 200;
+        }
+       
+        public boolean canAddLayer( ILayer layer ) {
+            return layer.hasResource(FeatureSource.class);
+        }
+
+        public boolean canStyle( String styleID, Object value ) {
+            return false;
+        }
+
+        public Renderer createRenderer() {
+            return new HighLatencyRenderer();
+        }
+
+        @SuppressWarnings("unchecked")
+        public Set<Range<Double>> getValidScaleRanges() {
+            return new HashSet<Range<Double>>();
+        }
+        
+    }
+
+    /**
+     * Renderer used by {@link HighLatencyFeatureRenderMetricsFactory} 
+     *
+     */
+    public class HighLatencyRenderer extends RendererImpl {
+
+        @Override
+        public void render( Graphics2D destination, IProgressMonitor monitor ) throws RenderException {
+        }
+
+        @Override
+        public void render( IProgressMonitor monitor ) throws RenderException {
+        }
+
+    }
+    
+    public boolean canRender( IRenderContext context ) throws IOException {
+        return context.getGeoResource().canResolve(FeatureSource.class);
+    }
+
+    public AbstractRenderMetrics createMetrics( IRenderContext context ) {
+        return new HighLatencyFeatureRendererMetrics(context, this);
+    }
+
+    public Class< ? extends IRenderer> getRendererType() {
+        return HighLatencyRenderer.class;
+    }
+
+}

--- a/plugins/org.locationtech.udig.project.tests/src/org/locationtech/udig/project/internal/render/impl/renderercreator/LowLatencyFeatureRenderMetricsFactory.java
+++ b/plugins/org.locationtech.udig.project.tests/src/org/locationtech/udig/project/internal/render/impl/renderercreator/LowLatencyFeatureRenderMetricsFactory.java
@@ -1,0 +1,104 @@
+/* uDig - User Friendly Desktop Internet GIS client
+ * https://locationtech.org/projects/technology.udig
+ * (C) 2017, Eclipse Foundation
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * (http://www.eclipse.org/legal/epl-v10.html), and the Eclipse Distribution
+ * License v1.0 (http://www.eclipse.org/org/documents/edl-v10.html).
+ */
+package org.locationtech.udig.project.internal.render.impl.renderercreator;
+
+import java.awt.Graphics2D;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.Set;
+
+import org.eclipse.core.runtime.IProgressMonitor;
+import org.geotools.data.FeatureSource;
+import org.geotools.util.Range;
+import org.locationtech.udig.project.ILayer;
+import org.locationtech.udig.project.internal.render.Renderer;
+import org.locationtech.udig.project.internal.render.impl.RendererImpl;
+import org.locationtech.udig.project.render.AbstractRenderMetrics;
+import org.locationtech.udig.project.render.IRenderContext;
+import org.locationtech.udig.project.render.IRenderMetricsFactory;
+import org.locationtech.udig.project.render.IRenderer;
+import org.locationtech.udig.project.render.RenderException;
+
+/**
+ * For testing.  Creates a normal Renderer.  Accepts resources that resolve to FeatureSource objects.
+ * 
+ * The factory creates a Renderer with zero latency  and time to draw metrics
+ * 
+ * @author Nikolaos Pringouris <nprigour@gmail.com>
+ */
+public class LowLatencyFeatureRenderMetricsFactory implements IRenderMetricsFactory {
+
+
+    /**
+     * Define an AbstractRenderMetrics instance with the following values:
+     * <ul>
+     * <li>latency metric -  0</li>
+     * <li>time to draw metric - 0</li>
+     * </ul>
+     * @author Nikolaos Pringouris <nprigour@gmail.com>
+     *
+     */
+    public class LowLatencyFeatureRendererMetrics extends AbstractRenderMetrics {
+
+        public LowLatencyFeatureRendererMetrics( IRenderContext context, IRenderMetricsFactory factory ) {
+            super(context, factory, new ArrayList<String>());
+            latencyMetric = 0;
+            timeToDrawMetric = 0;
+        }
+      
+        public boolean canAddLayer( ILayer layer ) {
+            return layer.hasResource(FeatureSource.class);
+        }
+
+        public boolean canStyle( String styleID, Object value ) {
+            return value instanceof SingleRendererStyleContent;
+        }
+
+        public Renderer createRenderer() {
+            return new LowLatencyRenderer();
+        }
+        
+
+        @SuppressWarnings("unchecked")
+        public Set<Range<Double>> getValidScaleRanges() {
+            return new HashSet<Range<Double>>();
+        }
+    }
+
+    /**
+     * Renderer used by {@link LowLatencyFeatureRenderMetricsFactory} 
+     *
+     */
+    public class LowLatencyRenderer extends RendererImpl {
+
+        @Override
+        public void render( Graphics2D destination, IProgressMonitor monitor ) throws RenderException {
+        }
+
+        @Override
+        public void render( IProgressMonitor monitor ) throws RenderException {
+        }
+
+    }
+    
+    public boolean canRender( IRenderContext context ) throws IOException {
+        return context.getGeoResource().canResolve(FeatureSource.class);
+    }
+
+    public AbstractRenderMetrics createMetrics( IRenderContext context ) {
+        return new LowLatencyFeatureRendererMetrics(context, this);
+    }
+
+    public Class< ? extends IRenderer> getRendererType() {
+        return LowLatencyRenderer.class;
+    }
+
+}

--- a/plugins/org.locationtech.udig.project.tests/src/org/locationtech/udig/project/internal/render/impl/renderercreator/SingleRenderer.java
+++ b/plugins/org.locationtech.udig.project.tests/src/org/locationtech/udig/project/internal/render/impl/renderercreator/SingleRenderer.java
@@ -17,7 +17,7 @@ import org.locationtech.udig.project.render.RenderException;
 import org.eclipse.core.runtime.IProgressMonitor;
 
 /**
- * Simulats a renderer that renders a single class.
+ * Simulates a renderer that renders a single class.
  * 
  * @author Jesse
  * @since 1.1.0

--- a/plugins/org.locationtech.udig.project.tests/src/org/locationtech/udig/project/internal/render/impl/renderercreator/SingleRenderer2.java
+++ b/plugins/org.locationtech.udig.project.tests/src/org/locationtech/udig/project/internal/render/impl/renderercreator/SingleRenderer2.java
@@ -17,7 +17,7 @@ import org.locationtech.udig.project.render.RenderException;
 import org.eclipse.core.runtime.IProgressMonitor;
 
 /**
- * Simulats a renderer that renders a single class.
+ * Simulates a renderer that renders a single class.
  * 
  * @author Jesse
  * @since 1.1.0

--- a/plugins/org.locationtech.udig.project/src/org/locationtech/udig/project/internal/render/RendererCreator.java
+++ b/plugins/org.locationtech.udig.project/src/org/locationtech/udig/project/internal/render/RendererCreator.java
@@ -130,4 +130,11 @@ public interface RendererCreator{
      * @return the set of {@link IRenderMetrics} that can render the provided layer.
      */
     public Collection<AbstractRenderMetrics> getAvailableRendererMetrics(Layer layer);
+    
+    /**
+     * Returns the ids of all the renderers that are capable of rendering the provided layer.
+     *
+     * @return the the ids of all the renderers that are capable of rendering the provided layer.
+     */
+    public Collection<String> getAvailableRendererIds(Layer layer);
 }

--- a/plugins/org.locationtech.udig.project/src/org/locationtech/udig/project/internal/render/impl/AbstractRenderMetricsSorter.java
+++ b/plugins/org.locationtech.udig.project/src/org/locationtech/udig/project/internal/render/impl/AbstractRenderMetricsSorter.java
@@ -100,11 +100,19 @@ public class AbstractRenderMetricsSorter implements Comparator<AbstractRenderMet
         int first = -1;
         int last = 1;
 
-        // check the layer blackboard for a preferred or non-preferred renderer
+        // check the layer blackboards for a preferred or non-preferred renderer
         int perferredMapRenderer = rateUsingBlackboardSettings(o1, o1.getRenderContext().getLayer()
-                .getStyleBlackboard());
+                .getBlackboard());
+        if (perferredMapRenderer == 0) {
+        	perferredMapRenderer = rateUsingBlackboardSettings(o1, o1.getRenderContext().getLayer()
+                    .getStyleBlackboard());
+        }
         int perferredMapRenderer2 = rateUsingBlackboardSettings(o2, o2.getRenderContext().getLayer()
-                .getStyleBlackboard());        
+                .getBlackboard());
+        if (perferredMapRenderer2 == 0) {
+        	perferredMapRenderer2 = rateUsingBlackboardSettings(o2, o2.getRenderContext().getLayer()
+                    .getStyleBlackboard());
+        }
         if (perferredMapRenderer > perferredMapRenderer2) {
             return first;
         }

--- a/plugins/org.locationtech.udig.project/src/org/locationtech/udig/project/internal/render/impl/AbstractRenderMetricsSorter.java
+++ b/plugins/org.locationtech.udig.project/src/org/locationtech/udig/project/internal/render/impl/AbstractRenderMetricsSorter.java
@@ -100,16 +100,32 @@ public class AbstractRenderMetricsSorter implements Comparator<AbstractRenderMet
         int first = -1;
         int last = 1;
 
-        // check the layer/map blackboard for a preferred or non-preferred renderer
-        int perferredMapRenderer = rateUsingBlackboardSettings(o1, o1.getRenderContext().getMap()
+        // check the layer blackboard for a preferred or non-preferred renderer
+        int perferredMapRenderer = rateUsingBlackboardSettings(o1, o1.getRenderContext().getLayer()
                 .getBlackboard());
-        if (perferredMapRenderer > 0) {
+        int perferredMapRenderer2 = rateUsingBlackboardSettings(o2, o2.getRenderContext().getLayer()
+                .getBlackboard());        
+        if (perferredMapRenderer > perferredMapRenderer2) {
             return first;
         }
-        if (perferredMapRenderer < 0) {
+        if (perferredMapRenderer < perferredMapRenderer2) {
+            return last;
+        }
+        
+        // check the map blackboard for a preferred or non-preferred renderer
+        perferredMapRenderer = rateUsingBlackboardSettings(o1, o1.getRenderContext().getMap()
+                .getBlackboard());
+        perferredMapRenderer2 = rateUsingBlackboardSettings(o2, o2.getRenderContext().getMap()
+                .getBlackboard());  
+        if (perferredMapRenderer > perferredMapRenderer2) {
+            return first;
+        }
+        if (perferredMapRenderer < perferredMapRenderer2) {
             return last;
         }
 
+        //if no BlackboardSettings exist to influence the renderer choice then
+        //compute a rate for each metric and compare
         double r1 = rate(o1);
         double r2 = rate(o2);
 

--- a/plugins/org.locationtech.udig.project/src/org/locationtech/udig/project/internal/render/impl/AbstractRenderMetricsSorter.java
+++ b/plugins/org.locationtech.udig.project/src/org/locationtech/udig/project/internal/render/impl/AbstractRenderMetricsSorter.java
@@ -102,9 +102,9 @@ public class AbstractRenderMetricsSorter implements Comparator<AbstractRenderMet
 
         // check the layer blackboard for a preferred or non-preferred renderer
         int perferredMapRenderer = rateUsingBlackboardSettings(o1, o1.getRenderContext().getLayer()
-                .getBlackboard());
+                .getStyleBlackboard());
         int perferredMapRenderer2 = rateUsingBlackboardSettings(o2, o2.getRenderContext().getLayer()
-                .getBlackboard());        
+                .getStyleBlackboard());        
         if (perferredMapRenderer > perferredMapRenderer2) {
             return first;
         }

--- a/plugins/org.locationtech.udig.project/src/org/locationtech/udig/project/internal/render/impl/RenderMetricsSorter.java
+++ b/plugins/org.locationtech.udig.project/src/org/locationtech/udig/project/internal/render/impl/RenderMetricsSorter.java
@@ -97,36 +97,35 @@ public class RenderMetricsSorter implements Comparator<InternalRenderMetrics>, S
         int first = -1;
         int last = 1;
         
-        // check the layer blackboard for a preferred or non-preferred renderer
         // check the layer blackboards for a preferred or non-preferred renderer
-        int perferredMapRenderer = rateUsingBlackboardSettings(o1, o1.getRenderContext().getLayer()
+        int preferredLayerRenderer = rateUsingBlackboardSettings(o1, o1.getRenderContext().getLayer()
                 .getBlackboard());
-        if (perferredMapRenderer == 0) {
-        	perferredMapRenderer = rateUsingBlackboardSettings(o1, o1.getRenderContext().getLayer()
+        if (preferredLayerRenderer == 0) {
+            preferredLayerRenderer = rateUsingBlackboardSettings(o1, o1.getRenderContext().getLayer()
                     .getStyleBlackboard());
         }
-        int perferredMapRenderer2 = rateUsingBlackboardSettings(o2, o2.getRenderContext().getLayer()
+        int preferredLayerRenderer2 = rateUsingBlackboardSettings(o2, o2.getRenderContext().getLayer()
                 .getBlackboard());
-        if (perferredMapRenderer2 == 0) {
-        	perferredMapRenderer2 = rateUsingBlackboardSettings(o2, o2.getRenderContext().getLayer()
+        if (preferredLayerRenderer2 == 0) {
+            preferredLayerRenderer2 = rateUsingBlackboardSettings(o2, o2.getRenderContext().getLayer()
                     .getStyleBlackboard());
         }       
-        if (perferredMapRenderer > perferredMapRenderer2) {
+        if (preferredLayerRenderer > preferredLayerRenderer2) {
             return first;
         }
-        if (perferredMapRenderer < perferredMapRenderer2) {
+        if (preferredLayerRenderer < preferredLayerRenderer2) {
             return last;
         }
         
         // check the map blackboard for a preferred or non-preferred renderer
-        perferredMapRenderer = rateUsingBlackboardSettings(o1, o1.getRenderContext().getMap()
+        int preferredMapRenderer = rateUsingBlackboardSettings(o1, o1.getRenderContext().getMap()
                 .getBlackboard());
-        perferredMapRenderer2 = rateUsingBlackboardSettings(o2, o2.getRenderContext().getMap()
+        int preferredMapRenderer2 = rateUsingBlackboardSettings(o2, o2.getRenderContext().getMap()
                 .getBlackboard());  
-        if (perferredMapRenderer > perferredMapRenderer2) {
+        if (preferredMapRenderer > preferredMapRenderer2) {
             return first;
         }
-        if (perferredMapRenderer < perferredMapRenderer2) {
+        if (preferredMapRenderer < preferredMapRenderer2) {
             return last;
         }
         

--- a/plugins/org.locationtech.udig.project/src/org/locationtech/udig/project/internal/render/impl/RenderMetricsSorter.java
+++ b/plugins/org.locationtech.udig.project/src/org/locationtech/udig/project/internal/render/impl/RenderMetricsSorter.java
@@ -97,12 +97,27 @@ public class RenderMetricsSorter implements Comparator<InternalRenderMetrics>, S
         int first = -1;
         int last = 1;
         
-        // check the layer/map blackboard for a preferred or non-preferred renderer 
-        int perferredMapRenderer = rateUsingBlackboardSettings(o1, o1.getRenderContext().getMap().getBlackboard());
-        if (perferredMapRenderer > 0){
+        // check the layer blackboard for a preferred or non-preferred renderer
+        int perferredMapRenderer = rateUsingBlackboardSettings(o1, o1.getRenderContext().getLayer()
+                .getBlackboard());
+        int perferredMapRenderer2 = rateUsingBlackboardSettings(o2, o2.getRenderContext().getLayer()
+                .getBlackboard());        
+        if (perferredMapRenderer > perferredMapRenderer2) {
             return first;
         }
-        if (perferredMapRenderer < 0){
+        if (perferredMapRenderer < perferredMapRenderer2) {
+            return last;
+        }
+        
+        // check the map blackboard for a preferred or non-preferred renderer
+        perferredMapRenderer = rateUsingBlackboardSettings(o1, o1.getRenderContext().getMap()
+                .getBlackboard());
+        perferredMapRenderer2 = rateUsingBlackboardSettings(o2, o2.getRenderContext().getMap()
+                .getBlackboard());  
+        if (perferredMapRenderer > perferredMapRenderer2) {
+            return first;
+        }
+        if (perferredMapRenderer < perferredMapRenderer2) {
             return last;
         }
         

--- a/plugins/org.locationtech.udig.project/src/org/locationtech/udig/project/internal/render/impl/RenderMetricsSorter.java
+++ b/plugins/org.locationtech.udig.project/src/org/locationtech/udig/project/internal/render/impl/RenderMetricsSorter.java
@@ -99,9 +99,9 @@ public class RenderMetricsSorter implements Comparator<InternalRenderMetrics>, S
         
         // check the layer blackboard for a preferred or non-preferred renderer
         int perferredMapRenderer = rateUsingBlackboardSettings(o1, o1.getRenderContext().getLayer()
-                .getBlackboard());
+                .getStyleBlackboard());
         int perferredMapRenderer2 = rateUsingBlackboardSettings(o2, o2.getRenderContext().getLayer()
-                .getBlackboard());        
+                .getStyleBlackboard());        
         if (perferredMapRenderer > perferredMapRenderer2) {
             return first;
         }

--- a/plugins/org.locationtech.udig.project/src/org/locationtech/udig/project/internal/render/impl/RenderMetricsSorter.java
+++ b/plugins/org.locationtech.udig.project/src/org/locationtech/udig/project/internal/render/impl/RenderMetricsSorter.java
@@ -98,10 +98,19 @@ public class RenderMetricsSorter implements Comparator<InternalRenderMetrics>, S
         int last = 1;
         
         // check the layer blackboard for a preferred or non-preferred renderer
+        // check the layer blackboards for a preferred or non-preferred renderer
         int perferredMapRenderer = rateUsingBlackboardSettings(o1, o1.getRenderContext().getLayer()
-                .getStyleBlackboard());
+                .getBlackboard());
+        if (perferredMapRenderer == 0) {
+        	perferredMapRenderer = rateUsingBlackboardSettings(o1, o1.getRenderContext().getLayer()
+                    .getStyleBlackboard());
+        }
         int perferredMapRenderer2 = rateUsingBlackboardSettings(o2, o2.getRenderContext().getLayer()
-                .getStyleBlackboard());        
+                .getBlackboard());
+        if (perferredMapRenderer2 == 0) {
+        	perferredMapRenderer2 = rateUsingBlackboardSettings(o2, o2.getRenderContext().getLayer()
+                    .getStyleBlackboard());
+        }       
         if (perferredMapRenderer > perferredMapRenderer2) {
             return first;
         }

--- a/plugins/org.locationtech.udig.project/src/org/locationtech/udig/project/internal/render/impl/RendererCreatorImpl.java
+++ b/plugins/org.locationtech.udig.project/src/org/locationtech/udig/project/internal/render/impl/RendererCreatorImpl.java
@@ -116,6 +116,25 @@ public class RendererCreatorImpl implements RendererCreator {
         return renderers;
     }
 
+    /**
+     * returns a list of available metrics Ids by Layer.
+     *  
+     * @param layer
+     * @return
+     */
+    public Collection<String> getAvailableRendererIds(Layer layer) {
+        List<String> idsList = new ArrayList<String>();
+        
+        List<InternalRenderMetrics> availableRenderers = layerToMetricsFactoryMap.get(layer);
+        
+        for( InternalRenderMetrics irm : availableRenderers ) {
+        	idsList.add(irm.getId());
+        }
+        
+        return idsList;
+    }
+
+    
     public Collection<AbstractRenderMetrics> getAvailableRendererMetrics(Layer layer) {
         List<AbstractRenderMetrics> metrics = new ArrayList<AbstractRenderMetrics>();
         
@@ -132,6 +151,8 @@ public class RendererCreatorImpl implements RendererCreator {
             IRenderContext renderContext = internalRenderMetrics.getRenderContext();
             IRenderMetricsFactory renderMetricsFactory = internalRenderMetrics.getRenderMetricsFactory();
             AbstractRenderMetrics createMetrics = renderMetricsFactory.createMetrics(renderContext);
+            //set the id since initially it is set only in InternalRenderMetrics 
+            createMetrics.setId(internalRenderMetrics.getId());
             metrics.add(createMetrics);
         }
         return metrics;

--- a/plugins/org.locationtech.udig.project/src/org/locationtech/udig/project/internal/render/impl/TiledRendererCreatorImpl.java
+++ b/plugins/org.locationtech.udig.project/src/org/locationtech/udig/project/internal/render/impl/TiledRendererCreatorImpl.java
@@ -322,6 +322,18 @@ public class TiledRendererCreatorImpl implements RendererCreator {
     }
 
     /**
+     * @throws UnsupportedOperationException
+     */
+    public Collection<String> getAvailableRendererIds(Layer layer) {
+    	List<String> result = new ArrayList<String>(); 
+    	Collection<AbstractRenderMetrics> metrics = getAvailableRendererMetrics(layer);
+    	for (AbstractRenderMetrics metric : metrics) {
+    		result.add(metric.getId());
+    	}
+    	return result;
+    }
+    
+    /**
      * 
      * @throws UnsupportedOperationException
      */

--- a/plugins/org.locationtech.udig.project/src/org/locationtech/udig/project/internal/render/impl/TiledRendererCreatorImpl.java
+++ b/plugins/org.locationtech.udig.project/src/org/locationtech/udig/project/internal/render/impl/TiledRendererCreatorImpl.java
@@ -321,8 +321,9 @@ public class TiledRendererCreatorImpl implements RendererCreator {
         throw new UnsupportedOperationException("Renderers don't have information in this system."); //$NON-NLS-1$
     }
 
+
     /**
-     * @throws UnsupportedOperationException
+     * 
      */
     public Collection<String> getAvailableRendererIds(Layer layer) {
     	List<String> result = new ArrayList<String>(); 


### PR DESCRIPTION
fix render metric sorter comparison implementation (`compareMetrics( AbstractRenderMetrics o1, AbstractRenderMetrics o2 )`) to:

- consider both arguments during checking for a preferred renderer
- check both layer and map blackboard settings

 
Signed-off-by: Nikolaos Pringouris <nprigour@gmail.com>