### PR TITLE
ActiveMapTracker as IStartup

### DIFF
--- a/plugins/org.locationtech.udig.project.ui.tests/src/org/locationtech/udig/project/ui/ApplicationGISTest.java
+++ b/plugins/org.locationtech.udig.project.ui.tests/src/org/locationtech/udig/project/ui/ApplicationGISTest.java
@@ -1,0 +1,89 @@
+package org.locationtech.udig.project.ui;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.assertThat;
+import static org.hamcrest.core.IsCollectionContaining.hasItem;
+import static org.locationtech.udig.core.internal.ExtensionPointUtil.list;
+
+import java.util.Collection;
+import java.util.List;
+
+import org.eclipse.core.runtime.IConfigurationElement;
+import org.eclipse.core.runtime.IExtension;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.locationtech.udig.core.internal.ExtensionPointItemCreator;
+import org.locationtech.udig.project.IMap;
+import org.locationtech.udig.project.ui.internal.ActiveMapTracker;
+
+public class ApplicationGISTest {
+
+
+    @Before
+    public void setUp() {
+        ApplicationGIS.setActiveMapTracker(null);
+    }
+
+    @After
+    public void shutDown() {
+        ApplicationGIS.setActiveMapTracker(null);
+    }
+
+    @Test
+    public void activeMapTrackerIsRegisteredIStartupExtension() {
+        final String expectedElementRegistredAsIStartup = "expectedElementRegistredAsIStartup";
+        @SuppressWarnings("unchecked")
+        List<String> validationList = list("org.eclipse.ui.startup",
+                new ExtensionPointItemCreator() {
+
+            @Override
+            public Object createItem(IExtension extension, IConfigurationElement element)
+                    throws Exception {
+                String iStartupClass = element.getAttribute("class");
+                if (iStartupClass != null
+                        && ActiveMapTracker.class.getName().equals(iStartupClass)) {
+                            return expectedElementRegistredAsIStartup;
+                }
+                return null;
+            }
+        });
+        assertThat("missing registered IStartup extension for ActiveMapTracker", validationList,
+                hasItem(expectedElementRegistredAsIStartup));
+    }
+
+    @Test
+    public void noMapInstanceIfActiveMapTrackerNotSet() {
+        IMap activeMap = ApplicationGIS.getActiveMap();
+        assertNotNull(activeMap);
+        assertEquals(ApplicationGIS.NO_MAP, activeMap);
+    }
+
+    @Test
+    public void openMapsReturnsEmptyCollectionIfActiveMapTrackerNotSet() {
+        Collection<? extends IMap> openMap = ApplicationGIS.getOpenMaps();
+        assertNotNull(openMap);
+        assertTrue(openMap.isEmpty());
+    }
+
+    @Test
+    public void visibleMapsReturnsEmptyCollectionIfActiveMapTrackerNotSet() throws Exception {
+        Collection<? extends IMap> visibleMaps = ApplicationGIS.getVisibleMaps();
+        assertNotNull(visibleMaps);
+        assertTrue(visibleMaps.isEmpty());
+    }
+
+    @Test(expected = Error.class)
+    public void setActiveMapTrackerTwiceCausesError() throws Exception {
+        ActiveMapTracker first = new ActiveMapTracker();
+
+        // first is fine
+        ApplicationGIS.setActiveMapTracker(first);
+
+        ActiveMapTracker second = new ActiveMapTracker();
+
+        ApplicationGIS.setActiveMapTracker(second);
+    }
+}

--- a/plugins/org.locationtech.udig.project.ui/plugin.xml
+++ b/plugins/org.locationtech.udig.project.ui/plugin.xml
@@ -9,8 +9,13 @@
    <extension-point id="toolManagers" name="toolManagers" schema="schema/toolManagers.exsd"/>
    <extension-point id="pdfTemplates" name="PDF Templates" schema="schema/pdfTemplates.exsd"/>
    <extension-point id="featurePanel" name="%featurePanel.point" schema="schema/featurePanel.exsd"/>
-   
- 	<extension
+
+   <extension point="org.eclipse.ui.startup">
+     <startup
+          class="org.locationtech.udig.project.ui.internal.ActiveMapTracker">
+     </startup>
+   </extension>
+   <extension
          point="org.eclipse.ui.popupMenus">
       <objectContribution
             objectClass="org.locationtech.udig.catalog.IGeoResource"

--- a/plugins/org.locationtech.udig.project.ui/src/org/locationtech/udig/project/ui/ApplicationGIS.java
+++ b/plugins/org.locationtech.udig.project.ui/src/org/locationtech/udig/project/ui/ApplicationGIS.java
@@ -100,7 +100,7 @@ import org.opengis.coverage.grid.GridCoverage;
  */
 public class ApplicationGIS {
 
-    private static IToolManager                                          toolManager;
+    private static IToolManager toolManager;
     private static ActiveMapTracker activeMapTracker;
 
     /**
@@ -137,23 +137,33 @@ public class ApplicationGIS {
      *         editor.
      */
     public static IMap getActiveMap() {
+        if (activeMapTracker == null) {
+            return ApplicationGIS.NO_MAP;
+        }
         return activeMapTracker.getActiveMap();
     }
+
     /**
      * Returns all open maps.
-     * 
+     *
      * @return a Collection of maps contained.
      */
-    public static Collection< ? extends IMap> getOpenMaps() {
+    public static Collection<? extends IMap> getOpenMaps() {
+        if (activeMapTracker == null) {
+            return Collections.emptyList();
+        }
         return activeMapTracker.getOpenMaps();
     }
 
     /**
      * Returns all visible maps.
-     * 
+     *
      * @return a Collection of maps contained.
      */
-    public static Collection< ? extends IMap> getVisibleMaps() {
+    public static Collection<? extends IMap> getVisibleMaps() {
+        if (activeMapTracker == null) {
+            return Collections.emptyList();
+        }
         return activeMapTracker.getVisibleMaps();
     }
 
@@ -969,13 +979,15 @@ public class ApplicationGIS {
     }
 
     /**
-     * This method should only be called by uDig.  If it is called by any one else an exception will be thrown.
+     * This method should only be called by uDig. If it is called by any one else an exception will
+     * be thrown.
      *
      * @param activeMapTracker the tracker that managers
      */
-    public static void setActiveMapTracker( ActiveMapTracker activeMapTrackerToSet ) {
-        if (activeMapTracker != null ){
-            throw new Error("This method has already been called! It is an error for non-uDig code to call this method");
+    public static void setActiveMapTracker(ActiveMapTracker activeMapTrackerToSet) {
+        if (activeMapTracker != null && activeMapTrackerToSet != null) {
+            throw new Error(
+                    "This method has already been called! It is an error for non-uDig code to call this method");
         }
         activeMapTracker = activeMapTrackerToSet;
     }

--- a/plugins/org.locationtech.udig.project.ui/src/org/locationtech/udig/project/ui/internal/ActiveMapTracker.java
+++ b/plugins/org.locationtech.udig.project.ui/src/org/locationtech/udig/project/ui/internal/ActiveMapTracker.java
@@ -21,6 +21,7 @@ import org.eclipse.swt.widgets.Display;
 import org.eclipse.ui.IEditorReference;
 import org.eclipse.ui.IPageListener;
 import org.eclipse.ui.IPartListener2;
+import org.eclipse.ui.IStartup;
 import org.eclipse.ui.IViewReference;
 import org.eclipse.ui.IWindowListener;
 import org.eclipse.ui.IWorkbench;
@@ -40,243 +41,251 @@ import org.locationtech.udig.project.ui.ApplicationGIS;
  * @author jesse
  * @since 1.1.0
  */
-public class ActiveMapTracker implements IPartListener2, IWindowListener, IPageListener{
+public class ActiveMapTracker implements IStartup, IPartListener2, IWindowListener, IPageListener {
 
-	/**
-	 * All the parts that are have been active in the order of activation.
-	 * 
-	 */
-    private List<MapPart> activeParts = new CopyOnWriteArrayList<MapPart>();
+    /**
+     * All the parts that are have been active in the order of activation.
+     * 
+     */
+    private List<MapPart> activeParts = new CopyOnWriteArrayList<>();
+
     /**
      * All the maps that are currently visible
      */
-    private Set<MapPart> visibleMaps = new CopyOnWriteArraySet<MapPart>();
+    private Set<MapPart> visibleMaps = new CopyOnWriteArraySet<>();
+
     /**
      * All the maps that are currently open
      */
-    private Set<MapPart> openMaps = new CopyOnWriteArraySet<MapPart>();
-    
+    private Set<MapPart> openMaps = new CopyOnWriteArraySet<>();
+
     /**
      * Returns the set of the visible maps.
      *
      * @return the set of the visible maps.
      */
-    public Collection< ? extends IMap> getVisibleMaps(){
-        HashSet<IMap> maps = new HashSet<IMap>();
-        for( MapPart part : visibleMaps ) {
+    public Collection<? extends IMap> getVisibleMaps() {
+        HashSet<IMap> maps = new HashSet<>();
+        for (MapPart part : visibleMaps) {
             maps.add(part.getMap());
         }
         return Collections.unmodifiableCollection(maps);
     }
-    
+
     /**
-     * Returns the most recently active map or {@link ApplicationGIS#NO_MAP} if all maps have been closed 
+     * Returns the most recently active map or {@link ApplicationGIS#NO_MAP} if all maps have been
+     * closed
      *
      * @return
      */
-    public Map getActiveMap(){
-    	
-    	if( Display.getCurrent()!=null ){
-    		MapPart part = getActivePart();
-    		if( part!=null && !activeParts.isEmpty() && part!=activeParts.get(0)){
-    			addActivePart(part);
-    			return part.getMap();
-    		}
-    	}
-    	
-    	//lets first look at activeParts
-    	MapPart mapPart = null;
-    	if ( !activeParts.isEmpty() ){
-    	    mapPart = activeParts.get(0);
-    	}
-    	if (mapPart == null){
-    	    //not activeParts found so lets look at the open maps.
-    	    //lets see if we can find one that is open and visible
-    	    for( MapPart part : openMaps ) {
-    	        if (visibleMaps.contains(part)){
-    	            mapPart = part;
-    	            break;
-    	        }
+    public Map getActiveMap() {
+
+        if (Display.getCurrent() != null) {
+            MapPart part = getActivePart();
+            if (part != null && !activeParts.isEmpty() && part != activeParts.get(0)) {
+                addActivePart(part);
+                return part.getMap();
             }
-    	}
-    	
-    	if (mapPart == null){
-    	    //nothing found 
-    	    return ApplicationGIS.NO_MAP;
-    	}
+        }
+
+        // lets first look at activeParts
+        MapPart mapPart = null;
+        if (!activeParts.isEmpty()) {
+            mapPart = activeParts.get(0);
+        }
+        if (mapPart == null) {
+            // not activeParts found so lets look at the open maps.
+            // lets see if we can find one that is open and visible
+            for (MapPart part : openMaps) {
+                if (visibleMaps.contains(part)) {
+                    mapPart = part;
+                    break;
+                }
+            }
+        }
+
+        if (mapPart == null || mapPart.getMap() == null) {
+            // nothing found
+            return ApplicationGIS.NO_MAP;
+        }
         return mapPart.getMap();
     }
-    
 
     private MapPart getActivePart() {
-    	IWorkbenchWindow window = PlatformUI.getWorkbench().getActiveWorkbenchWindow();
-    	if( window==null ){
-    		return null;
-    	}
-    	
-    	IWorkbenchPage page = window.getActivePage();
-    	if( page!=null ){
-    		IWorkbenchPart part = page.getActivePart();
-    		if( part instanceof MapPart ){
-    			return (MapPart) part;
-    		}
-    	}
-    	
-		return null;
-	}
+        IWorkbenchWindow window = PlatformUI.getWorkbench().getActiveWorkbenchWindow();
+        if (window == null) {
+            return null;
+        }
 
-	/**
+        IWorkbenchPage page = window.getActivePage();
+        if (page != null) {
+            IWorkbenchPart part = page.getActivePart();
+            if (part instanceof MapPart) {
+                return (MapPart) part;
+            }
+        }
+
+        return null;
+    }
+
+    /**
      * Returns all currently open maps;
      *
      * @return all currently open maps and empty set if no maps are open.
      */
-    public Collection< ? extends IMap> getOpenMaps() {
-        HashSet<IMap> maps = new HashSet<IMap>();
-        for( MapPart part : openMaps ) {
+    public Collection<? extends IMap> getOpenMaps() {
+        HashSet<IMap> maps = new HashSet<>();
+        for (MapPart part : openMaps) {
             maps.add(part.getMap());
         }
         return Collections.unmodifiableCollection(maps);
     }
 
-    /**
-     * Registers the object with the platform
-     */
-    public void startup() {
-        ApplicationGIS.setActiveMapTracker(this);
-        IWorkbench workbench = PlatformUI.getWorkbench();
-        workbench.addWindowListener(this);
-        IWorkbenchWindow[] windows = workbench.getWorkbenchWindows();
-        for( IWorkbenchWindow workbenchWindow : windows ) {
-            windowOpened(workbenchWindow);
-        }
+    private void addActivePart(MapPart part) {
+        while (activeParts.remove(part))
+            ;
+        activeParts.add(0, part);
     }
 
-	private void addActivePart(MapPart part) {
-		while (activeParts.remove(part));
-		activeParts.add(0,part);
-	}
-
-    private void removePart(IWorkbenchPart part) {
-        while(activeParts.remove(part));
+    private void removePart(MapPart part) {
+        while (activeParts.remove(part))
+            ;
         visibleMaps.remove(part);
         openMaps.remove(part);
-	}
+    }
 
-	private boolean addOpenMap(IWorkbenchPart part) {
-		return openMaps.add((MapPart) part);
-	}
+    private boolean addOpenMap(IWorkbenchPart part) {
+        return openMaps.add((MapPart) part);
+    }
 
-    public void windowClosed( IWorkbenchWindow window ) {
+    public void windowClosed(IWorkbenchWindow window) {
         // stop listening to pages and parts
         IWorkbenchPage[] pages = window.getPages();
-        for( IWorkbenchPage workbenchPage : pages ) {
+        for (IWorkbenchPage workbenchPage : pages) {
             workbenchPage.removePartListener(this);
         }
         window.removePageListener(this);
     }
-    
-    public void windowOpened( IWorkbenchWindow window ) {
+
+    public void windowOpened(IWorkbenchWindow window) {
         // start listening to pages and parts
         // stop listening to pages and parts
         IWorkbenchPage[] pages = window.getPages();
-        for( IWorkbenchPage workbenchPage : pages ) {
+        for (IWorkbenchPage workbenchPage : pages) {
             pageOpened(workbenchPage);
         }
         window.addPageListener(this);
     }
 
-    public void pageClosed( IWorkbenchPage page ) {
+    public void pageClosed(IWorkbenchPage page) {
         page.removePartListener(this);
     }
 
-    public void pageOpened( IWorkbenchPage page ) {
+    public void pageOpened(IWorkbenchPage page) {
         page.addPartListener(this);
         IEditorReference[] editors = page.getEditorReferences();
-        for( IEditorReference reference : editors ) {
+        for (IEditorReference reference : editors) {
             IWorkbenchPart workpart = reference.getPart(false);
-            if( reference.getPart(false) instanceof MapPart ){
+            if (reference.getPart(false) instanceof MapPart) {
                 MapPart part = (MapPart) reference.getPart(false);
                 openMaps.add(part);
-                
-                if (page.isPartVisible(workpart)){
+
+                if (page.isPartVisible(workpart)) {
                     visibleMaps.add(part);
                 }
             }
         }
         IViewReference[] views = page.getViewReferences();
-        for( IViewReference reference : views ) {
+        for (IViewReference reference : views) {
             IWorkbenchPart workpart = reference.getPart(false);
-            if( workpart instanceof MapPart ){
+            if (workpart instanceof MapPart) {
                 MapPart part = (MapPart) reference.getPart(false);
                 openMaps.add(part);
-                
-                if (page.isPartVisible(workpart)){
+
+                if (page.isPartVisible(workpart)) {
                     visibleMaps.add(part);
                 }
             }
         }
     }
 
-    public void partActivated( IWorkbenchPartReference partRef ) {
+    public void partActivated(IWorkbenchPartReference partRef) {
         // make this the active map(if it is a MapPart)
         IWorkbenchPart part = partRef.getPart(false);
-        if( part instanceof MapPart){
+        if (part instanceof MapPart) {
             addActivePart((MapPart) part);
         }
     }
 
-    public void partClosed( IWorkbenchPartReference partRef ) {
+    public void partClosed(IWorkbenchPartReference partRef) {
         // if active map then make previous map be the active map
         IWorkbenchPart part = partRef.getPart(false);
-        removePart(part);
+        if (part instanceof MapPart) {
+            removePart((MapPart) part);
+        }
     }
 
-	public void partVisible( IWorkbenchPartReference partRef ) {
+    public void partVisible(IWorkbenchPartReference partRef) {
         // if no active map then make this the active map (if it is a MapPart)
         IWorkbenchPart part = partRef.getPart(false);
-        if( part instanceof MapPart){
+        if (part instanceof MapPart) {
             visibleMaps.add((MapPart) part);
-            if( activeParts.isEmpty() ){
+            if (activeParts.isEmpty()) {
                 activeParts.add((MapPart) part);
             }
         }
     }
 
-    public void partHidden( IWorkbenchPartReference partRef ) {
+    public void partHidden(IWorkbenchPartReference partRef) {
         IWorkbenchPart part = partRef.getPart(false);
-        if( part instanceof MapPart){
-            visibleMaps.remove(part);
+        if (part instanceof MapPart) {
+            visibleMaps.remove((MapPart)part);
         }
     }
 
-    public void partOpened( IWorkbenchPartReference partRef ) {
+    public void partOpened(IWorkbenchPartReference partRef) {
         IWorkbenchPart part = partRef.getPart(false);
-        if( part instanceof MapPart){
+        if (part instanceof MapPart) {
             addOpenMap(part);
         }
     }
 
-    public void partBroughtToTop( IWorkbenchPartReference partRef ) {
+    public void partBroughtToTop(IWorkbenchPartReference partRef) {
         // do nothing
     }
 
-    public void partDeactivated( IWorkbenchPartReference partRef ) {
+    public void partDeactivated(IWorkbenchPartReference partRef) {
         // do nothing
     }
 
-    public void partInputChanged( IWorkbenchPartReference partRef ) {
+    public void partInputChanged(IWorkbenchPartReference partRef) {
         // do nothing
     }
 
-    public void windowActivated( IWorkbenchWindow window ) {
-        // do nothing
-    }
-    
-    public void windowDeactivated( IWorkbenchWindow window ) {
+    public void windowActivated(IWorkbenchWindow window) {
         // do nothing
     }
 
-    public void pageActivated( IWorkbenchPage page ) {
+    public void windowDeactivated(IWorkbenchWindow window) {
         // do nothing
     }
+
+    public void pageActivated(IWorkbenchPage page) {
+        // do nothing
+    }
+
+    /**
+     * Registers the object with the platform
+     */
+    @Override
+    public void earlyStartup() {
+        ApplicationGIS.setActiveMapTracker(this);
+        IWorkbench workbench = PlatformUI.getWorkbench();
+        workbench.addWindowListener(this);
+        IWorkbenchWindow[] windows = workbench.getWorkbenchWindows();
+        for (IWorkbenchWindow workbenchWindow : windows) {
+            windowOpened(workbenchWindow);
+        }
+    }
+
 }

--- a/plugins/org.locationtech.udig.project.ui/src/org/locationtech/udig/project/ui/internal/ProjectUIPlugin.java
+++ b/plugins/org.locationtech.udig.project.ui/src/org/locationtech/udig/project/ui/internal/ProjectUIPlugin.java
@@ -93,8 +93,6 @@ public class ProjectUIPlugin extends AbstractUdigUIPlugin {
      */
     public void start( BundleContext context ) throws Exception {
         super.start(context);
-        
-        new ActiveMapTracker().startup();
     }
 
     /**

--- a/plugins/org.locationtech.udig.tutorials.tracking/src/org/locationtech/udig/tutorials/tracking/CreateSeagulls.java
+++ b/plugins/org.locationtech.udig.tutorials.tracking/src/org/locationtech/udig/tutorials/tracking/CreateSeagulls.java
@@ -27,8 +27,6 @@ import org.locationtech.jts.geom.Coordinate;
 import org.locationtech.udig.project.IBlackboard;
 import org.locationtech.udig.project.ILayer;
 import org.locationtech.udig.project.IMap;
-import org.locationtech.udig.project.ui.ApplicationGIS;
-import org.locationtech.udig.project.ui.internal.ActiveMapTracker;
 import org.locationtech.udig.tutorials.tracking.trackingitem.Seagull;
 import org.locationtech.udig.tutorials.tracking.trackingitem.SeagullFlock;
 import org.locationtech.udig.tutorials.tracking.trackingitem.TrackingItem;
@@ -36,6 +34,7 @@ import org.locationtech.udig.ui.operations.IOp;
 
 public class CreateSeagulls implements IOp {
 
+    @Override
     public void op( Display display, Object target, IProgressMonitor monitor ) throws Exception {
         
         //System.out.println("create seagulls called"); //$NON-NLS-1$
@@ -118,6 +117,7 @@ public class CreateSeagulls implements IOp {
             this.delay = delay;
         }
 
+        @Override
         protected IStatus run(IProgressMonitor monitor) {
             // check the blackboard of the given map for a current flock
             //System.out.println("update job called for map: " + map.getID()); //$NON-NLS-1$


### PR DESCRIPTION
Use Eclipse extension point `org.eclipse.ui.startup` to register ActiveMapTracker as early as possible to track opening Parts of the Workbench.

Change-Id: Icf74b00b15436080951f0c8426c81977963eece0
Signed-off-by: Frank Gasdorf <fgdrf@users.sourceforge.net>