### PR TITLE
get transparency of the vertex of an edit geom from preference store

### DIFF
--- a/plugins/org.locationtech.udig.tool.edit/src/org/locationtech/udig/tool/edit/internal/Messages.java
+++ b/plugins/org.locationtech.udig.tool.edit/src/org/locationtech/udig/tool/edit/internal/Messages.java
@@ -75,6 +75,7 @@ public class Messages extends NLS {
 	public static String EditToolPreferences_selectedGeom;
 	public static String EditToolPreferences_advanced_editing_name;
 	public static String EditToolPreferences_vertexDiameter;
+	public static String EditToolPreferneces_vertexTransparency;
 	public static String EditToolPreferences_grid;
 	public static String EditToolPreferences_all;
 	public static String EditToolPreferences_current;

--- a/plugins/org.locationtech.udig.tool.edit/src/org/locationtech/udig/tool/edit/internal/messages.properties
+++ b/plugins/org.locationtech.udig.tool.edit/src/org/locationtech/udig/tool/edit/internal/messages.properties
@@ -118,6 +118,8 @@ EditToolPreferences_vertexDiameter = Vertex Diameter
 
 EditToolPreferences_vertexOutline = Vertex Outlines
 
+EditToolPreferneces_vertexTransparency = Reduce Vertex Transparency (0-100)
+
 EventBehaviourCommand_name = EventBehaviour
 
 HoleTool_add_vertex = Click to add vertex

--- a/plugins/org.locationtech.udig.tool.edit/src/org/locationtech/udig/tool/edit/internal/messages.properties
+++ b/plugins/org.locationtech.udig.tool.edit/src/org/locationtech/udig/tool/edit/internal/messages.properties
@@ -118,7 +118,7 @@ EditToolPreferences_vertexDiameter = Vertex Diameter
 
 EditToolPreferences_vertexOutline = Vertex Outlines
 
-EditToolPreferneces_vertexTransparency = Reduce Vertex Transparency (0-100)
+EditToolPreferneces_vertexTransparency = Vertex Opacity
 
 EventBehaviourCommand_name = EventBehaviour
 

--- a/plugins/org.locationtech.udig.tool.edit/src/org/locationtech/udig/tools/edit/preferences/EditToolPreferences.java
+++ b/plugins/org.locationtech.udig.tool.edit/src/org/locationtech/udig/tools/edit/preferences/EditToolPreferences.java
@@ -74,6 +74,12 @@ public class EditToolPreferences extends FieldEditorPreferencePage
         		Messages.EditToolPreferences_vertexDiameter,
                 getFieldEditorParent()));
 
+        IntegerFieldEditor vertexTransparency = new IntegerFieldEditor(PreferenceConstants.P_VERTEX_TRANSPARENCY,
+                Messages.EditToolPreferneces_vertexTransparency,
+                getFieldEditorParent());
+        vertexTransparency.setValidRange(0, 100);
+        addField(vertexTransparency);
+
         addField(new ColorFieldEditor(PreferenceConstants.P_SNAP_CIRCLE_COLOR, 
         		Messages.EditToolPreferences_feedbackColor,
                 getFieldEditorParent()));

--- a/plugins/org.locationtech.udig.tool.edit/src/org/locationtech/udig/tools/edit/preferences/PreferenceConstants.java
+++ b/plugins/org.locationtech.udig.tool.edit/src/org/locationtech/udig/tools/edit/preferences/PreferenceConstants.java
@@ -42,4 +42,10 @@ public class PreferenceConstants {
      */
     public static final int P_DEFAULT_DELETE_SEARCH_SCALEFACTOR = 6;
 
+    /** 
+     * The factor to reduce the transparency of the color used for the vertex of 
+     * the edit geoms.
+     */
+    public static final String P_VERTEX_TRANSPARENCY = "P_VERTEX_TRANSPARENCY"; //$NON-NLS-1$
+
 }

--- a/plugins/org.locationtech.udig.tool.edit/src/org/locationtech/udig/tools/edit/preferences/PreferenceInitializer.java
+++ b/plugins/org.locationtech.udig.tool.edit/src/org/locationtech/udig/tools/edit/preferences/PreferenceInitializer.java
@@ -41,6 +41,7 @@ public class PreferenceInitializer extends AbstractPreferenceInitializer {
         store.setDefault(PreferenceConstants.P_DELETE_TOOL_CONFIRM, true); 
         store.setDefault(PreferenceConstants.P_DELETE_TOOL_SEARCH_SCALEFACTOR,
                 PreferenceConstants.P_DEFAULT_DELETE_SEARCH_SCALEFACTOR);
+        store.setDefault(PreferenceConstants.P_VERTEX_TRANSPARENCY, 35);
     }
 
 }

--- a/plugins/org.locationtech.udig.tool.edit/src/org/locationtech/udig/tools/edit/preferences/PreferenceUtil.java
+++ b/plugins/org.locationtech.udig.tool.edit/src/org/locationtech/udig/tools/edit/preferences/PreferenceUtil.java
@@ -154,7 +154,7 @@ public class PreferenceUtil {
      */
     public Color getDrawVertexFillColor() {
         Color base = getSelectionColor();
-        return reduceTransparency(base,.35f);
+        return reduceTransparency(base, (float) store.getInt(PreferenceConstants.P_VERTEX_TRANSPARENCY) / 100);
     }
 
     /**


### PR DESCRIPTION
adds the possibility to change the vertex transparency of an edit geom
via the preferences

Signed-off-by: sloob <sebastian.loob@ibykus.de>