### PR TITLE
SetScaleCommand as NavCommand

### DIFF
--- a/plugins/org.locationtech.udig.project.tests/src/org/locationtech/udig/project/internal/commands/SetScaleCommandTest.java
+++ b/plugins/org.locationtech.udig.project.tests/src/org/locationtech/udig/project/internal/commands/SetScaleCommandTest.java
@@ -1,0 +1,70 @@
+package org.locationtech.udig.project.internal.commands;
+
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import org.eclipse.core.runtime.IProgressMonitor;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.locationtech.udig.project.internal.render.ViewportModel;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+@RunWith(MockitoJUnitRunner.class)
+public class SetScaleCommandTest {
+
+	private static final double SCALE_TO_SET = 0.5;
+
+	private static final double PREVIOUS_SCALE = 0.3;
+
+	@Mock
+	private ViewportModel mockedViewportModel;
+
+	@Mock
+	private IProgressMonitor monitor;
+
+	@Captor
+	private ArgumentCaptor<Double> scaleDenominatorCaptor;
+
+	@Test
+	public void testCopy() throws Exception {
+		SetScaleCommand setScaleCommand = new SetScaleCommand(SCALE_TO_SET);
+		assertNotSame(setScaleCommand, setScaleCommand.copy());
+	}
+
+	@Test
+	public void ifModelIsSetSetScaleIsCalled() throws Exception {
+		when(mockedViewportModel.getScaleDenominator()).thenReturn(PREVIOUS_SCALE);
+
+		SetScaleCommand setScaleCommand = new SetScaleCommand(SCALE_TO_SET);
+		setScaleCommand.setViewportModel(mockedViewportModel);
+		setScaleCommand.run(monitor);
+
+		verify(mockedViewportModel).setScale(SCALE_TO_SET);
+	}
+
+	@Test
+	public void rollbackSetsPreviousScaleFromModel() throws Exception {
+		when(mockedViewportModel.getScaleDenominator()).thenReturn(PREVIOUS_SCALE);
+
+		SetScaleCommand setScaleCommand = new SetScaleCommand(SCALE_TO_SET);
+		setScaleCommand.setViewportModel(mockedViewportModel);
+
+		setScaleCommand.run(monitor);
+		setScaleCommand.rollback(monitor);
+
+		verify(mockedViewportModel, times(2)).setScale(scaleDenominatorCaptor.capture());
+
+		assertEquals(SCALE_TO_SET, scaleDenominatorCaptor.getAllValues().get(0), 0);
+		assertEquals(PREVIOUS_SCALE, scaleDenominatorCaptor.getAllValues().get(1), 0);
+	}
+
+	@Test
+	public void commandNameNotNull() throws Exception {
+		assertNotNull("Command name expected", new SetScaleCommand(SCALE_TO_SET).getName());
+	}
+}

--- a/plugins/org.locationtech.udig.project/src/org/locationtech/udig/project/internal/commands/SetScaleCommand.java
+++ b/plugins/org.locationtech.udig.project/src/org/locationtech/udig/project/internal/commands/SetScaleCommand.java
@@ -9,41 +9,66 @@
  */
 package org.locationtech.udig.project.internal.commands;
 
-import org.locationtech.udig.project.command.AbstractCommand;
+import org.eclipse.core.runtime.IProgressMonitor;
+import org.locationtech.udig.project.command.Command;
 import org.locationtech.udig.project.command.UndoableCommand;
 import org.locationtech.udig.project.internal.Messages;
-
-import org.eclipse.core.runtime.IProgressMonitor;
+import org.locationtech.udig.project.internal.command.navigation.AbstractNavCommand;
+import org.locationtech.udig.project.internal.render.ViewportModel;
 
 /**
  * Sets the scale denominator of the map.
- * 
+ *
  * @author Jesse
  * @since 1.1.0
  */
-public class SetScaleCommand extends AbstractCommand implements UndoableCommand {
+public class SetScaleCommand extends AbstractNavCommand implements UndoableCommand {
 
     private double oldScale;
+
     private double newScale;
+
     /**
-     * 
+     *
      * @param newScale Scale Denominator
      */
-    public SetScaleCommand( double newScale ) {
+    public SetScaleCommand(double newScale) {
         this.newScale = newScale;
     }
 
-    public void rollback( IProgressMonitor monitor ) throws Exception {
-        getMap().getViewportModelInternal().setScale(oldScale);
+    @Override
+    public void rollback(IProgressMonitor monitor) throws Exception {
+        if (model != null) {
+            model.setScale(oldScale);
+        } else {
+            getMap().getViewportModelInternal().setScale(oldScale);
+        }
     }
 
+    @Override
     public String getName() {
         return Messages.SetScaleCommand_name;
     }
 
-    public void run( IProgressMonitor monitor ) throws Exception {
-        this.oldScale=getMap().getViewportModel().getScaleDenominator();
-        getMap().getViewportModelInternal().setScale(newScale);
+    @Override
+    public void run(IProgressMonitor monitor) throws Exception {
+        if (model != null) {
+            oldScale = model.getScaleDenominator();
+            model.setScale(newScale);
+        } else {
+            ViewportModel viewportModel = getMap().getViewportModelInternal();
+            this.oldScale = viewportModel.getScaleDenominator();
+            viewportModel.setScale(newScale);
+        }
     }
 
+    @Override
+    public Command copy() {
+        return new SetScaleCommand(newScale);
+    }
+
+    @Override
+    protected void runImpl(IProgressMonitor monitor) throws Exception {
+        run(monitor);
+    }
 }


### PR DESCRIPTION
1. Current situation/state? (are there any commits/prototypes? any known issue?)

if the user sets a scale (scale contribution item in map) manually the new scale results in a new extent for the map.

The command isn't a NavCommand and therfore you cannot use back/forward navigation Tools in the map

2. Expected situation/state?

The back command Action should be enabled once the used set another scale. After hitting back, the previews scale with its extens sould be shown in map

Change-Id: Ib3a2170d79322aef532753ec8e1bd50292f6c1f6
Signed-off-by: kassid <kassid@web.de>
