### PR TITLE
improve check for jdbc catalog IDs

### DIFF
--- a/plugins/org.locationtech.udig.catalog/src/org/locationtech/udig/catalog/ID.java
+++ b/plugins/org.locationtech.udig.catalog/src/org/locationtech/udig/catalog/ID.java
@@ -468,7 +468,7 @@ public class ID implements Serializable {
      * @return true if ID refers to a database (ie is a jdbc url)
      */
     public boolean isJDBC() {
-        return id.startsWith("jdbc"); //$NON-NLS-1$
+        return id.startsWith("jdbc") || (url != null && url.getProtocol().contains("jdbc")) ; //$NON-NLS-1$ //$NON-NLS-2$
         // if( url != null){
         // String PROTOCOL = url.getProtocol();
         // String HOST = url.getHost();


### PR DESCRIPTION
Minor improvement so that ID.isJDBC() method also checks the URL protocol field to determine if ID refers to a database 

Signed-off-by: Nikolaos Pringouris <nprigour@gmail.com>