### PR TITLE
Feature #421 : allows to disable CRS selection in Map

### DIFF
--- a/docs/build.xml
+++ b/docs/build.xml
@@ -89,9 +89,9 @@
     </target>
 
     <target name="sphinx" if="sphinx.available">
-        <echo message="Running sphinx-build -D release=${project.version} -b ${build} -d &quot;${build.directory}/${id}/doctrees&quot; . &quot;${build.directory}/${id}/${build}&quot;"/>
+        <echo message="Running sphinx-build -D release=${project.version} -W -b ${build} -d &quot;${build.directory}/${id}/doctrees&quot; . &quot;${build.directory}/${id}/${build}&quot;"/>
         <exec executable="sphinx-build" failonerror="true" dir="${basedir}/${id}">
-            <arg line="-D release=${project.version} -b ${build} -d &quot;${build.directory}/${id}/doctrees&quot; . &quot;${build.directory}/${id}/${build}&quot;"/>
+            <arg line="-D release=${project.version} -W -b ${build} -d &quot;${build.directory}/${id}/doctrees&quot; . &quot;${build.directory}/${id}/${build}&quot;"/>
         </exec>
     </target>
 
@@ -102,9 +102,9 @@
     </target>
 
     <target name="sphinx-simple" if="sphinx.available">
-        <echo message="Running sphinx-build -D release=${project.version} -b ${build} -d &quot;${build.directory}/${id}/doctrees&quot; . &quot;${build.directory}/${id}/${build}&quot;"/>
+        <echo message="Running sphinx-build -D release=${project.version} -W -b ${build} -d &quot;${build.directory}/${id}/doctrees&quot; . &quot;${build.directory}/${id}/${build}&quot;"/>
         <exec executable="sphinx-build" failonerror="true" dir="${basedir}/${id}">
-            <arg line="-D release=${project.version} -D html_theme='simple' -D html_title='User Guide' -b ${build} -d &quot;${build.directory}/${id}/doctrees&quot; . &quot;${build.directory}/${id}/simple&quot;"/>
+            <arg line="-D release=${project.version} -D html_theme='simple' -D html_title='User Guide' -W -b ${build} -d &quot;${build.directory}/${id}/doctrees&quot; . &quot;${build.directory}/${id}/simple&quot;"/>
         </exec>
     </target>
 

--- a/docs/build.xml
+++ b/docs/build.xml
@@ -89,9 +89,9 @@
     </target>
 
     <target name="sphinx" if="sphinx.available">
-        <echo message="Running sphinx-build -D release=${project.version} -W -b ${build} -d &quot;${build.directory}/${id}/doctrees&quot; . &quot;${build.directory}/${id}/${build}&quot;"/>
+        <echo message="Running sphinx-build -D release=${project.version} -b ${build} -d &quot;${build.directory}/${id}/doctrees&quot; . &quot;${build.directory}/${id}/${build}&quot;"/>
         <exec executable="sphinx-build" failonerror="true" dir="${basedir}/${id}">
-            <arg line="-D release=${project.version} -W -b ${build} -d &quot;${build.directory}/${id}/doctrees&quot; . &quot;${build.directory}/${id}/${build}&quot;"/>
+            <arg line="-D release=${project.version} -b ${build} -d &quot;${build.directory}/${id}/doctrees&quot; . &quot;${build.directory}/${id}/${build}&quot;"/>
         </exec>
     </target>
 
@@ -102,9 +102,9 @@
     </target>
 
     <target name="sphinx-simple" if="sphinx.available">
-        <echo message="Running sphinx-build -D release=${project.version} -W -b ${build} -d &quot;${build.directory}/${id}/doctrees&quot; . &quot;${build.directory}/${id}/${build}&quot;"/>
+        <echo message="Running sphinx-build -D release=${project.version} -b ${build} -d &quot;${build.directory}/${id}/doctrees&quot; . &quot;${build.directory}/${id}/${build}&quot;"/>
         <exec executable="sphinx-build" failonerror="true" dir="${basedir}/${id}">
-            <arg line="-D release=${project.version} -D html_theme='simple' -D html_title='User Guide' -W -b ${build} -d &quot;${build.directory}/${id}/doctrees&quot; . &quot;${build.directory}/${id}/simple&quot;"/>
+            <arg line="-D release=${project.version} -D html_theme='simple' -D html_title='User Guide' -b ${build} -d &quot;${build.directory}/${id}/doctrees&quot; . &quot;${build.directory}/${id}/simple&quot;"/>
         </exec>
     </target>
 

--- a/docs/user/en/reference/Map editor.rst
+++ b/docs/user/en/reference/Map editor.rst
@@ -71,6 +71,8 @@ Scale
 
 Shows the scale of the map. You can enter a new number here to change the scale to an exact value.
 
+.. _map_editor_crs_display:
+
 Coordinate Reference System Display
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/docs/user/en/reference/Project Preferences.rst
+++ b/docs/user/en/reference/Project Preferences.rst
@@ -40,7 +40,7 @@ In case the organization would like to disallow to change CRS, the Preference Co
 
 .. code-block:: python
 
-    org.locationtech.udig.project\DISABLE_CRS_SELECTION=true
+    org.locationtech.udig.project/DISABLE_CRS_SELECTION=true
 
 can be used to disable CRS Chooser Dialog. If not set - this is the default (*false*) - the
 Application behaves like before. There is no option for this Prefenences in the Preferences Dialog to change behavior on demand.
@@ -55,7 +55,7 @@ of other long-running Tasks.
 
 .. code-block:: python
 
-    org.locationtech.udig.project\HIDE_RENDER_JOB=true
+    org.locationtech.udig.project/HIDE_RENDER_JOB=true
 
 can be used to hide Render Jobs. If not set - this is the default (*false*) - the
 Application behaves like before and the Jobs are shown in Progress View. There is no option for this Prefenences in
@@ -114,7 +114,7 @@ The default value is -1.
 
 .. code-block:: python
 
-    org.locationtech.udig.project\defaultCRSPreference=<EPSG-Code>
+    org.locationtech.udig.project/defaultCRSPreference=<EPSG-Code>
 
 For <EPSG-Code> use the number such es 4326 for EPSG:4326.
 

--- a/docs/user/en/reference/Project Preferences.rst
+++ b/docs/user/en/reference/Project Preferences.rst
@@ -29,6 +29,8 @@ Number of possible steps to undo
 
 Default is 10
 
+.. _pref_project_DISABLE_CRS_SELECTION:
+
 Disable CRS Chooser
 ```````````````````
 In the Map there is an option to choose different :ref:`Coordinate Reference System Display` for the Map. See
@@ -42,6 +44,8 @@ In case the organization would like to disallow to change CRS, the Preference Co
 
 can be used to disable CRS Chooser Dialog. If not set - this is the default (*false*) - the
 Application behaves like before. There is no option for this Prefenences in the Preferences Dialog to change behavior on demand.
+
+.. _pref_project_HIDE_RENDER_JOB:
 
 Hide Render Jobs in Progress View
 `````````````````````````````````
@@ -112,7 +116,7 @@ The default value is -1.
 
     org.locationtech.udig.project\defaultCRSPreference=<EPSG-Code>
 
-For <EPSG-Code> use the number such es 4326 for EPSG:4326 (WGS 84).
+For <EPSG-Code> use the number such es 4326 for EPSG:4326.
 
 Default map background color
 ````````````````````````````

--- a/docs/user/en/reference/Project Preferences.rst
+++ b/docs/user/en/reference/Project Preferences.rst
@@ -33,7 +33,7 @@ Default is 10
 
 Disable CRS Chooser
 ```````````````````
-In the Map there is an option to choose different :ref:`Coordinate Reference System Display` for the Map. See
+In the Map Editor is an option to choose different :ref:`Coordinate Reference System <map_editor_crs_display>` for the Map. See
 `EPSG code of default CRS`_ how to set a different default Coordinate Reference System for maps using an EPSG code.
 
 In case the organization would like to disallow to change CRS, the Preference Constant

--- a/docs/user/en/reference/Project Preferences.rst
+++ b/docs/user/en/reference/Project Preferences.rst
@@ -29,6 +29,33 @@ Number of possible steps to undo
 
 Default is 10
 
+Disable CRS Chooser
+```````````````````
+In the Map there is an option to choose different :ref:`Coordinate Reference System Display` for the Map. See
+`EPSG code of default CRS`_ how to set a different default Coordinate Reference System for maps using an EPSG code.
+
+In case the organization would like to disallow to change CRS, the Preference Constant
+
+.. code-block:: python
+
+    org.locationtech.udig.project\DISABLE_CRS_SELECTION=true
+
+can be used to disable CRS Chooser Dialog. If not set - this is the default (*false*) - the
+Application behaves like before. There is no option for this Prefenences in the Preferences Dialog to change behavior on demand.
+
+Hide Render Jobs in Progress View
+`````````````````````````````````
+In case of a Map has many layers configured and the Progress Views is open, lots of processes are shown "Rendering ..".
+The follwoing Prefenences Constant allows to hide Rendering Jobs displayed in Progress View. It helps to see the state
+of other long-running Tasks.
+
+.. code-block:: python
+
+    org.locationtech.udig.project\HIDE_RENDER_JOB=true
+
+can be used to hide Render Jobs. If not set - this is the default (*false*) - the
+Application behaves like before and the Jobs are shown in Progress View. There is no option for this Prefenences in
+the Preferences Dialog to change behavior on demand.
 
 Layer Preferences
 -----------------
@@ -80,6 +107,12 @@ You may wish to change this setting when working with a large number of shapefil
 the same projection.
 
 The default value is -1.
+
+.. code-block::
+
+    org.locationtech.udig.project\defaultCRSPreference=<EPSG-Code>
+
+For <EPSG-Code> use the number such es 4326 for EPSG:4326.
 
 Default map background color
 ````````````````````````````

--- a/docs/user/en/reference/Project Preferences.rst
+++ b/docs/user/en/reference/Project Preferences.rst
@@ -108,11 +108,11 @@ the same projection.
 
 The default value is -1.
 
-.. code-block::
+.. code-block:: python
 
     org.locationtech.udig.project\defaultCRSPreference=<EPSG-Code>
 
-For <EPSG-Code> use the number such es 4326 for EPSG:4326.
+For <EPSG-Code> use the number such es 4326 for EPSG:4326 (WGS 84).
 
 Default map background color
 ````````````````````````````

--- a/docs/user/en/what_is_new/What is new 2.3.rst
+++ b/docs/user/en/what_is_new/What is new 2.3.rst
@@ -12,8 +12,8 @@ Improvements and Fixes
 ----------------------
 * `#398 <https://github.com/locationtech/udig-platform/issues/398>`_ : valid state for layer in Layers View as checked if visible
 * `#415 <https://github.com/locationtech/udig-platform/issues/415>`_ : fixed NullPointerExecption if tool category extension has name attribut not set
-* `#420 <https://github.com/locationtech/udig-platform/issues/420>`_ : allows to hide composite renderer jobs shown in Progress View, see :ref:`Hide Render Jobs in Progress View`_
-* `#421 <https://github.com/locationtech/udig-platform/issues/421>`_ : Option to disable CRS Chooser in Map Editor, see :ref:`Disable CRS Chooser`_
+* `#420 <https://github.com/locationtech/udig-platform/issues/420>`_ : allows to hide composite renderer jobs shown in Progress View, see :ref:`pref_project_HIDE_RENDER_JOB`
+* `#421 <https://github.com/locationtech/udig-platform/issues/421>`_ : Option to disable CRS Chooser in Map Editor, see :ref:`pref_project_DISABLE_CRS_SELECTION`
 * `#432 <https://github.com/locationtech/udig-platform/issues/432>`_ : allows translate Progress View label and nl-specific icon
 * `#439 <https://github.com/locationtech/udig-platform/issues/439>`_ : uses Mockito as Test-Mockup framework rather than EasyMock
 * `#443 <https://github.com/locationtech/udig-platform/issues/443>`_ : moved jfreechart libaries into seperate bundle, to allow to choose other/newer version for sdk-users

--- a/docs/user/en/what_is_new/What is new 2.3.rst
+++ b/docs/user/en/what_is_new/What is new 2.3.rst
@@ -12,7 +12,8 @@ Improvements and Fixes
 ----------------------
 * `#398 <https://github.com/locationtech/udig-platform/issues/398>`_ : valid state for layer in Layers View as checked if visible
 * `#415 <https://github.com/locationtech/udig-platform/issues/415>`_ : fixed NullPointerExecption if tool category extension has name attribut not set
-* `#420 <https://github.com/locationtech/udig-platform/issues/420>`_ & `#611 <https://github.com/locationtech/udig-platform/issues/611>`_ : allows to hide composite renderer jobs with preference `org.locationtech.udig.project/HIDE_RENDER_JOB=true`, see :ref:`Hide render jobs in Progress View <project_preferences-hide-renderer-job>`
+* `#420 <https://github.com/locationtech/udig-platform/issues/420>`_ : allows to hide composite renderer jobs shown in Progress View, see :ref:`Hide Render Jobs in Progress View`_
+* `#421 <https://github.com/locationtech/udig-platform/issues/421>`_ : Option to disable CRS Chooser in Map Editor, see :ref:`Disable CRS Chooser`_
 * `#432 <https://github.com/locationtech/udig-platform/issues/432>`_ : allows translate Progress View label and nl-specific icon
 * `#439 <https://github.com/locationtech/udig-platform/issues/439>`_ : uses Mockito as Test-Mockup framework rather than EasyMock
 * `#443 <https://github.com/locationtech/udig-platform/issues/443>`_ : moved jfreechart libaries into seperate bundle, to allow to choose other/newer version for sdk-users

--- a/plugins/org.locationtech.udig.project.ui.tests/src/org/locationtech/udig/project/ui/internal/CRSContributionItemDisableStateButtonTest.java
+++ b/plugins/org.locationtech.udig.project.ui.tests/src/org/locationtech/udig/project/ui/internal/CRSContributionItemDisableStateButtonTest.java
@@ -1,0 +1,44 @@
+package org.locationtech.udig.project.ui.internal;
+
+import static java.util.Arrays.asList;
+import static org.junit.Assert.assertEquals;
+
+import java.util.Collection;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.Parameters;
+import org.locationtech.udig.project.internal.ProjectPlugin;
+import org.locationtech.udig.project.preferences.PreferenceConstants;
+
+@RunWith(Parameterized.class)
+public class CRSContributionItemDisableStateButtonTest {
+
+    private String givenPropertyValue;
+
+    private boolean expectedState;
+
+    @SuppressWarnings("rawtypes")
+    @Parameters
+    public static Collection disabledButton() {
+        return asList(new Object[][] {
+                { "True", true }, { "tRuE", true }, { "true", true }, { "false", false },
+                { "False", false }, });
+    }
+
+    public CRSContributionItemDisableStateButtonTest(String givenPropertyValue, boolean expectedState) {
+        this.givenPropertyValue = givenPropertyValue;
+        this.expectedState = expectedState;
+    }
+
+    @Test
+    public void testDisabledState() {
+        ProjectPlugin.getPlugin().getPreferenceStore().setValue(
+                PreferenceConstants.P_DISABLE_CRS_SELECTION,
+                givenPropertyValue);
+
+        assertEquals(expectedState, CRSContributionItem.isCRSSelectionDisabled());
+
+    }
+}

--- a/plugins/org.locationtech.udig.project.ui/src/org/locationtech/udig/project/ui/internal/CRSContributionItem.java
+++ b/plugins/org.locationtech.udig.project.ui/src/org/locationtech/udig/project/ui/internal/CRSContributionItem.java
@@ -20,7 +20,9 @@ import org.eclipse.swt.widgets.Display;
 import org.eclipse.swt.widgets.Label;
 import org.eclipse.ui.PlatformUI;
 import org.locationtech.udig.project.internal.Map;
+import org.locationtech.udig.project.internal.ProjectPlugin;
 import org.locationtech.udig.project.internal.commands.ChangeCRSCommand;
+import org.locationtech.udig.project.preferences.PreferenceConstants;
 import org.locationtech.udig.project.render.IViewportModelListener;
 import org.locationtech.udig.project.render.ViewportModelEvent.EventType;
 import org.locationtech.udig.ui.CRSChooserDialog;
@@ -59,6 +61,10 @@ public final class CRSContributionItem extends ContributionItem {
         this.mapEditor.getMap().getViewportModel().addViewportModelListener(viewportModelListener);
     }
 
+    public static boolean isCRSSelectionDisabled() {
+        return ProjectPlugin.getPlugin().getPreferenceStore()
+                .getBoolean(PreferenceConstants.P_DISABLE_CRS_SELECTION);
+    }
     @Override
     public boolean isDynamic() {
         return true;
@@ -102,7 +108,11 @@ public final class CRSContributionItem extends ContributionItem {
         data.widthHint = MINIMUM_WIDTH;
         button.setLayoutData(data);
 
-        button.addListener(SWT.Selection, (listener -> promptForCRS()));
+        boolean disableCRSSelection = isCRSSelectionDisabled();
+
+        if (!disableCRSSelection) {
+           button.addListener(SWT.Selection, (listener -> promptForCRS()));
+        }
 
         update();
     }

--- a/plugins/org.locationtech.udig.project.ui/src/org/locationtech/udig/project/ui/internal/CRSContributionItem.java
+++ b/plugins/org.locationtech.udig.project.ui/src/org/locationtech/udig/project/ui/internal/CRSContributionItem.java
@@ -61,10 +61,14 @@ public final class CRSContributionItem extends ContributionItem {
         this.mapEditor.getMap().getViewportModel().addViewportModelListener(viewportModelListener);
     }
 
+    /**
+     * @return <code>true</code>, if the CRS selection should be disabled. Otherwise <code>false</code>.
+     */
     public static boolean isCRSSelectionDisabled() {
         return ProjectPlugin.getPlugin().getPreferenceStore()
                 .getBoolean(PreferenceConstants.P_DISABLE_CRS_SELECTION);
     }
+
     @Override
     public boolean isDynamic() {
         return true;

--- a/plugins/org.locationtech.udig.project/src/org/locationtech/udig/project/preferences/PreferenceConstants.java
+++ b/plugins/org.locationtech.udig.project/src/org/locationtech/udig/project/preferences/PreferenceConstants.java
@@ -79,13 +79,13 @@ public final class PreferenceConstants {
     public static final String P_HIDE_RENDER_JOB = "HIDE_RENDER_JOB"; //$NON-NLS-1$
 
     /**
-     * Constant to denote that advanced projection support and continuous map wrapping are enabled
-     * for feature renderings such as shape files. Per default this is disabled.
+     * Constant to allow to disable Map CRS Selection Contribution Item.
      * <p>
-     * If this property is <code>true</code> then features such as shape files are wrapped
-     * continuously to the left and the right. </br>
-     * Use</br>
-     *
+     * If the property is <code>true</code> the user cannot change the CRS for the map.
+     */
+    public static final String P_DISABLE_CRS_SELECTION = "DISABLE_CRS_SELECTION"; //$NON-NLS-1$
+
+    /**
      * <code>
      *    {@value ProjectPlugin#ID}/{@value #P_ADVANCED_PROJECTION_SUPPORT}=true
      * </code> </br>

--- a/plugins/org.locationtech.udig.project/src/org/locationtech/udig/project/preferences/PreferenceInitializer.java
+++ b/plugins/org.locationtech.udig.project/src/org/locationtech/udig/project/preferences/PreferenceInitializer.java
@@ -55,6 +55,7 @@ public class PreferenceInitializer extends AbstractPreferenceInitializer {
         store.setDefault(PreferenceConstants.P_CHECK_DUPLICATE_LAYERS, false);
         store.setDefault(PreferenceConstants.P_HIDE_RENDER_JOB, false);
         store.setDefault(PreferenceConstants.P_ADVANCED_PROJECTION_SUPPORT, false);
+        store.setDefault(PreferenceConstants.P_DISABLE_CRS_SELECTION, false);
     }
 
 }


### PR DESCRIPTION
with an additional option its possible to disable CRS Selection Dialog (CRS button in statusbar).

![grafik](https://user-images.githubusercontent.com/644229/94163290-f274c380-fe87-11ea-8f5a-828fd4df370c.png)

I haven't added an option in preferences dialog, since it should be a configuration to start uDig without having the capability to change CRS for the map.

BUT: What happens if the user opens an empty map and adds a resource to the map that provides a CRS the user doesn't want to have for the map? 

Change-Id: Idcffeb250f2dbb71d9ef1f29ddd3f98600b4294c