### PR TITLE
fix NPE during initial loading of ProjectExplorer

### DIFF
--- a/plugins/org.locationtech.udig.project.ui/src/org/locationtech/udig/project/ui/internal/ProjectExplorer.java
+++ b/plugins/org.locationtech.udig.project.ui/src/org/locationtech/udig/project/ui/internal/ProjectExplorer.java
@@ -853,7 +853,9 @@ public class ProjectExplorer extends ViewPart
             }
             for( IProjectElement element2 : element ) {
                 IProject project = element2.getProject();
-                treeViewer.setExpandedState(project, true);
+                if (project != null) {
+                    treeViewer.setExpandedState(project, true);
+                }
             }
         }
     }


### PR DESCRIPTION
During initial loading of ProjectExplorer view a NPE may occur if retrieved IProject element resolves to null

Signed-off-by: Nikolaos Pringouris <nprigour@gmail.com>