### PR TITLE
change visibility of category finder methods in ToolManager to public and made them final 

### DIFF
--- a/plugins/org.locationtech.udig.project.tests.ui/src/org/locationtech/udig/project/ui/internal/tool/display/ToolManagerTest.java
+++ b/plugins/org.locationtech.udig.project.tests.ui/src/org/locationtech/udig/project/ui/internal/tool/display/ToolManagerTest.java
@@ -21,7 +21,7 @@ import org.locationtech.udig.project.tests.support.MapTests;
 import org.locationtech.udig.project.ui.ApplicationGIS;
 import org.locationtech.udig.project.ui.internal.ApplicationGISInternal;
 import org.locationtech.udig.project.ui.internal.MapEditorPart;
-
+import org.locationtech.udig.project.ui.tool.IToolManager;
 import org.junit.Before;
 import org.junit.Ignore;
 import org.junit.Test;
@@ -41,7 +41,7 @@ public class ToolManagerTest {
     @Ignore
     @Test
     public void testSetCurrentEditor() {
-        ToolManager manager = (ToolManager) ApplicationGIS.getToolManager();
+        IToolManager manager = ApplicationGIS.getToolManager();
         List<ActionToolCategory> categories = manager.getActiveToolCategories();
         ToolProxy tool=null;
         for( ActionToolCategory category : categories ) {

--- a/plugins/org.locationtech.udig.project.ui/src/org/locationtech/udig/project/ui/internal/tool/display/ModalToolCategory.java
+++ b/plugins/org.locationtech.udig.project.ui/src/org/locationtech/udig/project/ui/internal/tool/display/ModalToolCategory.java
@@ -209,7 +209,7 @@ public class ModalToolCategory extends ToolCategory {
 		 */
 		@Override
 		protected boolean isActiveItem() {
-			return getTools().contains( ((ToolManager)manager).getActiveToolProxy());
+			return getTools().contains(manager.getActiveToolProxy());
 		}
     }
 

--- a/plugins/org.locationtech.udig.project.ui/src/org/locationtech/udig/project/ui/internal/tool/display/ToolManager.java
+++ b/plugins/org.locationtech.udig.project.ui/src/org/locationtech/udig/project/ui/internal/tool/display/ToolManager.java
@@ -763,21 +763,21 @@ public class ToolManager implements IToolManager {
         addToolAction(toolAction);
         return toolAction;
     }
-    public ActionToolCategory findActionCategory( String id ) {
+    public final ActionToolCategory findActionCategory( String id ) {
         for( ActionToolCategory category : actionCategories ) {
             if (category.getId().equals(id))
                 return category;
         }
         return null;
     }
-    MenuToolCategory findMenuCategory( String id ) {
+    public final MenuToolCategory findMenuCategory( String id ) {
         for( MenuToolCategory category : menuCategories ) {
             if (category.getId().equals(id))
                 return category;
         }
         return null;
     }
-    protected ModalToolCategory findModalCategory( String id ) {
+    public final ModalToolCategory findModalCategory( String id ) {
         for( ModalToolCategory category : modalCategories ) {
             String id2 = category.getId();
             if (id2.equals(id))

--- a/plugins/org.locationtech.udig.project.ui/src/org/locationtech/udig/project/ui/internal/tool/display/ToolManager.java
+++ b/plugins/org.locationtech.udig.project.ui/src/org/locationtech/udig/project/ui/internal/tool/display/ToolManager.java
@@ -26,50 +26,6 @@ import java.util.Set;
 import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReentrantLock;
 
-import org.locationtech.udig.catalog.IGeoResource;
-import org.locationtech.udig.core.filter.AdaptingFilter;
-import org.locationtech.udig.core.filter.AdaptingFilterFactory;
-import org.locationtech.udig.core.internal.ExtensionPointList;
-import org.locationtech.udig.internal.ui.UDIGDNDProcessor;
-import org.locationtech.udig.internal.ui.UDIGDropHandler;
-import org.locationtech.udig.internal.ui.UDigByteAndLocalTransfer;
-import org.locationtech.udig.internal.ui.UiPlugin;
-import org.locationtech.udig.internal.ui.operations.OperationCategory;
-import org.locationtech.udig.internal.ui.operations.OperationMenuFactory;
-import org.locationtech.udig.internal.ui.operations.RunOperationsAction;
-import org.locationtech.udig.project.EditManagerEvent;
-import org.locationtech.udig.project.IEditManagerListener;
-import org.locationtech.udig.project.ILayer;
-import org.locationtech.udig.project.IMap;
-import org.locationtech.udig.project.internal.Map;
-import org.locationtech.udig.project.internal.ProjectPackage;
-import org.locationtech.udig.project.internal.commands.CreateMapCommand;
-import org.locationtech.udig.project.ui.ApplicationGIS;
-import org.locationtech.udig.project.ui.internal.ApplicationGISInternal;
-import org.locationtech.udig.project.ui.internal.MapEditor;
-import org.locationtech.udig.project.ui.internal.MapEditorPart;
-import org.locationtech.udig.project.ui.internal.MapEditorWithPalette;
-import org.locationtech.udig.project.ui.internal.MapPart;
-import org.locationtech.udig.project.ui.internal.Messages;
-import org.locationtech.udig.project.ui.internal.ProjectUIPlugin;
-import org.locationtech.udig.project.ui.internal.actions.Delete;
-import org.locationtech.udig.project.ui.internal.tool.ToolContext;
-import org.locationtech.udig.project.ui.internal.tool.impl.ToolContextImpl;
-import org.locationtech.udig.project.ui.tool.IContextMenuContributionTool;
-import org.locationtech.udig.project.ui.tool.IToolManager;
-import org.locationtech.udig.project.ui.tool.ModalTool;
-import org.locationtech.udig.project.ui.tool.Tool;
-import org.locationtech.udig.project.ui.tool.ToolConstants;
-import org.locationtech.udig.project.ui.tool.options.PreferencesShortcutToolOptionsContributionItem;
-import org.locationtech.udig.project.ui.viewers.MapEditDomain;
-import org.locationtech.udig.ui.IDropAction;
-import org.locationtech.udig.ui.IDropHandlerListener;
-import org.locationtech.udig.ui.PlatformGIS;
-import org.locationtech.udig.ui.UDIGDragDropUtilities;
-import org.locationtech.udig.ui.ViewerDropLocation;
-import org.locationtech.udig.ui.operations.LazyOpFilter;
-import org.locationtech.udig.ui.operations.OpAction;
-import org.locationtech.udig.ui.operations.OpFilter;
 import org.eclipse.core.commands.Command;
 import org.eclipse.core.runtime.IConfigurationElement;
 import org.eclipse.core.runtime.IExtension;
@@ -118,8 +74,50 @@ import org.eclipse.ui.actions.ActionFactory;
 import org.eclipse.ui.actions.ActionFactory.IWorkbenchAction;
 import org.eclipse.ui.commands.ICommandService;
 import org.eclipse.ui.dialogs.PropertyDialogAction;
-import org.eclipse.ui.part.EditorPart;
 import org.eclipse.ui.part.ViewPart;
+import org.locationtech.udig.catalog.IGeoResource;
+import org.locationtech.udig.core.filter.AdaptingFilter;
+import org.locationtech.udig.core.filter.AdaptingFilterFactory;
+import org.locationtech.udig.core.internal.ExtensionPointList;
+import org.locationtech.udig.internal.ui.UDIGDNDProcessor;
+import org.locationtech.udig.internal.ui.UDIGDropHandler;
+import org.locationtech.udig.internal.ui.UDigByteAndLocalTransfer;
+import org.locationtech.udig.internal.ui.UiPlugin;
+import org.locationtech.udig.internal.ui.operations.OperationCategory;
+import org.locationtech.udig.internal.ui.operations.OperationMenuFactory;
+import org.locationtech.udig.internal.ui.operations.RunOperationsAction;
+import org.locationtech.udig.project.EditManagerEvent;
+import org.locationtech.udig.project.IEditManagerListener;
+import org.locationtech.udig.project.ILayer;
+import org.locationtech.udig.project.IMap;
+import org.locationtech.udig.project.internal.Map;
+import org.locationtech.udig.project.internal.ProjectPackage;
+import org.locationtech.udig.project.internal.commands.CreateMapCommand;
+import org.locationtech.udig.project.ui.ApplicationGIS;
+import org.locationtech.udig.project.ui.internal.ApplicationGISInternal;
+import org.locationtech.udig.project.ui.internal.MapEditorPart;
+import org.locationtech.udig.project.ui.internal.MapEditorWithPalette;
+import org.locationtech.udig.project.ui.internal.MapPart;
+import org.locationtech.udig.project.ui.internal.Messages;
+import org.locationtech.udig.project.ui.internal.ProjectUIPlugin;
+import org.locationtech.udig.project.ui.internal.actions.Delete;
+import org.locationtech.udig.project.ui.internal.tool.ToolContext;
+import org.locationtech.udig.project.ui.internal.tool.impl.ToolContextImpl;
+import org.locationtech.udig.project.ui.tool.IContextMenuContributionTool;
+import org.locationtech.udig.project.ui.tool.IToolManager;
+import org.locationtech.udig.project.ui.tool.ModalTool;
+import org.locationtech.udig.project.ui.tool.Tool;
+import org.locationtech.udig.project.ui.tool.ToolConstants;
+import org.locationtech.udig.project.ui.tool.options.PreferencesShortcutToolOptionsContributionItem;
+import org.locationtech.udig.project.ui.viewers.MapEditDomain;
+import org.locationtech.udig.ui.IDropAction;
+import org.locationtech.udig.ui.IDropHandlerListener;
+import org.locationtech.udig.ui.PlatformGIS;
+import org.locationtech.udig.ui.UDIGDragDropUtilities;
+import org.locationtech.udig.ui.ViewerDropLocation;
+import org.locationtech.udig.ui.operations.LazyOpFilter;
+import org.locationtech.udig.ui.operations.OpAction;
+import org.locationtech.udig.ui.operations.OpFilter;
 import org.opengis.filter.Filter;
 
 /**
@@ -763,6 +761,8 @@ public class ToolManager implements IToolManager {
         addToolAction(toolAction);
         return toolAction;
     }
+    
+    @Override
     public final ActionToolCategory findActionCategory( String id ) {
         for( ActionToolCategory category : actionCategories ) {
             if (category.getId().equals(id))
@@ -770,6 +770,7 @@ public class ToolManager implements IToolManager {
         }
         return null;
     }
+    @Override
     public final MenuToolCategory findMenuCategory( String id ) {
         for( MenuToolCategory category : menuCategories ) {
             if (category.getId().equals(id))
@@ -777,6 +778,7 @@ public class ToolManager implements IToolManager {
         }
         return null;
     }
+    @Override
     public final ModalToolCategory findModalCategory( String id ) {
         for( ModalToolCategory category : modalCategories ) {
             String id2 = category.getId();

--- a/plugins/org.locationtech.udig.project.ui/src/org/locationtech/udig/project/ui/internal/tool/display/ToolProxy.java
+++ b/plugins/org.locationtech.udig.project.ui/src/org/locationtech/udig/project/ui/internal/tool/display/ToolProxy.java
@@ -27,6 +27,7 @@ import org.locationtech.udig.project.ui.tool.AbstractTool;
 import org.locationtech.udig.project.ui.tool.ActionTool;
 import org.locationtech.udig.project.ui.tool.IMapEditorSelectionProvider;
 import org.locationtech.udig.project.ui.tool.IToolContext;
+import org.locationtech.udig.project.ui.tool.IToolManager;
 import org.locationtech.udig.project.ui.tool.ModalTool;
 import org.locationtech.udig.project.ui.tool.Tool;
 import org.locationtech.udig.project.ui.tool.ToolConstants;
@@ -643,7 +644,7 @@ public class ToolProxy extends ModalItem implements ModalTool, ActionTool {
                     if (selectionProviderInstance != null)
                         return selectionProviderInstance;
                 }
-                ToolManager m = (ToolManager) ApplicationGIS.getToolManager();
+                IToolManager m = ApplicationGIS.getToolManager();
                 ModalToolCategory cat = m.findModalCategory(getCategoryId());
                 if (cat != null){
                     selectionProviderInstance = cat.getSelectionProvider();

--- a/plugins/org.locationtech.udig.project.ui/src/org/locationtech/udig/project/ui/tool/IToolManager.java
+++ b/plugins/org.locationtech.udig.project.ui/src/org/locationtech/udig/project/ui/tool/IToolManager.java
@@ -14,9 +14,10 @@ import java.util.List;
 
 import org.locationtech.udig.project.ui.internal.MapPart;
 import org.locationtech.udig.project.ui.internal.tool.display.ActionToolCategory;
+import org.locationtech.udig.project.ui.internal.tool.display.MenuToolCategory;
 import org.locationtech.udig.project.ui.internal.tool.display.ModalToolCategory;
 import org.locationtech.udig.project.ui.internal.tool.display.ToolCategory;
-
+import org.locationtech.udig.project.ui.internal.tool.display.ToolProxy;
 import org.eclipse.jface.action.IAction;
 import org.eclipse.jface.action.IMenuManager;
 import org.eclipse.jface.action.IToolBarManager;
@@ -29,23 +30,23 @@ import org.eclipse.ui.IWorkbenchPart;
 
 public interface IToolManager {
     
-    public final String XPID = "org.locationtech.udig.project.ui.toolManagers"; //$NON-NLS-1$
+    final String XPID = "org.locationtech.udig.project.ui.toolManagers"; //$NON-NLS-1$
     /**
      * Points to id field of extension point attribute
      */
-    public final String ATTR_ID = "id"; //$NON-NLS-1$
+    final String ATTR_ID = "id"; //$NON-NLS-1$
     
     /**
      * Points to class field of extension point attribute
      */
-    public final String ATTR_CLASS = "class"; //$NON-NLS-1$
+    final String ATTR_CLASS = "class"; //$NON-NLS-1$
     
     /**
      * Preference constant that can used to set and look up the default 
      * IToolManager. This can be set in plugin_customization.ini with the key
      * "org.locationtech.udig.project.ui/toolManager".
      */
-    public final String P_TOOL_MANAGER = "toolManager"; //$NON-NLS-1$
+    final String P_TOOL_MANAGER = "toolManager"; //$NON-NLS-1$
 
     void setCurrentEditor( MapPart editor );
 
@@ -67,8 +68,6 @@ public interface IToolManager {
      * @return a proxy action that can be put in other toolbars
      */
     IAction createToolAction( final String toolID, final String categoryID );
-
-    ActionToolCategory findActionCategory( String id );
 
     void contributeToMenu( IMenuManager manager );
     
@@ -120,7 +119,7 @@ public interface IToolManager {
      *
      * @param part
      */
-    public void unregisterActions( IWorkbenchPart  part );
+    void unregisterActions( IWorkbenchPart  part );
     /**
      * Retrieves the backward navigation action that is used by much of the map components such as
      * the MapEditor and the LayersView. Undoes the last Nav command set to the current map.
@@ -173,7 +172,7 @@ public interface IToolManager {
      * @param toolManager
      * @param bars
      */
-    public void contributeActionTools( IToolBarManager toolBarManager, IActionBars bars );
+    void contributeActionTools( IToolBarManager toolBarManager, IActionBars bars );
     
     /**
      * Adds modal tools contribution items to the toolbar.
@@ -184,7 +183,7 @@ public interface IToolManager {
      * @param toolManager
      * @param bars
      */
-    public void contributeModalTools( IToolBarManager toolBarManager, IActionBars bars );
+    void contributeModalTools( IToolBarManager toolBarManager, IActionBars bars );
 
     /**
      * Contributes the common global actions.
@@ -265,6 +264,39 @@ public interface IToolManager {
      * @param cursorID
      * @return
      */
-    public Cursor findToolCursor(String cursorID);
+    Cursor findToolCursor(String cursorID);
+
+    /**
+     * @param id Category id
+     * @return ModalToolCategory for given categoryId, null if it doesn't exists
+     */
+    ModalToolCategory findModalCategory(String categoryId);
+
+    /**
+     * @param categoryId Category id
+     * @return MenuToolCategory for given categoryId, null if it doesn't exists
+     */
+    MenuToolCategory findMenuCategory(String categoryId);
+
+    /**
+     * @param categoryId Category id
+     * @return ActionToolCategory for given categoryId, null if it doesn't exists
+     */
+    ActionToolCategory findActionCategory(String categoryId);
+
+    /**
+     * @return List of ActiveToolCategories
+     */
+    List<ActionToolCategory> getActiveToolCategories();
+
+    /**
+     * @return active ToolProxy or null if there isn't any
+     */
+    ToolProxy getActiveToolProxy();
+
+    /**
+     * @param toolProxy ToolProxy to set as active ToolProxy
+     */
+    void setActiveModalToolProxy(ToolProxy toolProxy);
 
 }

--- a/plugins/org.locationtech.udig.project.ui/src/org/locationtech/udig/project/ui/viewers/MapEditDomain.java
+++ b/plugins/org.locationtech.udig.project.ui/src/org/locationtech/udig/project/ui/viewers/MapEditDomain.java
@@ -10,22 +10,17 @@
  */
 package org.locationtech.udig.project.ui.viewers;
 
-import org.locationtech.udig.project.ui.ApplicationGIS;
-import org.locationtech.udig.project.ui.internal.MapToolEntry;
-import org.locationtech.udig.project.ui.internal.tool.display.ToolManager;
-import org.locationtech.udig.project.ui.internal.tool.display.ToolProxy;
-import org.locationtech.udig.project.ui.tool.IToolManager;
-import org.locationtech.udig.project.ui.tool.ModalTool;
-
 import org.eclipse.gef.DefaultEditDomain;
-import org.eclipse.gef.EditDomain;
 import org.eclipse.gef.palette.PaletteContainer;
 import org.eclipse.gef.palette.PaletteEntry;
 import org.eclipse.gef.palette.PaletteListener;
-import org.eclipse.gef.palette.PaletteRoot;
 import org.eclipse.gef.palette.ToolEntry;
 import org.eclipse.gef.ui.palette.PaletteViewer;
 import org.eclipse.ui.IEditorPart;
+import org.locationtech.udig.project.ui.ApplicationGIS;
+import org.locationtech.udig.project.ui.internal.MapToolEntry;
+import org.locationtech.udig.project.ui.internal.tool.display.ToolProxy;
+import org.locationtech.udig.project.ui.tool.IToolManager;
 
 /**
  * Domain responsible for managing the active tool; and advertising the set of
@@ -42,7 +37,7 @@ public class MapEditDomain extends DefaultEditDomain {
 
 	private PaletteListener paletteListener = new PaletteListener() {
 		public void activeToolChanged(PaletteViewer viewer, ToolEntry tool) {
-			ToolManager tools = (ToolManager) ApplicationGIS.getToolManager();
+			IToolManager tools = ApplicationGIS.getToolManager();
 			if (viewer != null) {
 			    ToolEntry entry = viewer.getActiveTool();
 				if (entry instanceof MapToolEntry) {

--- a/plugins/org.locationtech.udig.tool.select/src/org/locationtech/udig/tool/select/TableView.java
+++ b/plugins/org.locationtech.udig.tool.select/src/org/locationtech/udig/tool/select/TableView.java
@@ -19,50 +19,6 @@ import java.util.List;
 import java.util.Set;
 import java.util.concurrent.CopyOnWriteArraySet;
 
-import org.locationtech.udig.aoi.AOIListener;
-import org.locationtech.udig.aoi.IAOIService;
-import org.locationtech.udig.core.IBlockingProvider;
-import org.locationtech.udig.core.IProvider;
-import org.locationtech.udig.core.StaticBlockingProvider;
-import org.locationtech.udig.core.feature.AdaptableFeatureCollection;
-import org.locationtech.udig.core.filter.AdaptingFilter;
-import org.locationtech.udig.core.filter.AdaptingFilterFactory;
-import org.locationtech.udig.internal.ui.UDIGDropHandler;
-import org.locationtech.udig.project.EditManagerEvent;
-import org.locationtech.udig.project.IEditManagerListener;
-import org.locationtech.udig.project.ILayer;
-import org.locationtech.udig.project.ILayerListener;
-import org.locationtech.udig.project.IMapCompositionListener;
-import org.locationtech.udig.project.LayerEvent;
-import org.locationtech.udig.project.MapCompositionEvent;
-import org.locationtech.udig.project.command.AbstractCommand;
-import org.locationtech.udig.project.command.CompositeCommand;
-import org.locationtech.udig.project.command.MapCommand;
-import org.locationtech.udig.project.command.UndoableCommand;
-import org.locationtech.udig.project.command.UndoableComposite;
-import org.locationtech.udig.project.command.factory.EditCommandFactory;
-import org.locationtech.udig.project.command.factory.SelectionCommandFactory;
-import org.locationtech.udig.project.command.provider.FIDFeatureProvider;
-import org.locationtech.udig.project.internal.Layer;
-import org.locationtech.udig.project.internal.Map;
-import org.locationtech.udig.project.internal.ProjectPlugin;
-import org.locationtech.udig.project.internal.commands.edit.DeleteFeatureCommand;
-import org.locationtech.udig.project.internal.commands.edit.DeleteManyFeaturesCommand;
-import org.locationtech.udig.project.ui.ApplicationGIS;
-import org.locationtech.udig.project.ui.IUDIGView;
-import org.locationtech.udig.project.ui.internal.MapEditor;
-import org.locationtech.udig.project.ui.internal.MapPart;
-import org.locationtech.udig.project.ui.internal.tool.display.ToolManager;
-import org.locationtech.udig.project.ui.tool.IToolContext;
-import org.locationtech.udig.project.ui.tool.ToolsConstants;
-import org.locationtech.udig.tool.select.internal.Messages;
-import org.locationtech.udig.tool.select.internal.ZoomSelection;
-import org.locationtech.udig.ui.FeatureTableControl;
-import org.locationtech.udig.ui.IDropAction;
-import org.locationtech.udig.ui.IDropHandlerListener;
-import org.locationtech.udig.ui.IFeatureTableLoadingListener;
-import org.locationtech.udig.ui.PlatformGIS;
-import org.locationtech.udig.ui.ProgressManager;
 import org.eclipse.core.commands.AbstractHandler;
 import org.eclipse.core.commands.ExecutionEvent;
 import org.eclipse.core.commands.ExecutionException;
@@ -127,12 +83,50 @@ import org.geotools.data.Query;
 import org.geotools.factory.CommonFactoryFinder;
 import org.geotools.factory.GeoTools;
 import org.geotools.feature.FeatureCollection;
-import org.geotools.feature.FeatureIterator;
 import org.geotools.feature.Schema;
 import org.geotools.filter.FilterAttributeExtractor;
 import org.geotools.filter.IllegalFilterException;
 import org.geotools.geometry.jts.JTS;
 import org.geotools.referencing.CRS;
+import org.locationtech.udig.aoi.AOIListener;
+import org.locationtech.udig.aoi.IAOIService;
+import org.locationtech.udig.core.IBlockingProvider;
+import org.locationtech.udig.core.IProvider;
+import org.locationtech.udig.core.StaticBlockingProvider;
+import org.locationtech.udig.core.feature.AdaptableFeatureCollection;
+import org.locationtech.udig.core.filter.AdaptingFilter;
+import org.locationtech.udig.core.filter.AdaptingFilterFactory;
+import org.locationtech.udig.project.EditManagerEvent;
+import org.locationtech.udig.project.IEditManagerListener;
+import org.locationtech.udig.project.ILayer;
+import org.locationtech.udig.project.ILayerListener;
+import org.locationtech.udig.project.IMapCompositionListener;
+import org.locationtech.udig.project.LayerEvent;
+import org.locationtech.udig.project.MapCompositionEvent;
+import org.locationtech.udig.project.command.AbstractCommand;
+import org.locationtech.udig.project.command.CompositeCommand;
+import org.locationtech.udig.project.command.MapCommand;
+import org.locationtech.udig.project.command.UndoableCommand;
+import org.locationtech.udig.project.command.UndoableComposite;
+import org.locationtech.udig.project.command.factory.EditCommandFactory;
+import org.locationtech.udig.project.command.factory.SelectionCommandFactory;
+import org.locationtech.udig.project.command.provider.FIDFeatureProvider;
+import org.locationtech.udig.project.internal.Layer;
+import org.locationtech.udig.project.internal.Map;
+import org.locationtech.udig.project.internal.ProjectPlugin;
+import org.locationtech.udig.project.internal.commands.edit.DeleteFeatureCommand;
+import org.locationtech.udig.project.internal.commands.edit.DeleteManyFeaturesCommand;
+import org.locationtech.udig.project.ui.ApplicationGIS;
+import org.locationtech.udig.project.ui.IUDIGView;
+import org.locationtech.udig.project.ui.internal.MapPart;
+import org.locationtech.udig.project.ui.tool.IToolContext;
+import org.locationtech.udig.project.ui.tool.ToolsConstants;
+import org.locationtech.udig.tool.select.internal.Messages;
+import org.locationtech.udig.tool.select.internal.ZoomSelection;
+import org.locationtech.udig.ui.FeatureTableControl;
+import org.locationtech.udig.ui.IFeatureTableLoadingListener;
+import org.locationtech.udig.ui.PlatformGIS;
+import org.locationtech.udig.ui.ProgressManager;
 import org.opengis.feature.Feature;
 import org.opengis.feature.FeatureVisitor;
 import org.opengis.feature.simple.SimpleFeature;
@@ -143,10 +137,8 @@ import org.opengis.filter.Filter;
 import org.opengis.filter.FilterFactory;
 import org.opengis.filter.FilterFactory2;
 import org.opengis.filter.Id;
-import org.opengis.filter.IncludeFilter;
 import org.opengis.filter.identity.FeatureId;
 import org.opengis.filter.spatial.BBOX;
-import org.opengis.filter.spatial.Intersects;
 import org.opengis.referencing.FactoryException;
 import org.opengis.referencing.crs.CoordinateReferenceSystem;
 import org.opengis.referencing.operation.MathTransform;
@@ -154,7 +146,6 @@ import org.opengis.referencing.operation.TransformException;
 
 import com.vividsolutions.jts.geom.Envelope;
 import com.vividsolutions.jts.geom.Geometry;
-import com.vividsolutions.jts.geom.GeometryFactory;
 
 /**
  * Table view for selected Layer, may choose
@@ -593,7 +584,7 @@ public class TableView extends ViewPart implements ISelectionProvider, IUDIGView
         
         this.promoteSelection=new PromoteSelectionAction();
         
-        zoom=((ToolManager) ApplicationGIS.getToolManager()).createToolAction(ZoomSelection.ID, ToolsConstants.ZOOM_CATEGORY);
+        zoom=ApplicationGIS.getToolManager().createToolAction(ZoomSelection.ID, ToolsConstants.ZOOM_CATEGORY);
         icon = AbstractUIPlugin.imageDescriptorFromPlugin( SelectPlugin.ID, "icons/elcl16/zoom_select_co.png"); //$NON-NLS-1$
         zoom.setImageDescriptor( icon );
         zoom.setText(Messages.TableView_zoomToolText);
@@ -1379,20 +1370,21 @@ public class TableView extends ViewPart implements ISelectionProvider, IUDIGView
 	        searchWidget.setEditable(true);
 	        searchWidget.addListener(SWT.FocusIn, new Listener(){
 	            public void handleEvent( Event e ) {
-                    if( searchWidget.getForeground().equals(systemColor) ){
-                        searchWidget.setForeground(e.display.getSystemColor(SWT.COLOR_BLACK));
-                        searchWidget.setText(""); //$NON-NLS-1$
-                    }
-					ApplicationGIS.getToolManager().unregisterActions(TableView.this);
+                        if (searchWidget.getForeground().equals(systemColor)) {
+                            searchWidget.setForeground(e.display.getSystemColor(SWT.COLOR_BLACK));
+                            searchWidget.setText(""); //$NON-NLS-1$
+                        }
+                        ApplicationGIS.getToolManager().unregisterActions(TableView.this);
 	            }
 	        });
 	        searchWidget.addListener(SWT.FocusOut, new Listener(){
 	            public void handleEvent( Event e ) {
-	                    if( !searchWidget.getForeground().equals(systemColor) && searchWidget.getText().trim().length()==0 ){
-	                        searchWidget.setForeground(systemColor);
-	                        searchWidget.setText(""); //$NON-NLS-1$
-	                    }
-	                    ApplicationGIS.getToolManager().registerActionsWithPart(TableView.this);
+                        if (!searchWidget.getForeground().equals(systemColor)
+                                && searchWidget.getText().trim().length() == 0) {
+                            searchWidget.setForeground(systemColor);
+                            searchWidget.setText(""); //$NON-NLS-1$
+                        }
+                        ApplicationGIS.getToolManager().registerActionsWithPart(TableView.this);
 	            }
 	        });
 			searchWidget.addListener(SWT.KeyUp, this);	


### PR DESCRIPTION
change visibility of category finder methods in ToolMnager to public and made them final to prohibit their subclassing.

Signed-off-by: Nikolaos Pringouris <nprigour@gmail.com>