### PR TITLE
provides products (win/lin) for download

### DIFF
--- a/.github/workflows/maven-jdk8-linux.yml
+++ b/.github/workflows/maven-jdk8-linux.yml
@@ -45,17 +45,17 @@ jobs:
       uses: actions/upload-artifact@v2
       with:
         name: udig-product.win32.win32.x86_64
-        path: ${{ github.workspace }}/features/org.locationtech.udig-product/target/products/*win32.win32.x86_64.zip
+        path: ${{ github.workspace }}/features/org.locationtech.udig-product/target/products/org.locationtech.udig-product/win32/win32/x86_64
         retention-days: 10
     - name: provide Linux product for download
       uses: actions/upload-artifact@v2
       with:
         name: udig-product.linux.gtk.x86_64
-        path: ${{ github.workspace }}/features/org.locationtech.udig-product/target/products/*linux.gtk.x86_64.zip
+        path: ${{ github.workspace }}/features/org.locationtech.udig-product/target/products/org.locationtech.udig-product/linux/gtk/x86_64
         retention-days: 10
     - name: provide MacOSX product for download
       uses: actions/upload-artifact@v2
       with:
         name: udig-product.macosx.cocoa.x86_64
-        path: ${{ github.workspace }}/features/org.locationtech.udig-product/target/products/*macosx.cocoa.x86_64.zip
+        path: ${{ github.workspace }}/features/org.locationtech.udig-product/target/products/org.locationtech.udig-product/macosx/cocoa/x86_64
         retention-days: 10

--- a/.github/workflows/maven-jdk8-linux.yml
+++ b/.github/workflows/maven-jdk8-linux.yml
@@ -51,7 +51,7 @@ jobs:
       uses: actions/upload-artifact@v2
       with:
         name: udig-product.linux.gtk.x86_64
-        path: ${{ github.workspace }}/features/org.locationtech.udig-product/target/products/*linux.gtk.x86_64.zi10
+        path: ${{ github.workspace }}/features/org.locationtech.udig-product/target/products/*linux.gtk.x86_64.zip
         retention-days: 10
     - name: provide MacOSX product for download
       uses: actions/upload-artifact@v2

--- a/.github/workflows/maven-jdk8-linux.yml
+++ b/.github/workflows/maven-jdk8-linux.yml
@@ -41,3 +41,13 @@ jobs:
       uses: GabrielBB/xvfb-action@v1
       with:
          run: mvn verify -B -Pproduct -Psdk -Ptest --fail-at-end -T4
+    - name: provide Windows product for download
+      uses: actions/upload-artifact@v2
+      with:
+        name: udig-platform.win32.win32.x86_64
+        path: ${{ github.workspace }}/features/org.locationtech.udig-product/target/products/*win32.win32.x86_64.zip
+    - name: provide Linux product for download
+      uses: actions/upload-artifact@v2
+      with:
+        name: udig-platform.linux.gtk.x86_64
+        path: ${{ github.workspace }}/features/org.locationtech.udig-product/target/products/*linux.gtk.x86_64.zip

--- a/.github/workflows/maven-jdk8-linux.yml
+++ b/.github/workflows/maven-jdk8-linux.yml
@@ -44,10 +44,18 @@ jobs:
     - name: provide Windows product for download
       uses: actions/upload-artifact@v2
       with:
-        name: udig-platform.win32.win32.x86_64
+        name: udig-product.win32.win32.x86_64
         path: ${{ github.workspace }}/features/org.locationtech.udig-product/target/products/*win32.win32.x86_64.zip
+        retention-days: 10
     - name: provide Linux product for download
       uses: actions/upload-artifact@v2
       with:
-        name: udig-platform.linux.gtk.x86_64
-        path: ${{ github.workspace }}/features/org.locationtech.udig-product/target/products/*linux.gtk.x86_64.zip
+        name: udig-product.linux.gtk.x86_64
+        path: ${{ github.workspace }}/features/org.locationtech.udig-product/target/products/*linux.gtk.x86_64.zi10
+        retention-days: 10
+    - name: provide MacOSX product for download
+      uses: actions/upload-artifact@v2
+      with:
+        name: udig-product.macosx.cocoa.x86_64
+        path: ${{ github.workspace }}/features/org.locationtech.udig-product/target/products/*macosx.cocoa.x86_64.zip
+        retention-days: 10

--- a/.github/workflows/maven-jdk8-linux.yml
+++ b/.github/workflows/maven-jdk8-linux.yml
@@ -46,16 +46,13 @@ jobs:
       with:
         name: udig-product.win32.win32.x86_64
         path: ${{ github.workspace }}/features/org.locationtech.udig-product/target/products/org.locationtech.udig-product/win32/win32/x86_64
-        retention-days: 10
     - name: provide Linux product for download
       uses: actions/upload-artifact@v2
       with:
         name: udig-product.linux.gtk.x86_64
         path: ${{ github.workspace }}/features/org.locationtech.udig-product/target/products/org.locationtech.udig-product/linux/gtk/x86_64
-        retention-days: 10
     - name: provide MacOSX product for download
       uses: actions/upload-artifact@v2
       with:
         name: udig-product.macosx.cocoa.x86_64
         path: ${{ github.workspace }}/features/org.locationtech.udig-product/target/products/org.locationtech.udig-product/macosx/cocoa/x86_64
-        retention-days: 10


### PR DESCRIPTION
With this change ist possible to download product artifacts from github action if the build finished successfully. Supported platforms are Linux, Windows, and MacOSX (each 64bit)

![A368D47F-EE95-4215-BFB3-57AD46B23534](https://user-images.githubusercontent.com/644229/132108342-f9e453fb-5743-42ab-9b69-baca7a898dfa.png)

This allows everybody to test changesets much easier getting a pre-build uDig product. It reduces dev-cycles and review efforts a lot without merging changes locally (on dev-box), run a build and test it.


