### PR TITLE
allows to hide composite renderer jobs

### DIFF
--- a/plugins/org.locationtech.udig.project.tests/src/org/locationtech/udig/project/internal/render/impl/CompositeRendererHideJobsTest.java
+++ b/plugins/org.locationtech.udig.project.tests/src/org/locationtech/udig/project/internal/render/impl/CompositeRendererHideJobsTest.java
@@ -1,0 +1,55 @@
+package org.locationtech.udig.project.internal.render.impl;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+
+import org.eclipse.ui.preferences.ScopedPreferenceStore;
+import org.junit.Test;
+import org.locationtech.udig.project.internal.ProjectPlugin;
+import org.locationtech.udig.project.preferences.PreferenceConstants;
+
+public class CompositeRendererHideJobsTest {
+
+    class TestRenderer extends RenderExecutorComposite {
+        public RenderJob getRenderJob() {
+            return renderJob;
+        }
+    }
+
+    @Test
+    public void defaultHideRenderJobIsFalse() {
+        ScopedPreferenceStore preferenceStore = ProjectPlugin.getPlugin().getPreferenceStore();
+        assertFalse(preferenceStore.getDefaultBoolean(PreferenceConstants.P_HIDE_RENDER_JOB));
+    }
+
+    @Test
+    public void jobIsShownInProgressView() {
+        assertJobHasSystemState(false, false);
+    }
+
+    @Test
+    public void jobIsSystemJobAndThereforeNotVisibleInProgressView() {
+        assertJobHasSystemState(true, false);
+    }
+
+    @Test
+    public void jobIsStillSystemJobAfterRenderIsSet() {
+        assertJobHasSystemState(true, true);
+    }
+
+    @Test
+    public void jobIsStillNonSystemJobAfterRenderIsSet() {
+        assertJobHasSystemState(false, true);
+    }
+
+    private void assertJobHasSystemState(boolean expectedState, boolean setRenderer) {
+        ScopedPreferenceStore preferenceStore = ProjectPlugin.getPlugin().getPreferenceStore();
+        preferenceStore.setValue(PreferenceConstants.P_HIDE_RENDER_JOB, expectedState);
+        TestRenderer testRenderer = new TestRenderer();
+        if (setRenderer) {
+            testRenderer.setRenderer(null);
+        }
+        assertEquals(expectedState, testRenderer.getRenderJob().isSystem());
+    }
+
+}

--- a/plugins/org.locationtech.udig.project/src/org/locationtech/udig/project/internal/render/impl/CompositeRendererImpl.java
+++ b/plugins/org.locationtech.udig.project/src/org/locationtech/udig/project/internal/render/impl/CompositeRendererImpl.java
@@ -21,6 +21,12 @@ import java.util.SortedSet;
 import java.util.TreeSet;
 import java.util.concurrent.CopyOnWriteArraySet;
 
+import org.eclipse.core.runtime.IProgressMonitor;
+import org.eclipse.emf.common.notify.Notification;
+import org.eclipse.emf.ecore.EObject;
+import org.eclipse.jface.preference.IPreferenceStore;
+import org.eclipse.jface.preference.PreferenceConverter;
+import org.eclipse.swt.graphics.RGB;
 import org.locationtech.udig.project.IMap;
 import org.locationtech.udig.project.ProjectBlackboardConstants;
 import org.locationtech.udig.project.internal.ProjectPlugin;
@@ -39,13 +45,6 @@ import org.locationtech.udig.project.render.ILabelPainter;
 import org.locationtech.udig.project.render.IRenderContext;
 import org.locationtech.udig.project.render.RenderException;
 
-import org.eclipse.core.runtime.IProgressMonitor;
-import org.eclipse.emf.common.notify.Notification;
-import org.eclipse.emf.ecore.EObject;
-import org.eclipse.jface.preference.IPreferenceStore;
-import org.eclipse.jface.preference.PreferenceConverter;
-import org.eclipse.swt.graphics.RGB;
-
 /**
  * <ul>
  * <li>Combines the output from several renderer into a single image.</li>
@@ -58,6 +57,7 @@ public class CompositeRendererImpl extends RendererImpl implements MultiLayerRen
 
     private final static Comparator<? super RenderExecutor> comparator = new Comparator<RenderExecutor>(){
         
+        @Override
         public int compare(RenderExecutor e1,RenderExecutor e2){
             
             return e1.getContext().getLayer().compareTo(
@@ -66,21 +66,6 @@ public class CompositeRendererImpl extends RendererImpl implements MultiLayerRen
         }
     };
 
-    /**
-     * <!-- begin-user-doc --> <!-- end-user-doc -->
-     * 
-     * @generated NOT
-     */
-    public static final String copyright = 
-          "uDig - User Friendly Desktop Internet GIS client\n"
-        + "http://udig.refractions.net\n"
-        + "(C) 2004-2012, Refractions Research Inc.\n"
-        + "\n\n"
-        + "All rights reserved. This program and the accompanying materials\n"
-        + "are made available under the terms of the Eclipse Public License v1.0\n"
-        + "(http://www.eclipse.org/legal/epl-v10.html), and the Refractions BSD\n"
-        + "License v1.0 (http://udig.refractions.net/files/bsd3-v10.html).\n";
-    
     static final AffineTransform IDENTITY = new AffineTransform();
     CompositeContextListener contextListener = new CompositeContextListener(){
    
@@ -97,6 +82,7 @@ public class CompositeRendererImpl extends RendererImpl implements MultiLayerRen
             }
         }
 
+        @Override
         public void notifyChanged( CompositeRenderContext context, List<RenderContext> contexts, boolean added ) {
             if( added ){
                 add(contexts);
@@ -158,6 +144,7 @@ public class CompositeRendererImpl extends RendererImpl implements MultiLayerRen
             /**
              * @see org.locationtech.udig.project.internal.render.RenderListenerAdapter#renderDisposed(org.eclipse.emf.common.notify.Notification)
              */
+            @Override
             protected void renderDisposed( Notification msg ) {
                 EObject obj = (EObject) getTarget();
                 obj.eAdapters().remove(this);
@@ -166,10 +153,12 @@ public class CompositeRendererImpl extends RendererImpl implements MultiLayerRen
             /**
              * @see org.locationtech.udig.project.internal.render.RenderListenerAdapter#renderDone()
              */
+            @Override
             protected void renderDone() {
                setState(DONE);
             }
 
+            @Override
             protected void renderRequest() {
                 setRenderBounds(executor.getRenderBounds());
                 setState(RENDER_REQUEST);
@@ -183,6 +172,7 @@ public class CompositeRendererImpl extends RendererImpl implements MultiLayerRen
             /**
              * @see org.locationtech.udig.project.internal.render.RenderListenerAdapter#renderUpdate()
              */
+            @Override
             protected void renderUpdate() {
                 synchronized (CompositeRendererImpl.this) {
 //                    try {
@@ -200,6 +190,7 @@ public class CompositeRendererImpl extends RendererImpl implements MultiLayerRen
     /**
      * @see org.locationtech.udig.project.internal.render.impl.RendererImpl#dispose()
      */
+    @Override
     public synchronized void dispose() {
         for (RenderExecutor renderer : getRenderExecutors()) {
             renderer.dispose();
@@ -214,7 +205,7 @@ public class CompositeRendererImpl extends RendererImpl implements MultiLayerRen
      */
     protected RenderExecutor findExecutor( IRenderContext context ) {
         for( Iterator<RenderExecutor> eIter = getRenderExecutors().iterator(); eIter.hasNext(); ) {
-            RenderExecutor executor = (RenderExecutor) eIter.next();
+            RenderExecutor executor = eIter.next();
             if (executor.getRenderer().getContext().equals(context))
                 return executor;
         }
@@ -224,6 +215,7 @@ public class CompositeRendererImpl extends RendererImpl implements MultiLayerRen
     /**
      * @see org.locationtech.udig.project.internal.render.impl.RendererImpl#getContext()
      */
+    @Override
     public CompositeRenderContext getContext() {
         return (CompositeRenderContext) super.getContext();
     }
@@ -301,6 +293,7 @@ public class CompositeRendererImpl extends RendererImpl implements MultiLayerRen
      * @throws RenderException
      * @generated NOT
      */
+    @Override
     public void refreshImage() throws RenderException {
         refreshImage(true);
     }
@@ -413,6 +406,7 @@ public class CompositeRendererImpl extends RendererImpl implements MultiLayerRen
      * @throws RenderException
      * @generated NOT
      */
+    @Override
     public void render( Graphics2D destination, IProgressMonitor monitor ) throws RenderException {
         // notify that they are starting
         for( RenderExecutor executor : renderExecutors ) {
@@ -436,6 +430,7 @@ public class CompositeRendererImpl extends RendererImpl implements MultiLayerRen
      * @throws RenderException
      * @see org.locationtech.udig.project.internal.render.Renderer#render(org.locationtech.jts.geom.Envelope)
      */
+    @Override
     public void render( IProgressMonitor monitor ) throws RenderException {
         if (getRenderExecutors().size() == 0)
             setState(DONE);
@@ -448,6 +443,7 @@ public class CompositeRendererImpl extends RendererImpl implements MultiLayerRen
     /**
      * @see org.locationtech.udig.project.internal.render.impl.RendererImpl#setContext(org.locationtech.udig.project.render.RenderContext)
      */
+    @Override
     @SuppressWarnings("unchecked")
     public void setContext( IRenderContext newContext ) {
         if (context != null) {

--- a/plugins/org.locationtech.udig.project/src/org/locationtech/udig/project/preferences/PreferenceConstants.java
+++ b/plugins/org.locationtech.udig.project/src/org/locationtech/udig/project/preferences/PreferenceConstants.java
@@ -15,16 +15,19 @@ import org.locationtech.udig.project.internal.render.impl.ScaleUtils;
 /**
  * Constant definitions for plug-in preferences
  */
-public class PreferenceConstants {
+public final class PreferenceConstants {
+    private PreferenceConstants() {
+    }
 
-	public static final String P_ANTI_ALIASING = "antiAliasingPreference"; //$NON-NLS-1$
+    public static final String P_ANTI_ALIASING = "antiAliasingPreference"; //$NON-NLS-1$
 
-	public static final String P_TRANSPARENCY = "transparencyPreference"; //$NON-NLS-1$
+    public static final String P_TRANSPARENCY = "transparencyPreference"; //$NON-NLS-1$
 
-	/**
-	 * The default crs assigned to a new map.  -1 indicates the crs of the first layer added should be used.
-	 */
-	public static final String P_DEFAULT_CRS = "defaultCRSPreference"; //$NON-NLS-1$
+    /**
+     * The default crs assigned to a new map. -1 indicates the crs of the first layer added should
+     * be used.
+     */
+    public static final String P_DEFAULT_CRS = "defaultCRSPreference"; //$NON-NLS-1$
 
     public static final String P_DEFAULT_PALETTE = "defaultPalette"; //$NON-NLS-1$
 
@@ -57,7 +60,14 @@ public class PreferenceConstants {
     public static final String P_MAX_UNDO = "P_MAX_UNDO"; //$NON-NLS-1$
 
     public static final String P_DEFAULT_FEATURE_EDITOR = "P_DEFAULT_FEATURE_EDITOR"; //$NON-NLS-1$
-    
+
+    /**
+     * Constant to denote that the render job is to be shown in the UI. Per default render jobs are
+     * shown in progress view and are not hidden.
+     * <p>
+     * If the property is <code>true</code> then jobs are not shown in Progress View.
+     */
+    public static final String P_HIDE_RENDER_JOB = "HIDE_RENDER_JOB"; //$NON-NLS-1$
 
     /**
      * The on/off switch for using tiled rendering
@@ -75,8 +85,7 @@ public class PreferenceConstants {
      * 
      */
     public static final String P_MINIMUM_ZOOM_SCALE = "P_MINIMUM_ZOOM_SCALE"; //$NON-NLS-1$
-    
-    
+
     /**
      * If this property contains <code>true</code> then no matter what are the bounds of feature events,
      * all the viewport will be refreshed by render manager.
@@ -89,9 +98,7 @@ public class PreferenceConstants {
      * 
      */
     public static final String P_FEATURE_EVENT_REFRESH_ALL = "P_FEATURE_EVENT_REFRESH_ALL"; //$NON-NLS-1$
-    
-    
-    
+
     /**
      * This property says to <code>LabelCacheDefault</code> whether to ignore labels overlapping checkings
      * or to force them no matter what is a "spaceAround" parameter of the TextSymbolizer in SLD style.
@@ -100,12 +107,10 @@ public class PreferenceConstants {
      * are rendered.
      */
     public static final String P_IGNORE_LABELS_OVERLAPPING = "P_IGNORE_LABELS_OVERLAPPING"; //$NON-NLS-1$
-    
-    
-    
+
     /**
-     * The property forces to make checking for layers diplicating - from the same georesource - in context
-     * of the map where new layers are added.
+     * The property forces to make checking for layers duplicating - from the same georesource - in
+     * context of the map where new layers are added.
      * <p>
      * If the property is <code>true</code> then no duplicate layers are possible.
      */
@@ -116,5 +121,5 @@ public class PreferenceConstants {
      *
      * @see ScaleUtils#calculateClosestScale
      */
-	public static final String P_ZOOM_REQUIRED_CLOSENESS = "P_ZOOM_REQUIRED_CLOSENESS";
+    public static final String P_ZOOM_REQUIRED_CLOSENESS = "P_ZOOM_REQUIRED_CLOSENESS";
 }

--- a/plugins/org.locationtech.udig.project/src/org/locationtech/udig/project/preferences/PreferenceInitializer.java
+++ b/plugins/org.locationtech.udig.project/src/org/locationtech/udig/project/preferences/PreferenceInitializer.java
@@ -10,47 +10,51 @@
  */
 package org.locationtech.udig.project.preferences;
 
-import org.locationtech.udig.project.internal.ProjectPlugin;
-import org.locationtech.udig.project.internal.interceptor.ResourceCacheInterceptor;
-
 import org.eclipse.core.runtime.preferences.AbstractPreferenceInitializer;
 import org.eclipse.jface.preference.IPreferenceStore;
 import org.eclipse.jface.preference.PreferenceConverter;
 import org.eclipse.swt.graphics.RGB;
+import org.locationtech.udig.project.internal.ProjectPlugin;
+import org.locationtech.udig.project.internal.interceptor.ResourceCacheInterceptor;
 
 /**
  * Class used to initialize default preference values.
  */
 public class PreferenceInitializer extends AbstractPreferenceInitializer {
-    public static final String P_DEFAULT_FEATURE_EDITOR_VALUE="org.locationtech.udig.tool.select.view"; //$NON-NLS-1$
-	public void initializeDefaultPreferences() {
-		IPreferenceStore store = ProjectPlugin.getPlugin()
-				.getPreferenceStore();
+    public static final String P_DEFAULT_FEATURE_EDITOR_VALUE = "org.locationtech.udig.tool.select.view"; //$NON-NLS-1$
+
+    @Override
+    public void initializeDefaultPreferences() {
+        IPreferenceStore store = ProjectPlugin.getPlugin().getPreferenceStore();
         store.setDefault(PreferenceConstants.P_ZOOM_REQUIRED_CLOSENESS, 0.7);
         store.setDefault(PreferenceConstants.P_REMOVE_LAYERS, true);
         store.setDefault(PreferenceConstants.P_WARN_IRREVERSIBLE_COMMAND, true);
         store.setDefault(PreferenceConstants.P_ANTI_ALIASING, true);
-		store.setDefault(PreferenceConstants.P_DEFAULT_CRS, -1);
+        store.setDefault(PreferenceConstants.P_DEFAULT_CRS, -1);
         store.setDefault(PreferenceConstants.P_TRANSPARENCY, true);
         store.setDefault(PreferenceConstants.P_TILING_RENDERER, false);
         store.setDefault(PreferenceConstants.P_HIGHLIGHT, PreferenceConstants.P_HIGHLIGHT_NONE);
         store.setDefault(PreferenceConstants.P_DEFAULT_PALETTE, "Dark2"); //$NON-NLS-1$
         store.setDefault(PreferenceConstants.P_STYLE_DEFAULT_PERPENDICULAR_OFFSET, "10"); //$NON-NLS-1$
-        store.setDefault(PreferenceConstants.P_LAYER_RESOURCE_CACHING_STRATEGY, ResourceCacheInterceptor.ID);
+        store.setDefault(PreferenceConstants.P_LAYER_RESOURCE_CACHING_STRATEGY,
+                ResourceCacheInterceptor.ID);
         store.setDefault(PreferenceConstants.P_PROJECT_DELETE_FILES, true);
         store.setDefault(PreferenceConstants.P_SHOW_ANIMATIONS, true);
         store.setDefault(PreferenceConstants.P_MAX_UNDO, 10);
-        store.setDefault(PreferenceConstants.P_DEFAULT_FEATURE_EDITOR, P_DEFAULT_FEATURE_EDITOR_VALUE );
-        
-        PreferenceConverter.setDefault(store, PreferenceConstants.P_BACKGROUND, new RGB(255,255,255));
-        PreferenceConverter.setDefault(store,PreferenceConstants.P_SELECTION_COLOR, new RGB(255,255,0));
-        PreferenceConverter.setDefault(store,PreferenceConstants.P_SELECTION2_COLOR, new RGB(0,0,0));
-        
-        
-        
-      store.setDefault(PreferenceConstants.P_FEATURE_EVENT_REFRESH_ALL, false);
-      store.setDefault(PreferenceConstants.P_IGNORE_LABELS_OVERLAPPING, false);
-      store.setDefault(PreferenceConstants.P_CHECK_DUPLICATE_LAYERS, false);
+        store.setDefault(PreferenceConstants.P_DEFAULT_FEATURE_EDITOR,
+                P_DEFAULT_FEATURE_EDITOR_VALUE);
+
+        PreferenceConverter.setDefault(store, PreferenceConstants.P_BACKGROUND,
+                new RGB(255, 255, 255));
+        PreferenceConverter.setDefault(store, PreferenceConstants.P_SELECTION_COLOR,
+                new RGB(255, 255, 0));
+        PreferenceConverter.setDefault(store, PreferenceConstants.P_SELECTION2_COLOR,
+                new RGB(0, 0, 0));
+
+        store.setDefault(PreferenceConstants.P_FEATURE_EVENT_REFRESH_ALL, false);
+        store.setDefault(PreferenceConstants.P_IGNORE_LABELS_OVERLAPPING, false);
+        store.setDefault(PreferenceConstants.P_CHECK_DUPLICATE_LAYERS, false);
+        store.setDefault(PreferenceConstants.P_HIDE_RENDER_JOB, false);
     }
 
 }


### PR DESCRIPTION
This changeset allows to configure uDig to avoid showing Composite renderer jobs are displayed in Progress View. 

option to enable it (e.g. config.ini) : 

`org.locationtech.udig.project/HIDE_RENDER_JOB=true`

Change-Id: Ic3285ab2b36518b534fe26b904056c81f9a73149
Signed-off-by: Frank Gasdorf <fgdrf@users.sourceforge.net>