### PR TITLE
fix issiue 435

### DIFF
--- a/plugins/org.locationtech.udig.printing.ui/src/org/locationtech/udig/printing/ui/internal/PrintAction.java
+++ b/plugins/org.locationtech.udig.printing.ui/src/org/locationtech/udig/printing/ui/internal/PrintAction.java
@@ -73,8 +73,12 @@ public class PrintAction extends Action implements IEditorActionDelegate {
             outFile = new File(path);
         }
 
+        // When the outFile exists, then
         // Workaround for Windows systems to check, if there is a lock
-        boolean fileIsLocked = !outFile.renameTo(outFile);
+        boolean fileIsLocked = false;
+        if (outFile.exists()) {
+            fileIsLocked = !outFile.renameTo(outFile);
+        }
         
         if (fileIsLocked) {
             MessageDialog.open(MessageDialog.ERROR, workbenchWindow.getShell(), Messages.PrintAction_errorDialogTitle, 


### PR DESCRIPTION
File.renameTo method always return false, when the outFile is not exists; There is no need to check the lock when the output file does not exist.

Signed-off-by: hu <2211844470@qq.com>