### PR TITLE
avoid to package os-specific Metadata

### DIFF
--- a/deploy/support_functions.sh
+++ b/deploy/support_functions.sh
@@ -34,7 +34,7 @@ function assemble() {
 
             echo "Assemble ${BUILD}/udig-${VERSION}.${EXT}.zip"
             cd ${BUILD}/${PLATFORM}
-            zip -9 -r -q ../udig-${VERSION}.${EXT}.zip udig
+            zip -9 -X -r -q ../udig-${VERSION}.${EXT}.zip udig
         else 
            echo "Already Exists ${BUILD}/udig-${VERSION}.${EXT}.zip"
         fi


### PR DESCRIPTION
such as __MACOSX or .DS_Store on MacOSX or other os-specific structures on Linux-OS

For Details of zip command options see `-X`or `--no-extra` at https://linux.die.net/man/1/zip

Signed-off-by: Frank Gasdorf <fgdrf@users.sourceforge.net>