### PR TITLE
fix warnings related to property'propertyId' references

### DIFF
--- a/plugins/org.locationtech.udig.tool.select/plugin.xml
+++ b/plugins/org.locationtech.udig.tool.select/plugin.xml
@@ -47,12 +47,12 @@
                   	<and>
                         <property propertyId="FeatureSourceResourceProperty" expectedValue=""/>                  	
 	                     <or>
-	                        <property propertyId="org.locationtech.udig.project.ui.GeometryType" expectedValue="com.vividsolutions.jts.geom.MultiLineString"/>
-	                        <property propertyId="org.locationtech.udig.project.ui.GeometryType" expectedValue="com.vividsolutions.jts.geom.LineString"/>
-	                        <property propertyId="org.locationtech.udig.project.ui.GeometryType" expectedValue="com.vividsolutions.jts.geom.MultiPolygon"/>
-	                        <property propertyId="org.locationtech.udig.project.ui.GeometryType" expectedValue="com.vividsolutions.jts.geom.Polygon"/>
-	                        <property propertyId="org.locationtech.udig.project.ui.GeometryType" expectedValue="com.vividsolutions.jts.geom.MultiPoint"/>
-	                        <property propertyId="org.locationtech.udig.project.ui.GeometryType" expectedValue="com.vividsolutions.jts.geom.Point"/>
+	                        <property propertyId="GeometryType" expectedValue="com.vividsolutions.jts.geom.MultiLineString"/>
+	                        <property propertyId="GeometryType" expectedValue="com.vividsolutions.jts.geom.LineString"/>
+	                        <property propertyId="GeometryType" expectedValue="com.vividsolutions.jts.geom.MultiPolygon"/>
+	                        <property propertyId="GeometryType" expectedValue="com.vividsolutions.jts.geom.Polygon"/>
+	                        <property propertyId="GeometryType" expectedValue="com.vividsolutions.jts.geom.MultiPoint"/>
+	                        <property propertyId="GeometryType" expectedValue="com.vividsolutions.jts.geom.Point"/>
 	                     </or>
                       <property
                             expectedValue="SELECT"
@@ -89,7 +89,7 @@
                   <enablement>
                      <property
                            expectedValue="unimportant"
-                           propertyId="org.locationtech.udig.tool.select.layerHasSelectionProperty"/>
+                           propertyId="layerHasSelectionProperty"/>
                   </enablement>
                </actionTool>
                <toolCursor

--- a/plugins/org.locationtech.udig.tools.jgrass/plugin.xml
+++ b/plugins/org.locationtech.udig.tools.jgrass/plugin.xml
@@ -86,8 +86,8 @@
              <and>
                <property propertyId="org.locationtech.udig.project.FeatureStoreResourceProperty" expectedValue=""/>  
                <or>
-                    <property propertyId="org.locationtech.udig.project.ui.GeometryType" expectedValue="com.vividsolutions.jts.geom.MultiLineString"/>
-                    <property propertyId="org.locationtech.udig.project.ui.GeometryType" expectedValue="com.vividsolutions.jts.geom.LineString"/>
+                    <property propertyId="GeometryType" expectedValue="com.vividsolutions.jts.geom.MultiLineString"/>
+                    <property propertyId="GeometryType" expectedValue="com.vividsolutions.jts.geom.LineString"/>
                </or>
              </and>
             </enablement>
@@ -104,10 +104,10 @@
              <and>
                <property propertyId="org.locationtech.udig.project.FeatureStoreResourceProperty" expectedValue=""/>  
                <or>
-                    <property propertyId="org.locationtech.udig.project.ui.GeometryType" expectedValue="com.vividsolutions.jts.geom.MultiLineString"/>
-                    <property propertyId="org.locationtech.udig.project.ui.GeometryType" expectedValue="com.vividsolutions.jts.geom.LineString"/>
-                    <property propertyId="org.locationtech.udig.project.ui.GeometryType" expectedValue="com.vividsolutions.jts.geom.MultiPolygon"/>
-                    <property propertyId="org.locationtech.udig.project.ui.GeometryType" expectedValue="com.vividsolutions.jts.geom.Polygon"/>
+                    <property propertyId="GeometryType" expectedValue="com.vividsolutions.jts.geom.MultiLineString"/>
+                    <property propertyId="GeometryType" expectedValue="com.vividsolutions.jts.geom.LineString"/>
+                    <property propertyId="GeometryType" expectedValue="com.vividsolutions.jts.geom.MultiPolygon"/>
+                    <property propertyId="GeometryType" expectedValue="com.vividsolutions.jts.geom.Polygon"/>
                </or>
              </and>
             </enablement>


### PR DESCRIPTION
In some plugin.xml files of certain plugins the following warnings appears in eclipse IDE:

> Referenced identifier 'org.locationtech.udig.tool.select.layerHasSelectionProperty' in attribute 'propertyId' cannot be found

or 

> Referenced identifier 'org.locationtech.udig.project.ui.GeometryType' in attribute 'propertyId' cannot be found

Although these warnings do not seem to have an impact in the behavior of the plugins during runtime, the proposed pull request is suggested to clear out these warnings.

Signed-off-by: Nikolaos Pringouris <nprigour@gmail.com>