### PR TITLE
upgrade maven-dependency-plugin to latest 3.1.1

### DIFF
--- a/pom-libs.xml
+++ b/pom-libs.xml
@@ -105,7 +105,7 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-dependency-plugin</artifactId>
-                    <version>2.3</version>
+                    <version>3.1.1</version>
                 </plugin>
             
                 <plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -317,7 +317,7 @@
 
                 <plugin>
                    <artifactId>maven-dependency-plugin</artifactId>
-                   <version>2.9</version>
+                   <version>3.1.1</version>
                 </plugin>
 
                 <plugin>


### PR DESCRIPTION
to allow parallel builds w/o warnings such as follows:

```
[WARNING] *****************************************************************
[WARNING] The following plugins are not marked @threadSafe in uDig 3rd-Party Core libraries Download:
[WARNING] org.apache.maven.plugins:maven-dependency-plugin:2.3
[WARNING] Enable debug to see more precisely which goals are not marked @threadSafe.
[WARNING] *****************************************************************
```