### PR TITLE
Return a safe default rather than null.

### DIFF
--- a/plugins/org.locationtech.udig.project/src/org/locationtech/udig/project/internal/render/impl/ViewportModelImpl.java
+++ b/plugins/org.locationtech.udig.project/src/org/locationtech/udig/project/internal/render/impl/ViewportModelImpl.java
@@ -685,7 +685,7 @@ public class ViewportModelImpl extends EObjectImpl implements ViewportModel {
      */
     public AffineTransform worldToScreenTransform() {
         if (!validState())
-            return null;
+            return new AffineTransform(); //Identity (screen-space is arbitrary here.)
         // set up the affine transform and calculate scale values
         return worldToScreenTransform(getBounds(), getRenderManagerInternal().getMapDisplay()
                 .getDisplaySize());


### PR DESCRIPTION
The interface is not clear whether null is allowed to be returned here. However, no clients currently test for null. This now returns a safe default instead.
Signed-off-by: Adam Kater <adam.kater@rgi-corp.com>