### PR TITLE
Fixed an exception occuring when switching from the "draw new rectangle" ...

### DIFF
--- a/plugins/org.locationtech.udig.tool.edit/src/org/locationtech/udig/tools/edit/EditToolHandler.java
+++ b/plugins/org.locationtech.udig.tool.edit/src/org/locationtech/udig/tools/edit/EditToolHandler.java
@@ -128,13 +128,14 @@ public class EditToolHandler {
             enableListeners();
 
         } else {
-            basicDisablement();
-            disableListeners();
 
             List<Behaviour> list = acceptBehaviours;
 
             BehaviourCommand command = getCommand(list);
-            getContext().sendASyncCommand(command);
+            getContext().sendSyncCommand(command);
+            
+            basicDisablement();
+            disableListeners();
             setCurrentState(EditState.NONE);
         }
     }


### PR DESCRIPTION
to edit-tool after drawing a rectangle (see [here](https://www.youtube.com/watch?v=10AF3b7FFDA) to reproduce).

The following exception occurs:
`!ENTRY org.locationtech.udig.project 1 0 2018-10-17 10:36:58.489
!MESSAGE EventVerhalten failed to run
!STACK 0
java.lang.NullPointerException
	at org.locationtech.udig.tools.edit.impl.RectangleTool$1.isValid(RectangleTool.java:70)
	at org.locationtech.udig.tools.edit.BehaviourCommand.execute(BehaviourCommand.java:50)
	at org.locationtech.udig.project.command.CommandManager$Executor.execute(CommandManager.java:395)
	at org.locationtech.udig.project.command.CommandManager$Executor.run(CommandManager.java:326)
	at org.locationtech.udig.project.command.CommandManager$Executor.run(CommandManager.java:312)
	at org.eclipse.core.internal.jobs.Worker.run(Worker.java:56)`

Signed-off-by: Michael Sementsov <michael.sementsov@ibykus.de>