### PR TITLE
improve behavior of WMS Renderering for not displayed scales

### DIFF
--- a/plugins/org.locationtech.udig.render.wms.basic/src/org/locationtech/udig/render/internal/wms/basic/BasicWMSRenderer2.java
+++ b/plugins/org.locationtech.udig.render.wms.basic/src/org/locationtech/udig/render/internal/wms/basic/BasicWMSRenderer2.java
@@ -219,6 +219,9 @@ public class BasicWMSRenderer2 extends RendererImpl implements IMultiLayerRender
                     } else {
                         request.addLayer(layer);
                     }
+                } else {
+                	//no point to continue since no rendering will occur
+                	return;
                 }
             }
 

--- a/plugins/org.locationtech.udig.render.wms.basic/src/org/locationtech/udig/render/internal/wms/basic/BasicWMSRenderer2.java
+++ b/plugins/org.locationtech.udig.render.wms.basic/src/org/locationtech/udig/render/internal/wms/basic/BasicWMSRenderer2.java
@@ -195,6 +195,7 @@ public class BasicWMSRenderer2 extends RendererImpl implements IMultiLayerRender
 
             double currScale = getContext().getViewportModel().getScaleDenominator();
             List<ILayer> layers = getLayers();
+            int countAddedLayers = 0;
             for( int i = layers.size() - 1; i >= 0; i-- ) {
                 ILayer ilayer = layers.get(i);
                 Layer layer;
@@ -219,14 +220,19 @@ public class BasicWMSRenderer2 extends RendererImpl implements IMultiLayerRender
                     } else {
                         request.addLayer(layer);
                     }
+                    countAddedLayers++;
                 } else {
-                	//no point to continue since no rendering will occur
-                	return;
+                    //skip layer addition
+                    continue;
                 }
             }
 
             if (monitor.isCanceled())
                 return;
+
+            if (countAddedLayers == 0) {
+                return;
+            }
 
             List<Layer> wmsLayers = getWMSLayers();
             if (wmsLayers == null || wmsLayers.isEmpty()){


### PR DESCRIPTION
Improve behavior of WMS renderer (BasicWMSRenderer2 class) by avoiding full execution of render method in scales ranges where rendering has been disabled.
Prior to this improvement the render method seemed to stuck (progress monitor did not finish) when reaching at line 309.
`BufferedImage image = readImage(wms, request, monitor);`

Signed-off-by: Nikolaos Pringouris <nprigour@gmail.com>