### PR TITLE
remove upper bound restriction during import of com.google.common.base in MANIFEST.MF 

### DIFF
--- a/plugins/org.locationtech.udig.catalog.postgis/META-INF/MANIFEST.MF
+++ b/plugins/org.locationtech.udig.catalog.postgis/META-INF/MANIFEST.MF
@@ -14,5 +14,5 @@ Require-Bundle: org.eclipse.ui,
 Bundle-ActivationPolicy: lazy
 Export-Package: org.locationtech.udig.catalog
 Bundle-RequiredExecutionEnvironment: JavaSE-1.7
-Import-Package: com.google.common.collect;version="[12.0.0,16.0.0)"
+Import-Package: com.google.common.collect;version="12.0.0"
 

--- a/plugins/org.locationtech.udig.core/META-INF/MANIFEST.MF
+++ b/plugins/org.locationtech.udig.core/META-INF/MANIFEST.MF
@@ -19,4 +19,4 @@ Require-Bundle: org.eclipse.core.runtime,
  org.locationtech.udig.libs;visibility:=reexport
 Bundle-ActivationPolicy: lazy
 Bundle-RequiredExecutionEnvironment: JavaSE-1.7
-Import-Package: com.google.common.cache;version="[12.0.0,16.0.0)"
+Import-Package: com.google.common.cache;version="12.0.0"

--- a/plugins/org.locationtech.udig.style.advanced.core/META-INF/MANIFEST.MF
+++ b/plugins/org.locationtech.udig.style.advanced.core/META-INF/MANIFEST.MF
@@ -12,4 +12,4 @@ Require-Bundle: org.eclipse.core.runtime,
 Bundle-RequiredExecutionEnvironment: JavaSE-1.6
 Bundle-ActivationPolicy: lazy
 Export-Package: org.locationtech.udig.style.advanced.utils
-Import-Package: com.google.common.collect;version="[12.0.0,16.0.0)"
+Import-Package: com.google.common.collect;version="12.0.0"

--- a/plugins/org.locationtech.udig.style.advanced.feature/META-INF/MANIFEST.MF
+++ b/plugins/org.locationtech.udig.style.advanced.feature/META-INF/MANIFEST.MF
@@ -14,5 +14,5 @@ Require-Bundle: org.eclipse.ui,
  org.locationtech.udig.project,
  org.locationtech.udig.style.advanced.core
 Bundle-ActivationPolicy: lazy
-Import-Package: com.google.common.collect;version="[12.0.0,16.0.0)"
+Import-Package: com.google.common.collect;version="12.0.0"
 Bundle-RequiredExecutionEnvironment: JavaSE-1.7

--- a/plugins/org.locationtech.udig.style.advanced.raster/META-INF/MANIFEST.MF
+++ b/plugins/org.locationtech.udig.style.advanced.raster/META-INF/MANIFEST.MF
@@ -16,6 +16,6 @@ Require-Bundle: org.eclipse.ui,
  org.locationtech.udig.style.sld,
  org.locationtech.udig.style.advanced.core
 Bundle-ActivationPolicy: lazy
-Import-Package: com.google.common.collect;version="[12.0.0,16.0.0)",
+Import-Package: com.google.common.collect;version="12.0.0",
  javax.media.jai.iterator
 Bundle-RequiredExecutionEnvironment: JavaSE-1.7

--- a/plugins/org.locationtech.udig.ui/META-INF/MANIFEST.MF
+++ b/plugins/org.locationtech.udig.ui/META-INF/MANIFEST.MF
@@ -30,6 +30,6 @@ Export-Package: org.locationtech.udig,
  org.locationtech.udig.ui.palette,
  org.locationtech.udig.ui.preferences,
  org.locationtech.udig.ui.properties
-Import-Package: com.google.common.base;version="[12.0.0,16.0.0)",
+Import-Package: com.google.common.base;version="12.0.0",
  net.miginfocom.swt;version="[3.7.0,3.8.0)"
 


### PR DESCRIPTION
Imports of com.google.common.base package in MANIFEST.MF have a version restriction --> version="[12.0.0,16.0.0)". This prevents upgrade to newer versions of guava library available in latest eclipse orbit releases. 

Signed-off-by: Nikolaos Pringouris <nprigour@gmail.com>