### PR TITLE
fix for locationtech bug 140

### DIFF
--- a/plugins/org.locationtech.udig.project/src/org/locationtech/udig/project/internal/impl/UDIGFeatureStore.java
+++ b/plugins/org.locationtech.udig.project/src/org/locationtech/udig/project/internal/impl/UDIGFeatureStore.java
@@ -154,7 +154,8 @@ public class UDIGFeatureStore implements FeatureStore<FeatureType,Feature>, UDIG
         EditManager editManager = (EditManager) layer.getMap().getEditManager();
         Transaction transaction = editManager.getTransaction();
         
-        if (wrapped.getTransaction() == Transaction.AUTO_COMMIT) {
+        if (wrapped.getTransaction() == null 
+        		|| wrapped.getTransaction() == Transaction.AUTO_COMMIT) {
             // change over from autocommit to transactional
             wrapped.setTransaction(transaction);
         }

--- a/plugins/org.locationtech.udig.project/src/org/locationtech/udig/project/internal/impl/UDIGSimpleFeatureStore.java
+++ b/plugins/org.locationtech.udig.project/src/org/locationtech/udig/project/internal/impl/UDIGSimpleFeatureStore.java
@@ -201,7 +201,8 @@ public class UDIGSimpleFeatureStore implements SimpleFeatureStore, UDIGStore {
         EditManager editManager = (EditManager) layer.getMap().getEditManager();
         Transaction transaction = editManager.getTransaction();
         
-        if (wrapped.getTransaction() == Transaction.AUTO_COMMIT) {
+        if (wrapped.getTransaction() == null 
+        		|| wrapped.getTransaction() == Transaction.AUTO_COMMIT) {
             // change over from autocommit to transactional
             wrapped.setTransaction(transaction);
         }


### PR DESCRIPTION
A fix for bug 140 (see https://bugs.locationtech.org/show_bug.cgi?id=140). It seems that for ShapefileDataStore the transaction mode is not set to AutoCommit by default. 

Signed-off-by: Nikolaos Pringouris <nprigour@gmail.com>