### PR TITLE
fixed 404 links

### DIFF
--- a/deploy/udig.html
+++ b/deploy/udig.html
@@ -20,9 +20,9 @@
 any configuration changes to your Machine. On Mac OSX uDig is able to check for Java Advanced Imaging and install if needed.</p>
 <p>To get started with uDig:</p>
 <ul>
-  <li>Help Menu provides a <a href="http://udig.github.com/docs/user/getting_started/Quickstart.html">Quickstart</a> and Guided Cheatsheet</li>
-  <li><a href="http://udig.github.com/docs/user/getting_started/Walkthrough%201.html">Walkthrough 1</a></li>
-  <li><a href="http://udig.github.com/docs/user/getting_started/Walkthrough%202.html">Walkthrough 2</a></li>
+  <li>Help Menu provides a <a href="http://udig.github.io/docs/user/getting_started/Quickstart.html">Quickstart</a> and Guided Cheatsheet</li>
+  <li><a href="http://udig.github.io/docs/user/getting_started/Walkthrough%201.html">Walkthrough 1</a></li>
+  <li><a href="http://udig.github.io/docs/user/getting_started/Walkthrough%202.html">Walkthrough 2</a></li>
 </ul>
 
 <h2 style="margin: 0.0px 0.0px 0.0px 0.0px; font: 18.0px Arial">About uDig VersionXXXX</h2>


### PR DESCRIPTION
The links ending with github.com lead to a 404. The actual docs are located under github.io domain