### PR TITLE
Fix issue causing always full layer export of abstract geometry types

### DIFF
--- a/plugins/org.locationtech.udig.catalog.ui/src/org/locationtech/udig/catalog/ui/export/CatalogExportWizard.java
+++ b/plugins/org.locationtech.udig.catalog.ui/src/org/locationtech/udig/catalog/ui/export/CatalogExportWizard.java
@@ -209,8 +209,7 @@ public class CatalogExportWizard extends WorkflowWizard implements IExportWizard
                 DefaultFeatureCollection lineCollection = new DefaultFeatureCollection();
                 DefaultFeatureCollection polygonCollection = new DefaultFeatureCollection();
 
-                SimpleFeatureCollection featureCollection = fs.getFeatures();
-                FeatureIterator<SimpleFeature> featureIterator = featureCollection.features();
+                FeatureIterator<SimpleFeature> featureIterator = fc.features();
                 while( featureIterator.hasNext() ) {
                     SimpleFeature feature = featureIterator.next();
                     String geometryType = ((Geometry) feature.getDefaultGeometry())


### PR DESCRIPTION
In org.locationtech.udig.catalog.ui.export.CatalogExportWizard when the type of layer is of the abstract type Geometry a selection during the action of a feature export (right click on a layer and selection of  Export->Other->Layer To Shapefile) is ignored causing all layers features to be exported. 

Signed-off-by: Nikolaos Pringouris <nprigour@gmail.com>