### PR TITLE
CRS info added in WMS GetFeatureInfo requests

### DIFF
--- a/plugins/org.locationtech.udig.info/src/org/locationtech/udig/tool/info/internal/WMSDescribeLayer.java
+++ b/plugins/org.locationtech.udig.info/src/org/locationtech/udig/tool/info/internal/WMSDescribeLayer.java
@@ -202,7 +202,7 @@ public class WMSDescribeLayer {
 
         getmap.setBBox( bbox );
         String srs = CRS.toSRS(bbox.getCoordinateReferenceSystem() );
-        //getmap.setSRS( code != null ? code : srs );
+        getmap.setSRS( code != null ? code : srs );
         
         getmap.setProperty( GetMapRequest.LAYERS, wmslayer.getName() );
         int width = map.getRenderManager().getMapDisplay().getWidth();


### PR DESCRIPTION
During WMS GetFeatureInfo requests CRS (for WMS version 1.3.0) or SRS (for WMS version 1.1.1) are not provided in the request URL. This may cause problem when retrieving layer information (see also #316 for a more analytical description of the problem)  

Signed-off-by: Nikolaos Pringouris <nprigour@gmail.com>