### PR TITLE
fix possible NPE exception due to null CRS during SelectAllFearureOp execution 

### DIFF
--- a/plugins/org.locationtech.udig.project.ui/src/org/locationtech/udig/project/ui/operations/SelectAllFeaturesOp.java
+++ b/plugins/org.locationtech.udig.project.ui/src/org/locationtech/udig/project/ui/operations/SelectAllFeaturesOp.java
@@ -56,6 +56,9 @@ public class SelectAllFeaturesOp implements IOp {
         ReferencedEnvelope bounds = viewportModel.getBounds();
         CoordinateReferenceSystem dataCrs = schema.getCoordinateReferenceSystem();
         
+        if (dataCrs == null) {
+        	dataCrs = viewportModel.getCRS();
+        }
         ReferencedEnvelope newBounds = bounds.transform(dataCrs, true);
         
         String name = geometryDescriptor.getLocalName();


### PR DESCRIPTION
if during execution of SelectAllFearureOp, CRS is not available at layer level then a NPE exception is thrown and features are not selected. In that case, the suggested fix attempts to obtain CRS from the Map (through the ViewportModel) so that selection is possible

Signed-off-by: Nikolaos Pringouris <nprigour@gmail.com>