### PR TITLE
get collapse vertices setting from preference store

### DIFF
--- a/plugins/org.locationtech.udig.tool.edit/src/org/locationtech/udig/tools/edit/preferences/PreferenceConstants.java
+++ b/plugins/org.locationtech.udig.tool.edit/src/org/locationtech/udig/tools/edit/preferences/PreferenceConstants.java
@@ -42,4 +42,9 @@ public class PreferenceConstants {
      */
     public static final int P_DEFAULT_DELETE_SEARCH_SCALEFACTOR = 6;
 
+    /**
+     * The collapse vertices setting in edit blackboard.
+     */
+    public static final String P_COLLAPSE_VERTICES = "P_COLLAPSE_VERTICES"; //$NON-NLS-1$
+
 }

--- a/plugins/org.locationtech.udig.tool.edit/src/org/locationtech/udig/tools/edit/preferences/PreferenceInitializer.java
+++ b/plugins/org.locationtech.udig.tool.edit/src/org/locationtech/udig/tools/edit/preferences/PreferenceInitializer.java
@@ -41,6 +41,7 @@ public class PreferenceInitializer extends AbstractPreferenceInitializer {
         store.setDefault(PreferenceConstants.P_DELETE_TOOL_CONFIRM, true); 
         store.setDefault(PreferenceConstants.P_DELETE_TOOL_SEARCH_SCALEFACTOR,
                 PreferenceConstants.P_DEFAULT_DELETE_SEARCH_SCALEFACTOR);
+        store.setDefault(PreferenceConstants.P_COLLAPSE_VERTICES, true);
     }
 
 }

--- a/plugins/org.locationtech.udig.tool.edit/src/org/locationtech/udig/tools/edit/preferences/PreferenceUtil.java
+++ b/plugins/org.locationtech.udig.tool.edit/src/org/locationtech/udig/tools/edit/preferences/PreferenceUtil.java
@@ -202,5 +202,9 @@ public class PreferenceUtil {
     public short getMessageDisplayDelay() {
         return 2000;
     }
+
+    public boolean collapseVertices() {
+        return store.getBoolean(PreferenceConstants.P_COLLAPSE_VERTICES);
+    }
     
 }

--- a/plugins/org.locationtech.udig.tool.edit/src/org/locationtech/udig/tools/edit/support/EditBlackboard.java
+++ b/plugins/org.locationtech.udig.tool.edit/src/org/locationtech/udig/tools/edit/support/EditBlackboard.java
@@ -72,7 +72,7 @@ public class EditBlackboard {
      */
     public EditBlackboard(int width, int height, AffineTransform toScreen,
             MathTransform layerToMap) {
-        collapseVertices = true;
+        collapseVertices = PreferenceUtil.instance().collapseVertices();
         this.width = width;
         this.height = height;
         coordMapping = new HashMap<Point, List<LazyCoord>>();


### PR DESCRIPTION
Adds the possibility to change the collapse vertices setting in
EditBlackboard programmatically via the preference store.

Signed-off-by: sloob <sebastian.loob@ibykus.de>