### PR TITLE
Findbugs to spotbugs

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -450,6 +450,18 @@
                     <artifactId>tycho-versions-plugin</artifactId>
                     <version>${tycho-version}</version>
                 </plugin>
+
+                <plugin>
+                    <groupId>com.github.spotbugs</groupId>
+                    <artifactId>spotbugs-maven-plugin</artifactId>
+                    <version>4.4.1</version>
+                    <configuration>
+                        <!-- too many issues at the moment -->
+                        <failOnError>false</failOnError>
+                        <xmlOutput>true</xmlOutput>
+                        <threshold>High</threshold>
+                    </configuration>
+                </plugin>
             </plugins>
         </pluginManagement>
     </build>
@@ -461,12 +473,6 @@
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>cobertura-maven-plugin</artifactId>
                 <version>2.2</version>
-            </plugin>
-
-            <plugin>
-                <groupId>org.codehaus.mojo</groupId>
-                <artifactId>findbugs-maven-plugin</artifactId>
-                <version>2.1</version>
             </plugin>
         </plugins>
     </reporting>


### PR DESCRIPTION
allow to check code with spotbugs rather than retired findbugs plugin.

just run build with `spotbugs:check` to get high-ranked issues in the codebase. At the moment of writing ist configured not to fail, just report high level problems.