### PR TITLE
Display Charset encoding in LayerSummary of Shapefile layers

### DIFF
--- a/plugins/org.locationtech.udig.project.ui/src/org/locationtech/udig/project/ui/internal/Messages.java
+++ b/plugins/org.locationtech.udig.project.ui/src/org/locationtech/udig/project/ui/internal/Messages.java
@@ -54,6 +54,8 @@ public class Messages extends NLS {
 
     public static String LayerSummary_boundsFormat;
 
+    public static String LayerSummary_charset;
+    
     public static String LayerSummary_featureType;
 
     public static String LayerSummary_maxOccurs;

--- a/plugins/org.locationtech.udig.project.ui/src/org/locationtech/udig/project/ui/internal/Messages.java
+++ b/plugins/org.locationtech.udig.project.ui/src/org/locationtech/udig/project/ui/internal/Messages.java
@@ -53,6 +53,8 @@ public class Messages extends NLS {
     public static String ImageExportPage_SelectionOverlay;
 
     public static String LayerSummary_boundsFormat;
+    
+    public static String LayerSummary_charset;
 
     public static String LayerSummary_featureType;
 

--- a/plugins/org.locationtech.udig.project.ui/src/org/locationtech/udig/project/ui/internal/Messages.java
+++ b/plugins/org.locationtech.udig.project.ui/src/org/locationtech/udig/project/ui/internal/Messages.java
@@ -53,8 +53,6 @@ public class Messages extends NLS {
     public static String ImageExportPage_SelectionOverlay;
 
     public static String LayerSummary_boundsFormat;
-    
-    public static String LayerSummary_charset;
 
     public static String LayerSummary_featureType;
 

--- a/plugins/org.locationtech.udig.project.ui/src/org/locationtech/udig/project/ui/internal/messages.properties
+++ b/plugins/org.locationtech.udig.project.ui/src/org/locationtech/udig/project/ui/internal/messages.properties
@@ -259,6 +259,8 @@ LayerSummary_bounds = Bounds
 
 LayerSummary_boundsFormat = ({0},{1}) ({2},{3})
 
+LayerSummary_charset = Character Set
+
 LayerSummary_crs = Data CRS
 
 LayerSummary_featureType = Feature Type

--- a/plugins/org.locationtech.udig.project.ui/src/org/locationtech/udig/project/ui/internal/messages.properties
+++ b/plugins/org.locationtech.udig.project.ui/src/org/locationtech/udig/project/ui/internal/messages.properties
@@ -259,8 +259,6 @@ LayerSummary_bounds = Bounds
 
 LayerSummary_boundsFormat = ({0},{1}) ({2},{3})
 
-LayerSummary_charset = Character Set
-
 LayerSummary_crs = Data CRS
 
 LayerSummary_featureType = Feature Type

--- a/plugins/org.locationtech.udig.project.ui/src/org/locationtech/udig/project/ui/internal/messages_de.properties
+++ b/plugins/org.locationtech.udig.project.ui/src/org/locationtech/udig/project/ui/internal/messages_de.properties
@@ -246,6 +246,8 @@ LayerSummary_bounds = Grenzen
 
 LayerSummary_boundsFormat = ({0},{1}) ({2},{3})
 
+LayerSummary_charset = Zeichensatz
+
 LayerSummary_crs = Daten-CRS
 
 LayerSummary_featureType = Featuretyp

--- a/plugins/org.locationtech.udig.project.ui/src/org/locationtech/udig/project/ui/internal/messages_de.properties
+++ b/plugins/org.locationtech.udig.project.ui/src/org/locationtech/udig/project/ui/internal/messages_de.properties
@@ -246,8 +246,6 @@ LayerSummary_bounds = Grenzen
 
 LayerSummary_boundsFormat = ({0},{1}) ({2},{3})
 
-LayerSummary_charset = Zeichensatz
-
 LayerSummary_crs = Daten-CRS
 
 LayerSummary_featureType = Featuretyp

--- a/plugins/org.locationtech.udig.project.ui/src/org/locationtech/udig/project/ui/internal/property/pages/LayerSummary.java
+++ b/plugins/org.locationtech.udig.project.ui/src/org/locationtech/udig/project/ui/internal/property/pages/LayerSummary.java
@@ -12,6 +12,7 @@ package org.locationtech.udig.project.ui.internal.property.pages;
 import java.util.ArrayList;
 import java.util.List;
 
+import org.locationtech.udig.catalog.IService;
 import org.locationtech.udig.project.internal.Layer;
 import org.locationtech.udig.project.ui.internal.Messages;
 import org.locationtech.udig.project.ui.summary.SummaryControl;
@@ -24,6 +25,7 @@ import org.eclipse.swt.widgets.Control;
 import org.eclipse.swt.widgets.TreeItem;
 import org.eclipse.ui.IWorkbenchPropertyPage;
 import org.eclipse.ui.dialogs.PropertyPage;
+import org.geotools.data.shapefile.ShapefileDataStore;
 import org.geotools.geometry.jts.ReferencedEnvelope;
 import org.opengis.feature.simple.SimpleFeatureType;
 import org.opengis.feature.type.AttributeDescriptor;
@@ -31,6 +33,7 @@ import org.opengis.filter.Filter;
 import org.opengis.referencing.crs.CoordinateReferenceSystem;
 
 import com.vividsolutions.jts.geom.Envelope;
+
 
 /**
  * Shows a summary of the layer
@@ -60,6 +63,18 @@ public class LayerSummary extends PropertyPage implements IWorkbenchPropertyPage
         data.add(new SummaryData(Messages.LayerSummary_bounds, bounds==null?Messages.LayerSummary_unknownBounds:parseBounds(bounds)));
         data.add(new SummaryData(Messages.LayerSummary_selection,layer.getFilter()));
         data.add(new SummaryData(Messages.LayerSummary_status, layer.getStatusMessage()));
+        try {
+        	if (layer.getGeoResource().canResolve(IService.class)) {
+        		IService service = layer.getGeoResource().resolve(IService.class, ProgressManager.instance().get());
+        		ShapefileDataStore store = service.resolve(ShapefileDataStore.class, ProgressManager.instance().get());
+        		if (store != null) {
+        			data.add(new SummaryData(Messages.LayerSummary_charset, store.getCharset()));
+        		}
+        	}
+        } catch (Exception e) {
+        	//
+        }       	
+        
         if ( layer.getSchema()!=null ){
             SimpleFeatureType schema = layer.getSchema();
             SummaryData schemaData=new SummaryData(Messages.LayerSummary_featureType, schema.getName().getLocalPart());

--- a/plugins/org.locationtech.udig.project.ui/src/org/locationtech/udig/project/ui/internal/property/pages/LayerSummary.java
+++ b/plugins/org.locationtech.udig.project.ui/src/org/locationtech/udig/project/ui/internal/property/pages/LayerSummary.java
@@ -12,6 +12,7 @@ package org.locationtech.udig.project.ui.internal.property.pages;
 import java.util.ArrayList;
 import java.util.List;
 
+import org.locationtech.udig.catalog.IService;
 import org.locationtech.udig.project.internal.Layer;
 import org.locationtech.udig.project.ui.internal.Messages;
 import org.locationtech.udig.project.ui.summary.SummaryControl;
@@ -24,6 +25,7 @@ import org.eclipse.swt.widgets.Control;
 import org.eclipse.swt.widgets.TreeItem;
 import org.eclipse.ui.IWorkbenchPropertyPage;
 import org.eclipse.ui.dialogs.PropertyPage;
+import org.geotools.data.shapefile.ShapefileDataStore;
 import org.geotools.geometry.jts.ReferencedEnvelope;
 import org.opengis.feature.simple.SimpleFeatureType;
 import org.opengis.feature.type.AttributeDescriptor;
@@ -60,6 +62,18 @@ public class LayerSummary extends PropertyPage implements IWorkbenchPropertyPage
         data.add(new SummaryData(Messages.LayerSummary_bounds, bounds==null?Messages.LayerSummary_unknownBounds:parseBounds(bounds)));
         data.add(new SummaryData(Messages.LayerSummary_selection,layer.getFilter()));
         data.add(new SummaryData(Messages.LayerSummary_status, layer.getStatusMessage()));
+        try {
+            if (layer.getGeoResource().canResolve(IService.class)) {
+                IService service = layer.getGeoResource().resolve(IService.class, ProgressManager.instance().get());
+                ShapefileDataStore store = service.resolve(ShapefileDataStore.class, ProgressManager.instance().get());
+                if (store != null) {
+                    data.add(new SummaryData(Messages.LayerSummary_charset, store.getCharset()));
+                }
+            }
+        } catch (Exception e) {
+            //
+        }               
+    
         if ( layer.getSchema()!=null ){
             SimpleFeatureType schema = layer.getSchema();
             SummaryData schemaData=new SummaryData(Messages.LayerSummary_featureType, schema.getName().getLocalPart());

--- a/plugins/org.locationtech.udig.project.ui/src/org/locationtech/udig/project/ui/internal/property/pages/LayerSummary.java
+++ b/plugins/org.locationtech.udig.project.ui/src/org/locationtech/udig/project/ui/internal/property/pages/LayerSummary.java
@@ -12,7 +12,6 @@ package org.locationtech.udig.project.ui.internal.property.pages;
 import java.util.ArrayList;
 import java.util.List;
 
-import org.locationtech.udig.catalog.IService;
 import org.locationtech.udig.project.internal.Layer;
 import org.locationtech.udig.project.ui.internal.Messages;
 import org.locationtech.udig.project.ui.summary.SummaryControl;
@@ -25,7 +24,6 @@ import org.eclipse.swt.widgets.Control;
 import org.eclipse.swt.widgets.TreeItem;
 import org.eclipse.ui.IWorkbenchPropertyPage;
 import org.eclipse.ui.dialogs.PropertyPage;
-import org.geotools.data.shapefile.ShapefileDataStore;
 import org.geotools.geometry.jts.ReferencedEnvelope;
 import org.opengis.feature.simple.SimpleFeatureType;
 import org.opengis.feature.type.AttributeDescriptor;
@@ -33,7 +31,6 @@ import org.opengis.filter.Filter;
 import org.opengis.referencing.crs.CoordinateReferenceSystem;
 
 import com.vividsolutions.jts.geom.Envelope;
-
 
 /**
  * Shows a summary of the layer
@@ -63,18 +60,6 @@ public class LayerSummary extends PropertyPage implements IWorkbenchPropertyPage
         data.add(new SummaryData(Messages.LayerSummary_bounds, bounds==null?Messages.LayerSummary_unknownBounds:parseBounds(bounds)));
         data.add(new SummaryData(Messages.LayerSummary_selection,layer.getFilter()));
         data.add(new SummaryData(Messages.LayerSummary_status, layer.getStatusMessage()));
-        try {
-        	if (layer.getGeoResource().canResolve(IService.class)) {
-        		IService service = layer.getGeoResource().resolve(IService.class, ProgressManager.instance().get());
-        		ShapefileDataStore store = service.resolve(ShapefileDataStore.class, ProgressManager.instance().get());
-        		if (store != null) {
-        			data.add(new SummaryData(Messages.LayerSummary_charset, store.getCharset()));
-        		}
-        	}
-        } catch (Exception e) {
-        	//
-        }       	
-        
         if ( layer.getSchema()!=null ){
             SimpleFeatureType schema = layer.getSchema();
             SummaryData schemaData=new SummaryData(Messages.LayerSummary_featureType, schema.getName().getLocalPart());


### PR DESCRIPTION
Enhancement that displays the character set encoding (only for shapefile resources)  in Layer Summary property page

![image](https://user-images.githubusercontent.com/26147785/43197664-851a121a-9014-11e8-896d-fbefeab1200a.png)

Signed-off-by: Nikolaos Pringouris <nprigour@gmail.com>