### PR TITLE
WellKnownMarkName text field length increase

### DIFF
--- a/plugins/org.locationtech.udig.style.sld/src/org/locationtech/udig/style/sld/simple/GraphicViewer.java
+++ b/plugins/org.locationtech.udig.style.sld/src/org/locationtech/udig/style/sld/simple/GraphicViewer.java
@@ -154,7 +154,7 @@ public class GraphicViewer {
         
         this.name = new Combo( part, SWT.DROP_DOWN );
         this.name.setItems(build.getWellKnownMarkNames());
-        this.name.setTextLimit( 9 );
+        this.name.setTextLimit( 32 );
         this.name.addKeyListener(klisten);
         this.name.setToolTipText(Messages.GraphicViewer_name_tooltip); 
         return part;            


### PR DESCRIPTION
increase the text field length use to specify a WellKnownMarkName (used in Style Layer Descriptor "graphic") from 9-->32 chars.  

Signed-off-by: Nikolaos Pringouris <nprigour@gmail.com>