### PR TITLE
Allows to abort edit tools

### DIFF
--- a/plugins/org.locationtech.udig.tool.edit/plugin.xml
+++ b/plugins/org.locationtech.udig.tool.edit/plugin.xml
@@ -437,6 +437,11 @@
    </extension>
    <extension
          point="org.eclipse.ui.bindings">
+       <key
+             commandId="org.locationtech.udig.tool.edit.clearAction"
+             contextId="org.eclipse.ui.contexts.window"
+             sequence="ESC"
+             schemeId="org.eclipse.ui.defaultAcceleratorConfiguration"/>
       <key
             commandId="org.locationtech.udig.tool.edit.clearAction"
             contextId="org.eclipse.ui.contexts.window"


### PR DESCRIPTION
with ESC & modifies user message shown on invalid geometry

Reproduction:

- Draw an invalid polygon on Map
- Error dialog appears
- You are not able to use ESC to exit the drawing