### PR TITLE
fixes enablement of layer move up/down actions

### DIFF
--- a/plugins/org.locationtech.udig.project/src/org/locationtech/udig/project/command/map/LayerMoveDownCommand.java
+++ b/plugins/org.locationtech.udig.project/src/org/locationtech/udig/project/command/map/LayerMoveDownCommand.java
@@ -67,10 +67,17 @@ public class LayerMoveDownCommand extends AbstractCommand implements UndoableMap
     public void run( IProgressMonitor monitor ) throws Exception {
         // need to reverse otherwise nothing happens on multiselect
         Collections.reverse(selection);
+        int lastAllowedIndex = 0; 
         for( ILayer layer : selection ) {
+            int layerIndex = layer.getZorder();
+            if (layerIndex == lastAllowedIndex) {
+                lastAllowedIndex++;
+                continue;
+            }
             getMap().lowerLayer((Layer) layer);
         }
     }
+    
     public void rollback( IProgressMonitor monitor ) throws Exception {
         for( ILayer layer : selection ) {
             getMap().raiseLayer((Layer) layer);

--- a/plugins/org.locationtech.udig.project/src/org/locationtech/udig/project/command/map/LayerMoveUpCommand.java
+++ b/plugins/org.locationtech.udig.project/src/org/locationtech/udig/project/command/map/LayerMoveUpCommand.java
@@ -65,10 +65,17 @@ public class LayerMoveUpCommand extends AbstractCommand implements UndoableMapCo
     }
 
     public void run( IProgressMonitor monitor ) throws Exception {
+        int maxAllowedIndex = getMap().getLayersInternal().size()-1;
         for( ILayer layer : selection ) {
+            int layerIndex = layer.getZorder();
+            if (layerIndex == maxAllowedIndex) {
+                maxAllowedIndex--;
+                continue;
+            }
             getMap().raiseLayer((Layer) layer);
         }
     }
+    
     public void rollback( IProgressMonitor monitor ) throws Exception {
         // need to reverse otherwise nothing happens on multiselect
         Collections.reverse(selection);


### PR DESCRIPTION
see issue #247

Now the selection is used to enable/disable Move Up/Down Action.

![grafik](https://user-images.githubusercontent.com/644229/28313512-6e2386c2-6bb7-11e7-8657-abb7ec7bc47d.png)

![grafik](https://user-images.githubusercontent.com/644229/28313529-79942110-6bb7-11e7-8563-b2859e4b1cc6.png)

If there are Layers in between, that are not selected, it's possible to move up/down

![grafik](https://user-images.githubusercontent.com/644229/28313585-b2f43c42-6bb7-11e7-87b3-fdb4b69e5dc7.png)

As a result of **Move Up** the selection it would look like this:

![grafik](https://user-images.githubusercontent.com/644229/28313621-da45397c-6bb7-11e7-93b9-283e3b7fe29d.png)


Signed-off-by: Frank Gasdorf <fgdrf@users.sourceforge.net>