### PR TITLE
match pluginid to file path

### DIFF
--- a/plugins/org.locationtech.udig.style.advanced.feature/src/org/locationtech/udig/style/advanced/StylePlugin.java
+++ b/plugins/org.locationtech.udig.style.advanced.feature/src/org/locationtech/udig/style/advanced/StylePlugin.java
@@ -20,7 +20,7 @@ import org.locationtech.udig.style.advanced.utils.ImageCache;
 public class StylePlugin extends AbstractUIPlugin {
 
     // The plug-in ID
-    public static final String PLUGIN_ID = "org.locationtech.udig.style.advanced"; //$NON-NLS-1$
+    public static final String PLUGIN_ID = "org.locationtech.udig.style.advanced.feature"; //$NON-NLS-1$
 
     // The shared instance
     private static StylePlugin plugin;


### PR DESCRIPTION
The point style editor was using the plugin id to find a file path (for Graphics Based Style) and this was causing an error as the plugin id didn't match the file path.  This request updates the pluginid to match the file path.
Signed-off-by: egouge <egouge@refractions.net>