### PR TITLE
[HK] hint to consult error log on failures

### DIFF
--- a/plugins/org.locationtech.udig.catalog.ui/src/org/locationtech/udig/catalog/ui/internal/messages.properties
+++ b/plugins/org.locationtech.udig.catalog.ui/src/org/locationtech/udig/catalog/ui/internal/messages.properties
@@ -13,7 +13,7 @@ CatalogExport_cannotWrite = Cannot write to file {0}
 
 CatalogExport_exportLayersTask = Export Resource to Shapefile
 
-CatalogExport_layerFail = Failed to export layer {0}
+CatalogExport_layerFail = Failed to export layer {0}\nSee Error Log for details
 
 CatalogExport_reprojectError = \ cannot be reprojected to chosen projection
 


### PR DESCRIPTION
Just a minor improment if layer export fails to give users a hint to have a look into error logfile to get details about the cause.

Change-Id: I2f96c7665a73705e50de5cf711f8a90434ec9c5b
Signed-off-by: Frank Gasdorf <fgdrf@users.sourceforge.net>