### PR TITLE
minor fix for duplicate legend entries for color ramp rasters

### DIFF
--- a/plugins/org.locationtech.udig.legend/src/org/locationtech/udig/legend/ui/ColorMapLegendCreator.java
+++ b/plugins/org.locationtech.udig.legend/src/org/locationtech/udig/legend/ui/ColorMapLegendCreator.java
@@ -205,7 +205,7 @@ public class ColorMapLegendCreator {
 
 			String l1 = entry.getLabel();
 			String l2 = prevEntry.getLabel();
-			if (i <= entries.length - 3){
+			if (i < entries.length - 1){
 				if (l2 == null){
 					text = new String[]{q2};
 				}else{


### PR DESCRIPTION
Fix for legend issue shown in attached image.
![legendfix](https://cloud.githubusercontent.com/assets/638844/26165721/d40b883e-3ae5-11e7-929d-ae14466264b6.png)


Signed-off-by: egouge <egouge@refractions.net>