### PR TITLE
upgrade Eclipse Tycho to 2.3 as preperation to move on to java11

### DIFF
--- a/.github/workflows/maven-java-linux.yml
+++ b/.github/workflows/maven-java-linux.yml
@@ -16,10 +16,10 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
-    - name: Set up JDK 8
+    - name: Set up JDK 11
       uses: actions/setup-java@v2
       with:
-        java-version: '8'
+        java-version: '11'
         distribution: 'adopt'
     - name: Maven repository caching
       uses: actions/cache@v2

--- a/pom.xml
+++ b/pom.xml
@@ -19,8 +19,8 @@
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
 
-        <tycho-version>1.6.0</tycho-version>
-        <tycho-extras-version>1.6.0</tycho-extras-version>
+        <tycho-version>2.3.0</tycho-version>
+        <tycho-extras-version>2.3.0</tycho-extras-version>
         <!-- necessary for e.g. hudson proxy settings
              see https://locationtech.org/bugs/show_bug.cgi?id=51
         -->


### PR DESCRIPTION
as request in issue #497 this pull-request adresses an upgrade to Tycho 2.3.0