### PR TITLE
fix issue with empty geom while addingEdges is called

### DIFF
--- a/plugins/org.locationtech.udig.tools/META-INF/MANIFEST.MF
+++ b/plugins/org.locationtech.udig.tools/META-INF/MANIFEST.MF
@@ -6,16 +6,17 @@ Bundle-Version: 2.0.0.qualifier
 Bundle-Activator: org.locationtech.udig.tools.Activator
 Bundle-Vendor: uDig Community
 Bundle-Localization: plugin
-Export-Package: org.locationtech.udig.tools.arc,org.locationtech.udig.
- tools.arc.internal;x-friends:="org.locationtech.udig.tools.tests",org
- .locationtech.udig.tools.geometry.merge;x-friends:="org.locationtech.
- udig.tools.tests",org.locationtech.udig.tools.geometry.split;x-friend
- s:="org.locationtech.udig.tools.tests",org.locationtech.udig.tools.ge
- ometry.trim;x-friends:="org.locationtech.udig.tools.tests",org.locati
- ontech.udig.tools.merge,org.locationtech.udig.tools.parallel,org.loca
- tiontech.udig.tools.parallel.internal;x-friends:="org.locationtech.ud
- ig.tools.tests",org.locationtech.udig.tools.split,org.locationtech.ud
- ig.tools.trim
+Export-Package: org.locationtech.udig.tools.arc,
+ org.locationtech.udig.tools.arc.internal;x-friends:="org.locationtech.udig.tools.tests",
+ org.locationtech.udig.tools.feature.util,
+ org.locationtech.udig.tools.geometry.merge;x-friends:="org.locationtech.udig.tools.tests",
+ org.locationtech.udig.tools.geometry.split;x-friends:="org.locationtech.udig.tools.tests",
+ org.locationtech.udig.tools.geometry.trim;x-friends:="org.locationtech.udig.tools.tests",
+ org.locationtech.udig.tools.merge,
+ org.locationtech.udig.tools.parallel,
+ org.locationtech.udig.tools.parallel.internal;x-friends:="org.locationtech.udig.tools.tests",
+ org.locationtech.udig.tools.split,
+ org.locationtech.udig.tools.trim
 Require-Bundle: org.eclipse.ui,
  org.eclipse.core.runtime,
  org.locationtech.udig.ui,

--- a/plugins/org.locationtech.udig.tools/src/org/locationtech/udig/tools/geometry/split/Graph.java
+++ b/plugins/org.locationtech.udig.tools/src/org/locationtech/udig/tools/geometry/split/Graph.java
@@ -60,8 +60,9 @@ final class Graph extends PlanarGraph{
     public void addEdges(final List<Geometry> nodedHolesList,final  int boundary, final int interior, final int exterior) {
 
         for (Geometry geom : nodedHolesList) {
-
-            addEdges(geom, boundary, interior, exterior);
+            if (!geom.isEmpty()){
+                addEdges(geom, boundary, interior, exterior);
+            }
         }
     }
     

--- a/plugins/org.locationtech.udig.tools/src/org/locationtech/udig/tools/split/SplitGeometryBehaviour.java
+++ b/plugins/org.locationtech.udig.tools/src/org/locationtech/udig/tools/split/SplitGeometryBehaviour.java
@@ -90,7 +90,7 @@ class SplitGeometryBehaviour implements Behaviour {
     public void handleError( EditToolHandler handler, Throwable error, UndoableMapCommand command ) {
         assert error != null;
 
-        String message = error.getMessage();
+        String message = getRootCause(error);
         DialogUtil.openError(Messages.SplitGeometryBehaviour_transaction_failed, message);
         
         //re-initializes the handler
@@ -99,4 +99,21 @@ class SplitGeometryBehaviour implements Behaviour {
         handler.getEditBlackboard( handler.getEditLayer() ).clear();
     }
 
+    /**
+     * 
+     * @param e
+     * @return
+     */
+    public String getRootCause(Throwable e) {
+        StringBuffer buf = new StringBuffer();
+        if (e.getMessage() != null) {
+            buf.append(e.getMessage()).append("\nRoot cause:"); //$NON-NLS-1$
+        }
+        while (e.getCause() != null) {
+            buf.append(e.getCause().getMessage()).append(" "); //$NON-NLS-1$
+            e = e.getCause();
+        }
+
+        return buf.toString();
+    }
 }


### PR DESCRIPTION
fixes an issue with empty geom that may lead to an exception. 
Also improves error logging during Geometry split process by retrieving the possible root cause of the exception.

Signed-off-by: Nikolaos Pringouris <nprigour@gmail.com>