### PR TITLE
Fix exceptions thrown by LineTool and PolygonTool

### DIFF
--- a/plugins/org.locationtech.udig.tool.edit/src/org/locationtech/udig/tools/edit/impl/LineTool.java
+++ b/plugins/org.locationtech.udig.tool.edit/src/org/locationtech/udig/tools/edit/impl/LineTool.java
@@ -124,10 +124,12 @@ public class LineTool extends AbstractEditTool {
         helper.add( new MoveVertexBehaviour() );
         helper.add( new MoveGeometryBehaviour());
         helper.stopMutualExclusiveList();
+        helper.stopAdvancedFeatures();
         
-
+        helper.startAdvancedFeatures();
         helper.add( new SelectVerticesWithBoxBehaviour() );
         helper.stopAdvancedFeatures();
+        
         helper.add( new AcceptOnDoubleClickBehaviour() );
         helper.add( new SetSnapSizeBehaviour());
         helper.add( new StartExtendLineBehaviour() );

--- a/plugins/org.locationtech.udig.tool.edit/src/org/locationtech/udig/tools/edit/impl/PolygonTool.java
+++ b/plugins/org.locationtech.udig.tool.edit/src/org/locationtech/udig/tools/edit/impl/PolygonTool.java
@@ -112,10 +112,12 @@ public class PolygonTool extends AbstractEditTool {
         helper.add( new MoveVertexBehaviour() );
         helper.add( new MoveGeometryBehaviour());
         helper.stopMutualExclusiveList();
+        helper.stopAdvancedFeatures();
         
-        
+        helper.startAdvancedFeatures();
         helper.add( new SelectVerticesWithBoxBehaviour() );
         helper.stopAdvancedFeatures();
+        
         helper.add( new AcceptOnDoubleClickBehaviour() );
         helper.add( new SetSnapSizeBehaviour());
         helper.done();


### PR DESCRIPTION
With "Advanced Editing" enabled in Preferences, PolygonTool and LineTool will throw many exceptions when dragging existing vertices or dragging the entire geometry.

AdvancedFeaturesEventBehavior attempts to composite its sub-behaviours. SelectVerticesWithBoxBehaviour cannot be successfully composited with the move behaviours since they both require the EditToolHandler lock.

The selection command is added to the undo stack, which is consistent with the Edit Geometry (SelectionTool) tool.