### PR TITLE
Revert classpath change for module 'org.locationtech.udig.catalog.tests'

### DIFF
--- a/plugins/org.locationtech.udig.catalog.tests/.classpath
+++ b/plugins/org.locationtech.udig.catalog.tests/.classpath
@@ -2,10 +2,6 @@
 <classpath>
 	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8"/>
 	<classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
-	<classpathentry kind="src" path="src/">
-		<attributes>
-			<attribute name="test" value="true"/>
-		</attributes>
-	</classpathentry>
+	<classpathentry kind="src" path="src/"/>
 	<classpathentry kind="output" path="bin"/>
 </classpath>


### PR DESCRIPTION
... in order to fix https://github.com/locationtech/udig-platform/issues/537