### PR TITLE
[HK] uses locationtech namespace in .options files

### DIFF
--- a/plugins/org.locationtech.udig.catalog.shp/.options
+++ b/plugins/org.locationtech.udig.catalog.shp/.options
@@ -1,3 +1,3 @@
-net.refractions.udig.catalog.shp/debug=true
-net.refractions.udig.catalog.shp/debug/finest=true
-net.refractions.udig.catalog.shp/debug/fine=true
+org.locationtech.udig.catalog.shp/debug=true
+org.locationtech.udig.catalog.shp/debug/finest=true
+org.locationtech.udig.catalog.shp/debug/fine=true

--- a/plugins/org.locationtech.udig.catalog.ui/.options
+++ b/plugins/org.locationtech.udig.catalog.ui/.options
@@ -1,1 +1,1 @@
-net.refractions.udig.catalog.ui/debug=true
+org.locationtech.udig.catalog.ui/debug=true

--- a/plugins/org.locationtech.udig.catalog.wfs/.options
+++ b/plugins/org.locationtech.udig.catalog.wfs/.options
@@ -1,5 +1,5 @@
-net.refractions.udig.catalog.wfs/debug=true
-net.refractions.udig.catalog.wfs/debug/request=true
-net.refractions.udig.catalog.wfs/debug/wfs=true
-net.refractions.udig.catalog.wfs/debug/xml=true
-net.refractions.udig.catalog.wfs/debug/gml=true
+org.locationtech.udig.catalog.wfs/debug=true
+org.locationtech.udig.catalog.wfs/debug/request=true
+org.locationtech.udig.catalog.wfs/debug/wfs=true
+org.locationtech.udig.catalog.wfs/debug/xml=true
+org.locationtech.udig.catalog.wfs/debug/gml=true

--- a/plugins/org.locationtech.udig.catalog.wms/.options
+++ b/plugins/org.locationtech.udig.catalog.wms/.options
@@ -1,2 +1,2 @@
-net.refractions.udig.catalog.wms/debug=true
-net.refractions.udig.catalog.wms/debug/request=true
+org.locationtech.udig.catalog.wms/debug=true
+org.locationtech.udig.catalog.wms/debug/request=true

--- a/plugins/org.locationtech.udig.catalog.wmt/.options
+++ b/plugins/org.locationtech.udig.catalog.wmt/.options
@@ -1,7 +1,7 @@
-net.refractions.udig.catalog.wmt/debug=true
-net.refractions.udig.catalog.wmt/debug/request=true
-net.refractions.udig.catalog.wmt/debug/osm=true
-net.refractions.udig.catalog.wmt/debug/nasa=true
-net.refractions.udig.catalog.wmt/debug/mq=true
-net.refractions.udig.catalog.wmt/debug/ww=true
-net.refractions.udig.catalog.wmt/debug/wizard=true
+org.locationtech.udig.catalog.wmt/debug=true
+org.locationtech.udig.catalog.wmt/debug/request=true
+org.locationtech.udig.catalog.wmt/debug/osm=true
+org.locationtech.udig.catalog.wmt/debug/nasa=true
+org.locationtech.udig.catalog.wmt/debug/mq=true
+org.locationtech.udig.catalog.wmt/debug/ww=true
+org.locationtech.udig.catalog.wmt/debug/wizard=true

--- a/plugins/org.locationtech.udig.catalog/.options
+++ b/plugins/org.locationtech.udig.catalog/.options
@@ -1,1 +1,1 @@
-net.refractions.udig.catalog/debug=true
+org.locationtech.udig.catalog/debug=true

--- a/plugins/org.locationtech.udig.libs/.options
+++ b/plugins/org.locationtech.udig.libs/.options
@@ -1,3 +1,3 @@
-net.refractions.udig.libs/debug=true
-net.refractions.udig.libs/debug/jdbc/fine=true
-net.refractions.udig.libs/debug/data/jdbc/fine=true
+org.locationtech.udig.libs/debug=true
+org.locationtech.udig.libs/debug/jdbc/fine=true
+org.locationtech.udig.libs/debug/data/jdbc/fine=true

--- a/plugins/org.locationtech.udig.printing.model/.options
+++ b/plugins/org.locationtech.udig.printing.model/.options
@@ -1,2 +1,2 @@
-net.refractions.udig.printing.model/debug=true
-net.refractions.udig.printing.model/debug/printing/trace=true
+org.locationtech.udig.printing.model/debug=true
+org.locationtech.udig.printing.model/debug/printing/trace=true

--- a/plugins/org.locationtech.udig.printing.ui/.options
+++ b/plugins/org.locationtech.udig.printing.ui/.options
@@ -1,2 +1,2 @@
-net.refractions.udig.printing.ui/debug=true
-net.refractions.udig.printing.ui/debug/printing=true
+org.locationtech.udig.printing.ui/debug=true
+org.locationtech.udig.printing.ui/debug/printing=true

--- a/plugins/org.locationtech.udig.project.ui/.options
+++ b/plugins/org.locationtech.udig.project.ui/.options
@@ -1,5 +1,5 @@
-net.refractions.udig.project.ui/debug=true
-net.refractions.udig.project.ui/debug/render/trace=true
-net.refractions.udig.project.ui/debug/render/timing=10s
-net.refractions.udig.project.ui/debug/dnd/trace=true
-net.refractions.udig.project.ui/debug/viewport/trace=true
+org.locationtech.udig.project.ui/debug=true
+org.locationtech.udig.project.ui/debug/render/trace=true
+org.locationtech.udig.project.ui/debug/render/timing=10s
+org.locationtech.udig.project.ui/debug/dnd/trace=true
+org.locationtech.udig.project.ui/debug/viewport/trace=true

--- a/plugins/org.locationtech.udig.project/.options
+++ b/plugins/org.locationtech.udig.project/.options
@@ -1,8 +1,8 @@
-net.refractions.udig.project/debug=true
-net.refractions.udig.project/debug/render/trace=true
-net.refractions.udig.project/debug/commands/trace=true
-net.refractions.udig.project/debug/model/trace=true
+org.locationtech.udig.project/debug=true
+org.locationtech.udig.project/debug/render/trace=true
+org.locationtech.udig.project/debug/commands/trace=true
+org.locationtech.udig.project/debug/model/trace=true
 
-net.refractions.udig.project.undoableCommandWarning=true
+org.locationtech.udig.project.undoableCommandWarning=true
 trace/keyBindings=true
 trace/keyBindings.verbose=true

--- a/plugins/org.locationtech.udig.render.feature.basic/.options
+++ b/plugins/org.locationtech.udig.render.feature.basic/.options
@@ -1,1 +1,1 @@
-net.refractions.udig.render.feature.basic/finest=false
+org.locationtech.udig.render.feature.basic/finest=false

--- a/plugins/org.locationtech.udig.render.feature.shapefile/.options
+++ b/plugins/org.locationtech.udig.render.feature.shapefile/.options
@@ -1,2 +1,2 @@
-net.refractions.udig.render.feature.shapefile/debug=true
-net.refractions.udig.render.feature.shapefile/finest=true
+org.locationtech.udig.render.feature.shapefile/debug=true
+org.locationtech.udig.render.feature.shapefile/finest=true

--- a/plugins/org.locationtech.udig.render.wms.basic/.options
+++ b/plugins/org.locationtech.udig.render.wms.basic/.options
@@ -1,2 +1,2 @@
-net.refractions.udig.render.wms.basic/debug=true
-net.refractions.udig.render.wms.basic/debug/render/trace=true
+org.locationtech.udig.render.wms.basic/debug=true
+org.locationtech.udig.render.wms.basic/debug/render/trace=true

--- a/plugins/org.locationtech.udig.render.wmt.basic/.options
+++ b/plugins/org.locationtech.udig.render.wmt.basic/.options
@@ -1,2 +1,2 @@
-net.refractions.udig.render.wmt.basic/debug=true
-net.refractions.udig.render.wmt.basic/debug/render/trace=true
+org.locationtech.udig.render.wmt.basic/debug=true
+org.locationtech.udig.render.wmt.basic/debug/render/trace=true

--- a/plugins/org.locationtech.udig.style.sld.raster/.options
+++ b/plugins/org.locationtech.udig.style.sld.raster/.options
@@ -1,1 +1,1 @@
-net.refractions.udig.style.sld/debug=true
+org.locationtech.udig.style.sld/debug=true

--- a/plugins/org.locationtech.udig.style.sld/.options
+++ b/plugins/org.locationtech.udig.style.sld/.options
@@ -1,1 +1,1 @@
-net.refractions.udig.style.sld/debug=true
+org.locationtech.udig.style.sld/debug=true

--- a/plugins/org.locationtech.udig.style/.options
+++ b/plugins/org.locationtech.udig.style/.options
@@ -1,1 +1,1 @@
-net.refractions.udig.style/debug=true
+org.locationtech.udig.style/debug=true

--- a/plugins/org.locationtech.udig.tool.edit/.options
+++ b/plugins/org.locationtech.udig.tool.edit/.options
@@ -1,6 +1,6 @@
-net.refractions.udig.tools.edit/debug=true
-net.refractions.udig.tools.edit/selection=true
-net.refractions.udig.tools.edit/activator=true
-net.refractions.udig.tools.edit/behaviour=true
-net.refractions.udig.tools.edit/handler/lock=true
-net.refractions.udig.tools.edit/debug/assertions=true
+org.locationtech.udig.tools.edit/debug=true
+org.locationtech.udig.tools.edit/selection=true
+org.locationtech.udig.tools.edit/activator=true
+org.locationtech.udig.tools.edit/behaviour=true
+org.locationtech.udig.tools.edit/handler/lock=true
+org.locationtech.udig.tools.edit/debug/assertions=true

--- a/plugins/org.locationtech.udig.ui/.options
+++ b/plugins/org.locationtech.udig.ui/.options
@@ -1,4 +1,4 @@
-net.refractions.udig.ui/debug=true
-net.refractions.udig.ui/debug/dnd=true
-net.refractions.udig.ui/debug/udigdisplaysafelock=true
-net.refractions.udig.ui/debug/featuretable=true
+org.locationtech.udig.ui/debug=true
+org.locationtech.udig.ui/debug/dnd=true
+org.locationtech.udig.ui/debug/udigdisplaysafelock=true
+org.locationtech.udig.ui/debug/featuretable=true


### PR DESCRIPTION
Since namespace change from net.refractions to org.locationtech this changes fixes missing .options files. With this commit its possible to enable debug options for product again.

Change-Id: Ieff47597e4e4f30030556772eee9a8f5163a7194
Signed-off-by: Frank Gasdorf <fgdrf@users.sourceforge.net>