### PR TITLE
Only asynchronous repaints

### DIFF
--- a/plugins/org.locationtech.udig.project.ui/src/org/locationtech/udig/project/ui/internal/render/displayAdapter/impl/ViewportPaneSWT.java
+++ b/plugins/org.locationtech.udig.project.ui/src/org/locationtech/udig/project/ui/internal/render/displayAdapter/impl/ViewportPaneSWT.java
@@ -559,10 +559,8 @@ public class ViewportPaneSWT extends Canvas implements ViewportPane {
         REPAINT.y = y;
         REPAINT.width = width;
         REPAINT.height = height;
-        if (Display.getCurrent() != null) {
-            REPAINT.run();
-        }else
-        	display.asyncExec(REPAINT);
+        
+        display.asyncExec(REPAINT);
     }
 
     /**


### PR DESCRIPTION
Otherwise this leads to a deadlock, when a thread owning Devicelock (which is needed for Display.getCurrent()) hangs above at the repaintMutex and another thread down here is waiting for devicelock


Signed-off-by: Michael Sementsov <michael.sementsov@ibykus.de>