### PR TITLE
add some exported packages to org.locationtech.udig.style.advanced.feature

### DIFF
--- a/plugins/org.locationtech.udig.style.advanced.feature/META-INF/MANIFEST.MF
+++ b/plugins/org.locationtech.udig.style.advanced.feature/META-INF/MANIFEST.MF
@@ -16,3 +16,8 @@ Require-Bundle: org.eclipse.ui,
 Bundle-ActivationPolicy: lazy
 Import-Package: com.google.common.collect;version="[12.0.0,16.0.0)"
 Bundle-RequiredExecutionEnvironment: JavaSE-1.7
+Export-Package: org.locationtech.udig.style.advanced.common,
+ org.locationtech.udig.style.advanced.lines,
+ org.locationtech.udig.style.advanced.points,
+ org.locationtech.udig.style.advanced.polygons,
+ org.locationtech.udig.style.advanced.utils


### PR DESCRIPTION
Some of the new org.locationtech.udig.style.advanced.feature plugin classes might be utilized by other custom application plugins that extend functionality of sld features. I would kindly appreciate to export them so that they are available as API without restrictions

Signed-off-by: Nikolaos Pringouris <nprigour@gmail.com>