### PR TITLE
Re-add opencsv (v 3.7) to fix Eclipse errors

### DIFF
--- a/plugins/org.locationtech.udig.libs/.classpath
+++ b/plugins/org.locationtech.udig.libs/.classpath
@@ -192,6 +192,7 @@
 	<classpathentry exported="true" kind="lib" path="lib/net.opengis.wfs-22.1.jar"/>
 	<classpathentry exported="true" kind="lib" path="lib/net.opengis.wmts-22.1.jar"/>
 	<classpathentry exported="true" kind="lib" path="lib/net.opengis.wps-22.1.jar"/>
+	<classpathentry exported="true" kind="lib" path="lib/opencsv-3.7.jar"/>
 	<classpathentry exported="true" kind="lib" path="lib/opendap-2.1.jar"/>
 	<classpathentry exported="true" kind="lib" path="lib/org.eclipse.xsd-2.12.0.jar"/>
 	<classpathentry exported="true" kind="lib" path="lib/org.w3.xlink-22.1.jar"/>

--- a/plugins/org.locationtech.udig.libs/build.properties
+++ b/plugins/org.locationtech.udig.libs/build.properties
@@ -198,6 +198,7 @@ bin.includes = .,\
                lib/net.opengis.wfs-22.1.jar,\
                lib/net.opengis.wmts-22.1.jar,\
                lib/net.opengis.wps-22.1.jar,\
+               lib/opencsv-3.7.jar,\
                lib/opendap-2.1.jar,\
                lib/org.eclipse.xsd-2.12.0.jar,\
                lib/org.w3.xlink-22.1.jar,\

--- a/plugins/org.locationtech.udig.libs/pom-libs.xml
+++ b/plugins/org.locationtech.udig.libs/pom-libs.xml
@@ -434,6 +434,11 @@
 		</dependency>
 
 		<dependency>
+			<groupId>com.opencsv</groupId>
+			<artifactId>opencsv</artifactId>
+			<version>3.7</version>
+		</dependency>
+		<dependency>
 			<groupId>opendap</groupId>
 			<artifactId>opendap</artifactId>
 			<version>2.1</version>


### PR DESCRIPTION
After the merge of https://github.com/locationtech/udig-platform/pull/532 I faced issues accross the project because "opencsv" could not be found anymore. Some of the projects rely on this library though.

Therefore I added the library again and all issues are resolved within my Eclipse!