### PR TITLE
use default CRS if it's set in preference store

### DIFF
--- a/plugins/org.locationtech.udig.project/src/org/locationtech/udig/project/internal/impl/InitMapCRS.java
+++ b/plugins/org.locationtech.udig.project/src/org/locationtech/udig/project/internal/impl/InitMapCRS.java
@@ -39,7 +39,7 @@ public class InitMapCRS implements LayerInterceptor {
 	        // If the Current CRS==ViewportModel.BAD_DEFAULT then it can also be changed.  It means that the DEFAULT_CRS was
 	        // an illegal EPSG code
 	        CoordinateReferenceSystem crs = layer.getMap().getViewportModel().getCRS();
-			if( defaultCRS!=-1 && crs==ViewportModel.BAD_DEFAULT ){
+			if( defaultCRS!=-1 && crs!=ViewportModel.BAD_DEFAULT ){
 	            return;
 	        }
 	        List<ILayer> layers = layer.getMapInternal().getMapLayers();


### PR DESCRIPTION
Fix bug, that the default CRS is never used, although a valid and not
"bad default" CRS is specified in the preference store.

Signed-off-by: sloob <sebastian.loob@ibykus.de>