### PR TITLE
Allow maps to behave like Views

### DIFF
--- a/plugins/org.locationtech.udig.project.ui.tests/src/org/locationtech/udig/project/tests/ui/dnd/MapEditorDNDTest.java
+++ b/plugins/org.locationtech.udig.project.ui.tests/src/org/locationtech/udig/project/tests/ui/dnd/MapEditorDNDTest.java
@@ -40,8 +40,8 @@ import org.locationtech.udig.project.internal.Map;
 import org.locationtech.udig.project.tests.support.MapTests;
 import org.locationtech.udig.project.ui.ApplicationGIS;
 import org.locationtech.udig.project.ui.internal.ApplicationGISInternal;
-import org.locationtech.udig.project.ui.internal.MapEditorPart;
 import org.locationtech.udig.project.ui.internal.MapEditorWithPalette;
+import org.locationtech.udig.project.ui.internal.MapPart;
 import org.locationtech.udig.ui.IDropAction;
 import org.locationtech.udig.ui.IDropHandlerListener;
 import org.locationtech.udig.ui.UDIGDragDropUtilities;
@@ -100,7 +100,7 @@ public class MapEditorDNDTest extends AbstractProjectUITestCase {
             assertLayerType(layer,typeNames, ShapefileDataStore.class);
         }
 
-        MapEditorPart activeEditor = ApplicationGISInternal.getActiveEditor();
+        MapPart activeEditor = ApplicationGISInternal.getActiveEditor();
         UDIGDropHandler dropHandler = activeEditor.getDropHandler();
         dropHandler.setTarget(activeEditor);
         dropHandler.setViewerLocation(ViewerDropLocation.NONE);

--- a/plugins/org.locationtech.udig.project.ui.tests/src/org/locationtech/udig/project/ui/internal/tool/display/ToolManagerTest.java
+++ b/plugins/org.locationtech.udig.project.ui.tests/src/org/locationtech/udig/project/ui/internal/tool/display/ToolManagerTest.java
@@ -23,14 +23,14 @@ import org.locationtech.udig.project.internal.Map;
 import org.locationtech.udig.project.tests.support.MapTests;
 import org.locationtech.udig.project.ui.ApplicationGIS;
 import org.locationtech.udig.project.ui.internal.ApplicationGISInternal;
-import org.locationtech.udig.project.ui.internal.MapEditorPart;
+import org.locationtech.udig.project.ui.internal.MapPart;
 import org.locationtech.udig.project.ui.tool.IToolManager;
 
 public class ToolManagerTest {
 
     private Map map;
 
-    private MapEditorPart editor;
+    private MapPart editor;
 
     @Before
     public void setUp() throws Exception {

--- a/plugins/org.locationtech.udig.project.ui.tests/src/org/locationtech/udig/project/ui/tool/ToolManagerTest.java
+++ b/plugins/org.locationtech.udig.project.ui.tests/src/org/locationtech/udig/project/ui/tool/ToolManagerTest.java
@@ -78,12 +78,15 @@ public class ToolManagerTest extends AbstractProjectUITestCase {
         AdaptingFilter filter = AdaptingFilterFactory.createAdaptingFilter(firstLayer.getFilter(), firstLayer );
         StructuredSelection structuredSelection = new StructuredSelection(filter);
         
-        ApplicationGISInternal.getActiveEditor().getEditorSite().getSelectionProvider().setSelection(structuredSelection) ;
+        ApplicationGISInternal.getActiveEditor().getSite().getSelectionProvider()
+                .setSelection(structuredSelection);
+
         Event event = new Event();
         event.display=Display.getCurrent();
         copyAction.runWithEvent(event);
 
-        ApplicationGISInternal.getActiveEditor().getEditorSite().getSelectionProvider().setSelection(new StructuredSelection(layer));
+        ApplicationGISInternal.getActiveEditor().getSite().getSelectionProvider()
+                .setSelection(new StructuredSelection(layer));
         
         pasteAction.runWithEvent(event);
         

--- a/plugins/org.locationtech.udig.project.ui/src/org/locationtech/udig/project/ui/internal/ApplicationGISInternal.java
+++ b/plugins/org.locationtech.udig.project.ui/src/org/locationtech/udig/project/ui/internal/ApplicationGISInternal.java
@@ -9,16 +9,16 @@
  */
 package org.locationtech.udig.project.ui.internal;
 
-import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
+import java.util.concurrent.atomic.AtomicReference;
 
 import org.eclipse.jface.viewers.StructuredSelection;
-import org.eclipse.ui.IEditorInput;
 import org.eclipse.ui.IEditorPart;
 import org.eclipse.ui.IEditorReference;
 import org.eclipse.ui.IWorkbenchPage;
+import org.eclipse.ui.IWorkbenchPart;
 import org.eclipse.ui.IWorkbenchWindow;
 import org.eclipse.ui.PlatformUI;
 import org.locationtech.udig.project.IMap;
@@ -26,7 +26,6 @@ import org.locationtech.udig.project.internal.Map;
 import org.locationtech.udig.project.internal.Project;
 import org.locationtech.udig.project.internal.ProjectPlugin;
 import org.locationtech.udig.project.ui.ApplicationGIS;
-import org.locationtech.udig.project.ui.UDIGEditorInput;
 import org.locationtech.udig.project.ui.internal.tool.ToolContext;
 import org.locationtech.udig.ui.PlatformGIS;
 import org.opengis.feature.simple.SimpleFeature;
@@ -94,28 +93,28 @@ public class ApplicationGISInternal {
                 new StructuredSelection(feature));
     }
 
-    public static MapEditorPart getActiveEditor() {
+    public static MapPart getActiveEditor() {
         try {
-            final ArrayList<IEditorPart> editor = new ArrayList<IEditorPart>();
+            final AtomicReference<MapPart> editor = new AtomicReference<MapPart>();
 
             Runnable runnable = new Runnable(){
                 public void run() {
                     try {
+
                         IWorkbenchWindow window = PlatformUI.getWorkbench()
                                 .getActiveWorkbenchWindow();
                         IEditorReference[] refs = window.getActivePage().getEditorReferences();
                         IMap map = ApplicationGIS.getActiveMap();
 
                         for( IEditorReference ref : refs ) {
-                            IEditorInput input = ref.getEditorInput();
-                            if (input instanceof UDIGEditorInput) {
-                                UDIGEditorInput in = (UDIGEditorInput) input;
-                                if (in.getProjectElement() == map) {
-                                    editor.add(ref.getEditor(false));
-                                    break;
-                                }
+                            IWorkbenchPart part = ref.getPart(false);
+                            Map adapter = part.getAdapter(Map.class);
+                            if (adapter != null && map == adapter && part instanceof MapPart) {
+                                editor.set((MapPart) part);
+                                break;
                             }
                         }
+
                     } catch (Throwable t) {
                         // do nothing
                     }
@@ -124,14 +123,10 @@ public class ApplicationGISInternal {
 
             PlatformGIS.syncInDisplayThread(runnable);
 
-            if (!editor.isEmpty() && editor.get(0) instanceof MapEditorPart) {
-                return (MapEditorPart) editor.get(0);
-            }
+            return editor.get();
         } catch (Exception e) {
             return null;
         }
-
-        return null;
     }
     public static MapEditorPart findMapEditor( final IMap map ) {
         if (map == null)

--- a/plugins/org.locationtech.udig.project.ui/src/org/locationtech/udig/project/ui/internal/DefaultMapViewPart.java
+++ b/plugins/org.locationtech.udig.project.ui/src/org/locationtech/udig/project/ui/internal/DefaultMapViewPart.java
@@ -23,6 +23,8 @@ import org.eclipse.ui.IActionBars;
 import org.eclipse.ui.part.ViewPart;
 import org.locationtech.udig.catalog.IGeoResource;
 import org.locationtech.udig.internal.ui.IDropTargetProvider;
+import org.locationtech.udig.internal.ui.UDIGControlDropListener;
+import org.locationtech.udig.internal.ui.UDIGDropHandler;
 import org.locationtech.udig.project.IProject;
 import org.locationtech.udig.project.internal.Map;
 import org.locationtech.udig.project.internal.commands.CreateMapCommand;
@@ -52,6 +54,9 @@ public abstract class DefaultMapViewPart extends ViewPart implements MapPart, ID
 
     private DropTargetDescriptor dropTarget;
 
+    /** This is for testing only DO NOT USE OTHERWISE */
+    public boolean isTesting;
+
     private IToolManager toolManager;
 
     private MapEditDomain editDomain;
@@ -80,7 +85,7 @@ public abstract class DefaultMapViewPart extends ViewPart implements MapPart, ID
         editDomain = new MapEditDomain(null);
         try {
             IProgressMonitor monitor = getViewSite().getActionBars().getStatusLineManager().getProgressMonitor();
-            viewer = new MapViewer(parent, SWT.DOUBLE_BUFFERED);
+            viewer = new MapViewer(parent, this, SWT.DOUBLE_BUFFERED);
             List<IGeoResource> resources = new ArrayList<IGeoResource>();
             createResources(resources, monitor);
             IProject activeProject = ApplicationGIS.getActiveProject();
@@ -204,6 +209,23 @@ public abstract class DefaultMapViewPart extends ViewPart implements MapPart, ID
             viewer.setMenu(menu);
             getSite().registerContextMenu(contextMenu, getSite().getSelectionProvider());
         }
+    }
+
+    @Override
+    public UDIGDropHandler getDropHandler() {
+        return ((UDIGControlDropListener) dropTarget.listener).getHandler();
+    }
+
+    //
+    // helper method for ToolManager
+    @Override
+    public boolean isTesting() {
+        return this.isTesting;
+    }
+
+    @Override
+    public void setTesting(boolean testing) {
+        this.isTesting = testing;
     }
 
 }

--- a/plugins/org.locationtech.udig.project.ui/src/org/locationtech/udig/project/ui/internal/MapEditor.java
+++ b/plugins/org.locationtech.udig.project.ui/src/org/locationtech/udig/project/ui/internal/MapEditor.java
@@ -675,7 +675,7 @@ public class MapEditor extends EditorPart
         setTitleToolTip(Messages.MapEditor_titleToolTip);
         setTitleImage(ProjectUIPlugin.getDefault().getImage(ISharedImages.MAP_OBJ));
 
-        viewer = new MapViewer(composite, SWT.DOUBLE_BUFFERED);
+        viewer = new MapViewer(composite, this, SWT.DOUBLE_BUFFERED);
         // allow the viewer to open our context menu; work with our selection provider etc
         viewer.init(this);
         // if a map was provided as input we can ask the viewer to use it

--- a/plugins/org.locationtech.udig.project.ui/src/org/locationtech/udig/project/ui/internal/MapEditorPart.java
+++ b/plugins/org.locationtech.udig.project.ui/src/org/locationtech/udig/project/ui/internal/MapEditorPart.java
@@ -12,7 +12,6 @@ package org.locationtech.udig.project.ui.internal;
 
 import org.eclipse.swt.widgets.Composite;
 import org.eclipse.ui.IEditorPart;
-import org.locationtech.udig.internal.ui.UDIGDropHandler;
 
 /**
  * interface for map editor related map parts
@@ -28,13 +27,6 @@ public interface MapEditorPart extends MapPart, IEditorPart {
     static final String LAYER_DIRTY_KEY = "DIRTY"; //$NON-NLS-1$
 
     MapEditorSite getMapEditorSite();
-    
-    // helper methods for tools
-    boolean isTesting();
-
-    void setTesting(boolean isTesting);
-
-    UDIGDropHandler getDropHandler();
 
     boolean isDragging();
 

--- a/plugins/org.locationtech.udig.project.ui/src/org/locationtech/udig/project/ui/internal/MapEditorWithPalette.java
+++ b/plugins/org.locationtech.udig.project.ui/src/org/locationtech/udig/project/ui/internal/MapEditorWithPalette.java
@@ -731,7 +731,7 @@ public class MapEditorWithPalette extends GraphicalEditorWithFlyoutPalette imple
         setTitleToolTip(Messages.MapEditor_titleToolTip);
         setTitleImage(ProjectUIPlugin.getDefault().getImage(ISharedImages.MAP_OBJ));
 
-        viewer = new MapViewer(composite, SWT.DOUBLE_BUFFERED);
+        viewer = new MapViewer(composite, this, SWT.DOUBLE_BUFFERED);
         // we need an edit domain for GEF
         // This represents the "Current Tool" for the Palette
         // We should not duplicate the idea of current tools so we may

--- a/plugins/org.locationtech.udig.project.ui/src/org/locationtech/udig/project/ui/internal/MapPart.java
+++ b/plugins/org.locationtech.udig.project.ui/src/org/locationtech/udig/project/ui/internal/MapPart.java
@@ -12,6 +12,8 @@ package org.locationtech.udig.project.ui.internal;
 
 import org.eclipse.jface.action.IStatusLineManager;
 import org.eclipse.swt.widgets.Control;
+import org.eclipse.ui.IWorkbenchPart;
+import org.locationtech.udig.internal.ui.UDIGDropHandler;
 import org.locationtech.udig.project.internal.Map;
 import org.locationtech.udig.project.ui.tool.IMapEditorSelectionProvider;
 
@@ -32,7 +34,7 @@ import org.locationtech.udig.project.ui.tool.IMapEditorSelectionProvider;
  * @since 1.1.0
  * @version 1.3.0
  */
-public interface MapPart {
+public interface MapPart extends IWorkbenchPart {
 
     /**
      * Returns the map that this editor edits
@@ -68,10 +70,16 @@ public interface MapPart {
      */
     public abstract IStatusLineManager getStatusLineManager();
 
-    // /**
-    // * EditDomain used to control the current tool.
-    // * @return
-    // */
-    // public abstract MapEditDomain getEditDomain();
+    /**
+     * Returns the DropHandler from this editor.
+     * 
+     * @return Returns the DropHandler from this editor.
+     */
+    public UDIGDropHandler getDropHandler();
+
+    // helper methods for tools
+    boolean isTesting();
+
+    void setTesting(boolean isTesting);
 
 }

--- a/plugins/org.locationtech.udig.project.ui/src/org/locationtech/udig/project/ui/internal/tool/display/ToolManager.java
+++ b/plugins/org.locationtech.udig.project.ui/src/org/locationtech/udig/project/ui/internal/tool/display/ToolManager.java
@@ -93,7 +93,6 @@ import org.locationtech.udig.project.internal.ProjectPackage;
 import org.locationtech.udig.project.internal.commands.CreateMapCommand;
 import org.locationtech.udig.project.ui.ApplicationGIS;
 import org.locationtech.udig.project.ui.internal.ApplicationGISInternal;
-import org.locationtech.udig.project.ui.internal.MapEditorPart;
 import org.locationtech.udig.project.ui.internal.MapEditorWithPalette;
 import org.locationtech.udig.project.ui.internal.MapPart;
 import org.locationtech.udig.project.ui.internal.Messages;
@@ -2178,7 +2177,7 @@ public class ToolManager implements IToolManager {
             Object selection = firstSelectedElement();
 
             if (contents != null) {
-                MapEditorPart activeEditor = ApplicationGISInternal.getActiveEditor();
+                MapPart activeEditor = ApplicationGISInternal.getActiveEditor();
                 final Map finalMap;
                 final UDIGDropHandler finalDropHandler;
                 if( selection instanceof Map){
@@ -2206,7 +2205,7 @@ public class ToolManager implements IToolManager {
                     finalMap = activeEditor.getMap();
                 }
 
-                final MapEditorPart finalActiveEditor = activeEditor;
+                final MapPart finalActiveEditor = activeEditor;
                 ILayer selectedLayer = finalMap.getEditManager().getSelectedLayer();
                 if( selectedLayer==null ){
                     finalDropHandler.setTarget(finalMap);

--- a/plugins/org.locationtech.udig.tool.edit/src/org/locationtech/udig/tools/edit/activator/DeleteGlobalActionSetterActivator.java
+++ b/plugins/org.locationtech.udig.tool.edit/src/org/locationtech/udig/tools/edit/activator/DeleteGlobalActionSetterActivator.java
@@ -22,6 +22,7 @@ import org.eclipse.ui.actions.ActionFactory;
 import org.locationtech.udig.project.command.UndoableComposite;
 import org.locationtech.udig.project.ui.ApplicationGIS;
 import org.locationtech.udig.project.ui.internal.ApplicationGISInternal;
+import org.locationtech.udig.project.ui.internal.MapPart;
 import org.locationtech.udig.tool.edit.internal.Messages;
 import org.locationtech.udig.tools.edit.Activator;
 import org.locationtech.udig.tools.edit.EditPlugin;
@@ -53,7 +54,7 @@ public class DeleteGlobalActionSetterActivator implements Activator {
         IActionBars actionBars = handler.getContext().getActionBars();
         if( actionBars==null )
             return;
-        IWorkbenchPart part= ApplicationGISInternal.getActiveEditor();
+        MapPart part = ApplicationGISInternal.getActiveEditor();
 
         if( part == null ) return;
 
@@ -67,7 +68,7 @@ public class DeleteGlobalActionSetterActivator implements Activator {
             deleteVertexHandler.setImageDescriptor(oldAction.getImageDescriptor());
             deleteVertexHandler.setDisabledImageDescriptor(oldAction.getDisabledImageDescriptor());
         }
-        ApplicationGIS.getToolManager().setDELETEAction(deleteVertexHandler,part);
+        ApplicationGIS.getToolManager().setDELETEAction(deleteVertexHandler, part);
         actionBars.setGlobalActionHandler(ActionFactory.DELETE.getId(), deleteVertexHandler);
         actionBars.updateActionBars();
         keyBindingService.registerAction(deleteVertexHandler);
@@ -79,17 +80,18 @@ public class DeleteGlobalActionSetterActivator implements Activator {
         if( actionBars==null || oldAction==null ){
             return;
         }
-        IWorkbenchPart part=ApplicationGISInternal.getActiveEditor();
+        MapPart part = ApplicationGISInternal.getActiveEditor();
+        IWorkbenchPart wbPart = (IWorkbenchPart) part;
 
         if( part == null ) return;
 
-        IWorkbenchPartSite site = part.getSite();
+        IWorkbenchPartSite site = wbPart.getSite();
 
         IKeyBindingService keyBindingService = site.getKeyBindingService();
         keyBindingService.unregisterAction(deleteVertexHandler);
         deleteVertexHandler=null;
 
-        ApplicationGIS.getToolManager().setDELETEAction(oldAction,part);
+        ApplicationGIS.getToolManager().setDELETEAction(oldAction, wbPart);
         actionBars.setGlobalActionHandler(ActionFactory.DELETE.getId(), oldAction);
         if( oldAction!=null ){
             keyBindingService.registerAction(oldAction);

--- a/plugins/org.locationtech.udig.tutorials.rcp/src/org/locationtech/udig/tutorials/rcp/MapView.java
+++ b/plugins/org.locationtech.udig.tutorials.rcp/src/org/locationtech/udig/tutorials/rcp/MapView.java
@@ -15,25 +15,6 @@ import java.net.URL;
 import java.util.ArrayList;
 import java.util.List;
 
-import org.locationtech.udig.catalog.CatalogPlugin;
-import org.locationtech.udig.catalog.ICatalog;
-import org.locationtech.udig.catalog.IGeoResource;
-import org.locationtech.udig.catalog.IService;
-import org.locationtech.udig.catalog.IServiceFactory;
-import org.locationtech.udig.project.internal.Layer;
-import org.locationtech.udig.project.internal.Map;
-import org.locationtech.udig.project.internal.ProjectFactory;
-import org.locationtech.udig.project.internal.command.navigation.SetViewportBBoxCommand;
-import org.locationtech.udig.project.internal.commands.AddLayersCommand;
-import org.locationtech.udig.project.ui.internal.MapPart;
-import org.locationtech.udig.project.ui.internal.wizard.MapImport;
-import org.locationtech.udig.project.ui.tool.IMapEditorSelectionProvider;
-import org.locationtech.udig.project.ui.tool.ModalTool;
-import org.locationtech.udig.project.ui.viewers.MapViewer;
-import org.locationtech.udig.tools.internal.FixedScalePan;
-import org.locationtech.udig.tools.internal.Zoom;
-import org.locationtech.udig.tutorials.tracking.glasspane.SeagullGlassPaneOp;
-
 import org.eclipse.core.runtime.IStatus;
 import org.eclipse.core.runtime.NullProgressMonitor;
 import org.eclipse.core.runtime.Status;
@@ -49,6 +30,24 @@ import org.eclipse.swt.widgets.Display;
 import org.eclipse.swt.widgets.FileDialog;
 import org.eclipse.ui.part.ViewPart;
 import org.geotools.geometry.jts.ReferencedEnvelope;
+import org.locationtech.udig.catalog.CatalogPlugin;
+import org.locationtech.udig.catalog.ICatalog;
+import org.locationtech.udig.catalog.IGeoResource;
+import org.locationtech.udig.catalog.IService;
+import org.locationtech.udig.internal.ui.UDIGDropHandler;
+import org.locationtech.udig.project.internal.Layer;
+import org.locationtech.udig.project.internal.Map;
+import org.locationtech.udig.project.internal.ProjectFactory;
+import org.locationtech.udig.project.internal.command.navigation.SetViewportBBoxCommand;
+import org.locationtech.udig.project.internal.commands.AddLayersCommand;
+import org.locationtech.udig.project.ui.internal.MapPart;
+import org.locationtech.udig.project.ui.internal.wizard.MapImport;
+import org.locationtech.udig.project.ui.tool.IMapEditorSelectionProvider;
+import org.locationtech.udig.project.ui.tool.ModalTool;
+import org.locationtech.udig.project.ui.viewers.MapViewer;
+import org.locationtech.udig.tools.internal.FixedScalePan;
+import org.locationtech.udig.tools.internal.Zoom;
+import org.locationtech.udig.tutorials.tracking.glasspane.SeagullGlassPaneOp;
 
 /**
  * A map view.
@@ -64,6 +63,9 @@ public class MapView extends ViewPart implements MapPart {
     // private RenderManager renderManager;
     private Map map;
     private SeagullGlassPaneOp seagullOp;
+
+    /** This is for testing only DO NOT USE OTHERWISE */
+    public boolean isTesting;
 
     public MapView() {
         super();
@@ -330,5 +332,21 @@ public class MapView extends ViewPart implements MapPart {
         }
         tool.setActive(true);
         activeTool = tool;
+    }
+
+    @Override
+     public UDIGDropHandler getDropHandler() {
+        return mapviewer.getDropHandler();
+     }
+
+    // helper methods for Toolmanager
+    @Override
+    public boolean isTesting() {
+        return this.isTesting;
+    }
+
+    @Override
+    public void setTesting(boolean testing) {
+        this.isTesting = testing;
     }
 }

--- a/plugins/org.locationtech.udig.tutorials.rcp/src/org/locationtech/udig/tutorials/rcp/OverviewMapView.java
+++ b/plugins/org.locationtech.udig.tutorials.rcp/src/org/locationtech/udig/tutorials/rcp/OverviewMapView.java
@@ -10,23 +10,6 @@
  */
 package org.locationtech.udig.tutorials.rcp;
 
-import org.locationtech.udig.project.internal.Map;
-import org.locationtech.udig.project.internal.ProjectFactory;
-import org.locationtech.udig.project.internal.command.navigation.SetViewportBBoxCommand;
-import org.locationtech.udig.project.ui.ApplicationGIS;
-import org.locationtech.udig.project.ui.internal.MapPart;
-import org.locationtech.udig.project.ui.internal.tool.display.ToolManager;
-import org.locationtech.udig.project.ui.internal.wizard.MapImport;
-import org.locationtech.udig.project.ui.tool.IMapEditorSelectionProvider;
-import org.locationtech.udig.project.ui.tool.IToolManager;
-import org.locationtech.udig.project.ui.tool.ModalTool;
-import org.locationtech.udig.project.ui.viewers.MapEditDomain;
-import org.locationtech.udig.project.ui.viewers.MapViewer;
-import org.locationtech.udig.tools.internal.ScrollPanTool;
-import org.locationtech.udig.tools.internal.Zoom;
-import org.locationtech.udig.tutorials.tracking.glasspane.SeagullGlassPaneOp;
-import org.locationtech.udig.tutorials.tracking.glasspane.TrackSeagullOp;
-
 import org.eclipse.core.runtime.NullProgressMonitor;
 import org.eclipse.jface.action.Action;
 import org.eclipse.jface.action.IMenuManager;
@@ -45,6 +28,20 @@ import org.eclipse.ui.IViewSite;
 import org.eclipse.ui.PartInitException;
 import org.eclipse.ui.part.ViewPart;
 import org.geotools.geometry.jts.ReferencedEnvelope;
+import org.locationtech.udig.internal.ui.UDIGDropHandler;
+import org.locationtech.udig.project.internal.Map;
+import org.locationtech.udig.project.internal.ProjectFactory;
+import org.locationtech.udig.project.internal.command.navigation.SetViewportBBoxCommand;
+import org.locationtech.udig.project.ui.internal.MapPart;
+import org.locationtech.udig.project.ui.internal.wizard.MapImport;
+import org.locationtech.udig.project.ui.tool.IMapEditorSelectionProvider;
+import org.locationtech.udig.project.ui.tool.ModalTool;
+import org.locationtech.udig.project.ui.viewers.MapEditDomain;
+import org.locationtech.udig.project.ui.viewers.MapViewer;
+import org.locationtech.udig.tools.internal.ScrollPanTool;
+import org.locationtech.udig.tools.internal.Zoom;
+import org.locationtech.udig.tutorials.tracking.glasspane.SeagullGlassPaneOp;
+import org.locationtech.udig.tutorials.tracking.glasspane.TrackSeagullOp;
 
 /**
  * A sample map view that contains an overview map in the lower left corner.
@@ -64,7 +61,10 @@ public class OverviewMapView extends ViewPart implements MapPart {
     private MapViewer mapviewer; // main map viewer
     private OverviewMapViewer overviewmapviewer; // overview map viewer
 
-	private MapEditDomain editDomain;
+    private MapEditDomain editDomain;
+
+    /** This is for testing only DO NOT USE OTHERWISE */
+    public boolean isTesting;
 
     public OverviewMapView() {
         super();
@@ -245,6 +245,22 @@ public class OverviewMapView extends ViewPart implements MapPart {
 
     }
 
+    @Override
+    public UDIGDropHandler getDropHandler() {
+        return mapviewer.getDropHandler(); // oder overviewmapviewer.getDropHandler() ????
+    }
+
+    // helper methods for Toolmanager
+    @Override
+    public boolean isTesting() {
+        return this.isTesting;
+    }
+
+    @Override
+    public void setTesting(boolean testing) {
+        this.isTesting = testing;
+    }
+
     class SetBackgroundWMSCAction extends Action {
         public SetBackgroundWMSCAction() {
             super("Add Background layer..."); //$NON-NLS-1$
@@ -264,6 +280,7 @@ public class OverviewMapView extends ViewPart implements MapPart {
 	public IStatusLineManager getStatusLineManager() {
 		return getViewSite().getActionBars().getStatusLineManager();
 	}
+
 }
 
 class OverviewLayoutManager extends Layout {
@@ -278,3 +295,4 @@ class OverviewLayoutManager extends Layout {
     }
 
 }
+


### PR DESCRIPTION
Change-Id: Ieba8d671ed5272fdb60ee575c4f8f5819a996dda
Signed-off-by: iharnisch <isabelle_harnisch@posteo.de>

By changing the corresponding occurences of IEditorPart to the more abstracted MapPart type, maps can now also behave like views.