### PR TITLE
get message display delay from preference store

### DIFF
--- a/plugins/org.locationtech.udig.tool.edit/src/org/locationtech/udig/tool/edit/internal/Messages.java
+++ b/plugins/org.locationtech.udig.tool.edit/src/org/locationtech/udig/tool/edit/internal/Messages.java
@@ -83,6 +83,7 @@ public class Messages extends NLS {
 	public static String EditToolPreferences_behaviour;
 	public static String EditToolPreferences_snapRadius;
 	public static String EditToolPreferences_description;
+	public static String EditToolPreferences_messageDisplayDelay;
 	public static String DeleteGlobalActionSetterActivator_tooltip;
 	public static String DeleteGlobalActionSetterActivator_title;
 	public static String DifferenceFeatureCommand_name;

--- a/plugins/org.locationtech.udig.tool.edit/src/org/locationtech/udig/tool/edit/internal/messages.properties
+++ b/plugins/org.locationtech.udig.tool.edit/src/org/locationtech/udig/tool/edit/internal/messages.properties
@@ -106,6 +106,8 @@ EditToolPreferences_grid = Grid
 
 EditToolPreferences_gridLabel = Grid Size (Degrees)
 
+EditToolPreferences_messageDisplayDelay = Message display delay in milliseconds
+
 EditToolPreferences_noSnapping = No Snapping
 
 EditToolPreferences_selected = Selected Features

--- a/plugins/org.locationtech.udig.tool.edit/src/org/locationtech/udig/tools/edit/preferences/EditToolPreferences.java
+++ b/plugins/org.locationtech.udig.tool.edit/src/org/locationtech/udig/tools/edit/preferences/EditToolPreferences.java
@@ -77,7 +77,11 @@ public class EditToolPreferences extends FieldEditorPreferencePage
         addField(new ColorFieldEditor(PreferenceConstants.P_SNAP_CIRCLE_COLOR, 
         		Messages.EditToolPreferences_feedbackColor,
                 getFieldEditorParent()));
-        
+
+        addField(new IntegerFieldEditor(PreferenceConstants.P_MESSAGE_DISPLAY_DELAY, 
+                Messages.EditToolPreferences_messageDisplayDelay,
+                getFieldEditorParent()));
+
         addField(new FeatureEditorFieldEditor(getFieldEditorParent()));
     }
 

--- a/plugins/org.locationtech.udig.tool.edit/src/org/locationtech/udig/tools/edit/preferences/PreferenceConstants.java
+++ b/plugins/org.locationtech.udig.tool.edit/src/org/locationtech/udig/tools/edit/preferences/PreferenceConstants.java
@@ -42,4 +42,9 @@ public class PreferenceConstants {
      */
     public static final int P_DEFAULT_DELETE_SEARCH_SCALEFACTOR = 6;
 
+    /**
+     * The message display delay.
+     */
+    public static final String P_MESSAGE_DISPLAY_DELAY = "P_MESSAGE_DISPLAY_DELAY"; //$NON-NLS-1$
+
 }

--- a/plugins/org.locationtech.udig.tool.edit/src/org/locationtech/udig/tools/edit/preferences/PreferenceInitializer.java
+++ b/plugins/org.locationtech.udig.tool.edit/src/org/locationtech/udig/tools/edit/preferences/PreferenceInitializer.java
@@ -41,6 +41,7 @@ public class PreferenceInitializer extends AbstractPreferenceInitializer {
         store.setDefault(PreferenceConstants.P_DELETE_TOOL_CONFIRM, true); 
         store.setDefault(PreferenceConstants.P_DELETE_TOOL_SEARCH_SCALEFACTOR,
                 PreferenceConstants.P_DEFAULT_DELETE_SEARCH_SCALEFACTOR);
+        store.setDefault(PreferenceConstants.P_MESSAGE_DISPLAY_DELAY, 2000);
     }
 
 }

--- a/plugins/org.locationtech.udig.tool.edit/src/org/locationtech/udig/tools/edit/preferences/PreferenceUtil.java
+++ b/plugins/org.locationtech.udig.tool.edit/src/org/locationtech/udig/tools/edit/preferences/PreferenceUtil.java
@@ -200,7 +200,7 @@ public class PreferenceUtil {
     }
 
     public short getMessageDisplayDelay() {
-        return 2000;
+        return (short) store.getInt(PreferenceConstants.P_MESSAGE_DISPLAY_DELAY);
     }
     
 }


### PR DESCRIPTION
Adds the possibility to set the delay of displaying messages via the preferences.

Signed-off-by: sloob <sebastian.loob@ibykus.de>