### PR TITLE
Feature to hide renderer job in progress views

### DIFF
--- a/docs/user/en/reference/Rendering Preferences.rst
+++ b/docs/user/en/reference/Rendering Preferences.rst
@@ -45,7 +45,23 @@ Available Preferences
    As stated this is an advanced option so do not modify it unless you understand the image formats
    and the ramifications of using one image type over another.
 
- 
+Other Preferences
+`````````````````
+
+.. _project_preferences-hide-renderer-job:
+
+HIDE_RENDER_JOB
+~~~~~~~~~~~~~~~
+Allows to control, if executed jobs are shown in Progress View. If this option is
+available or set to **true**, the jobs are not shown. Otherwise, which is the default, jobs
+are shown in Progress View. This option is not intended to be set or changed at runtime.
+Use *.option* file in installation folder to configure application behavior:
+
+.. code-block::
+   :caption: .options file
+
+       org.locationtech.udig.project/HIDE_RENDER_JOB=true
+
 **Related reference**
 
 :doc:`Catalog Preferences`

--- a/docs/user/en/what_is_new/What is new 2.3.rst
+++ b/docs/user/en/what_is_new/What is new 2.3.rst
@@ -12,7 +12,7 @@ Improvements and Fixes
 ----------------------
 * `#398 <https://github.com/locationtech/udig-platform/issues/398>`_ : valid state for layer in Layers View as checked if visible
 * `#415 <https://github.com/locationtech/udig-platform/issues/415>`_ : fixed NullPointerExecption if tool category extension has name attribut not set
-* `#420 <https://github.com/locationtech/udig-platform/issues/420>`_ : allows to hide composite renderer jobs with preferences `org.locationtech.udig.project/HIDE_RENDER_JOB=true`
+* `#420 <https://github.com/locationtech/udig-platform/issues/420>`_ & `#611 <https://github.com/locationtech/udig-platform/issues/611>`_ : allows to hide composite renderer jobs with preferences `org.locationtech.udig.project/HIDE_RENDER_JOB=true`, see :ref:`HIDE_RENDER_JOB Preferences <project_preferences-hide-renderer-job>`
 * `#432 <https://github.com/locationtech/udig-platform/issues/432>`_ : allows translate Progress View label and nl-specific icon
 * `#439 <https://github.com/locationtech/udig-platform/issues/439>`_ : uses Mockito as Test-Mockup framework rather than EasyMock
 * `#443 <https://github.com/locationtech/udig-platform/issues/443>`_ : moved jfreechart libaries into seperate bundle, to allow to choose other/newer version for sdk-users

--- a/plugins/org.locationtech.udig.project.tests/src/org/locationtech/udig/project/render/RendererUtilsTest.java
+++ b/plugins/org.locationtech.udig.project.tests/src/org/locationtech/udig/project/render/RendererUtilsTest.java
@@ -1,0 +1,57 @@
+/**
+ * uDig - User Friendly Desktop Internet GIS client
+ * http://udig.refractions.net
+ * (C) 2021, Refractions Research Inc.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * (http://www.eclipse.org/legal/epl-v10.html), and the Refractions BSD
+ * License v1.0 (http://udig.refractions.net/files/bsd3-v10.html).
+ */
+package org.locationtech.udig.project.render;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import org.eclipse.ui.preferences.ScopedPreferenceStore;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.locationtech.udig.project.internal.ProjectPlugin;
+import org.locationtech.udig.project.preferences.PreferenceConstants;
+
+public class RendererUtilsTest {
+
+    Boolean backUpPrefHideJobs = null;
+
+    private ScopedPreferenceStore preferenceStore;
+
+    @Before
+    public void setup() {
+        preferenceStore = ProjectPlugin.getPlugin().getPreferenceStore();
+        if (preferenceStore.contains(PreferenceConstants.P_HIDE_RENDER_JOB)) {
+            backUpPrefHideJobs = preferenceStore.getBoolean(PreferenceConstants.P_HIDE_RENDER_JOB);
+        } else {
+            assertFalse(RendererUtils.isRendererJobSystemJob());
+        }
+    }
+
+    @After
+    public void after() {
+        if (backUpPrefHideJobs != null) {
+            preferenceStore.setValue(PreferenceConstants.P_HIDE_RENDER_JOB, backUpPrefHideJobs);
+        }
+    }
+
+    @Test
+    public void rendererJob_IsSystemJob_HIDEPreferencesIsSet() throws Exception {
+        preferenceStore.setValue(PreferenceConstants.P_HIDE_RENDER_JOB, true);
+        assertTrue(RendererUtils.isRendererJobSystemJob());
+    }
+
+    @Test
+    public void rendererJob_IsNotSystemJob_HIDEPreferencesIsSetFalse() throws Exception {
+        preferenceStore.setValue(PreferenceConstants.P_HIDE_RENDER_JOB, false);
+        assertFalse(RendererUtils.isRendererJobSystemJob());
+    }
+}

--- a/plugins/org.locationtech.udig.project/src/org/locationtech/udig/project/internal/render/impl/RenderExecutorComposite.java
+++ b/plugins/org.locationtech.udig.project/src/org/locationtech/udig/project/internal/render/impl/RenderExecutorComposite.java
@@ -1,4 +1,5 @@
-/* uDig - User Friendly Desktop Internet GIS client
+/**
+ * uDig - User Friendly Desktop Internet GIS client
  * http://udig.refractions.net
  * (C) 2004-2012, Refractions Research Inc.
  *
@@ -26,21 +27,21 @@ import org.locationtech.udig.project.internal.Trace;
 import org.locationtech.udig.project.internal.render.ExecutorVisitor;
 import org.locationtech.udig.project.internal.render.RenderExecutor;
 import org.locationtech.udig.project.internal.render.Renderer;
-import org.locationtech.udig.project.preferences.PreferenceConstants;
 import org.locationtech.udig.project.render.IRenderContext;
 import org.locationtech.udig.project.render.IRenderer;
 import org.locationtech.udig.project.render.RenderException;
+import org.locationtech.udig.project.render.RendererUtils;
 
 /**
  * An Executor specifically for executing CompositeRenderers.
  * <p>
- * This class appears to actually *be* the uDig appplication :-)
+ * This class appears to actually *be* the uDig application :-)
  * <p>
  * This class is supposed to listen to all events going down and is supposed to queue up some work
  * and let 'er rip.
  * <ul>
  * <li>RENDER_REQUEST causes this to refresh()
- * 
+ *
  * @author jeichar
  * @since 0.6.0
  */
@@ -52,22 +53,22 @@ public class RenderExecutorComposite extends RenderExecutorMultiLayer {
 
         /**
          * Construct <code>CompositeRendererJob</code>.
-         * 
+         *
          * @param executor
          */
-        public CompositeRendererJob( RenderExecutorComposite executor ) {
+        public CompositeRendererJob(RenderExecutorComposite executor) {
             super(executor);
             setPriority(Job.INTERACTIVE);
         }
 
         @Override
-        protected void clearBounds( Envelope bounds2 ) {
+        protected void clearBounds(Envelope bounds2) {
             // ignore because we don't want to clear until first update is received from one of the
             // contained renderers
         }
 
         @Override
-        protected void finalizeLabelPainter( IRenderContext context2 ) {
+        protected void finalizeLabelPainter(IRenderContext context2) {
             // do nothing
         }
 
@@ -81,7 +82,7 @@ public class RenderExecutorComposite extends RenderExecutorMultiLayer {
 
         /**
          * Incrementally updates the display until rendering is complete.
-         * 
+         *
          * @throws InterruptedException
          * @throws RenderException
          */
@@ -96,23 +97,21 @@ public class RenderExecutorComposite extends RenderExecutorMultiLayer {
             CompositeRendererImpl renderer2 = getExecutor().getRenderer();
             long start = System.currentTimeMillis();
             synchronized (getExecutor()) {
-                while( (getMonitor() != null && !getMonitor().isCanceled())
-                        && isRendering(renderer2) && getExecutor().timeout < TIMEOUT ) {
+                while ((getMonitor() != null && !getMonitor().isCanceled())
+                        && isRendering(renderer2) && getExecutor().timeout < TIMEOUT) {
                     getExecutor().wait(wait_period);
                     long now = System.currentTimeMillis();
-                    getExecutor().timeout = (int)(now - start);
+                    getExecutor().timeout = (int) (now - start);
                     if (isRendering(renderer2)) {
                         renderer2.refreshImage(false);
                         getExecutor().setState(RENDERING);
                     }
                 }
             }
-//            if (getExecutor().timeout>= TIMEOUT){ 
-//                System.out.println("Timed Out"); 
-//            }            
 
-            if( ProjectPlugin.getPlugin().isDebugging()){
-                String message = "Time taken to render is: " + (System.currentTimeMillis() - start) / 1000 + "seconds"; //$NON-NLS-1$ //$NON-NLS-2$
+            if (ProjectPlugin.getPlugin().isDebugging()) {
+                String message = "Time taken to render is: " //$NON-NLS-1$
+                        + (System.currentTimeMillis() - start) / 1000 + "seconds"; //$NON-NLS-1$
                 ProjectPlugin.trace(Trace.RENDER, getClass(), message, null);
             }
             synchronized (getExecutor()) {
@@ -124,16 +123,6 @@ public class RenderExecutorComposite extends RenderExecutorMultiLayer {
             }
         }
 
-        @Override
-        protected void init() {
-            updateSystemState(this);
-        }
-
-        @Override
-        protected void initializeLabelPainter( IRenderContext context2 ) {
-            // do nothing
-        }
-
         /**
          * @see org.locationtech.udig.project.internal.render.impl.RenderJob#postRendering()
          */
@@ -142,14 +131,13 @@ public class RenderExecutorComposite extends RenderExecutorMultiLayer {
 
             if (monitor.isCanceled()) {
                 executor.getRenderer().setState(CANCELLED);
-                for( RenderExecutor renderer : ((CompositeRendererImpl) executor.getRenderer())
-                        .getRenderExecutors() ) {
-                    if (renderer.getContext().isVisible() && executor.getState() != IRenderer.DONE) {
+                for (RenderExecutor renderer : ((CompositeRendererImpl) executor.getRenderer())
+                        .getRenderExecutors()) {
+                    if (renderer.getContext().isVisible()
+                            && executor.getState() != IRenderer.DONE) {
                         renderer.getContext().setStatus(ILayer.WARNING);
-                        renderer
-                                .getContext()
-                                .setStatusMessage(
-                                        "Timed out while rendering this layer.  Seems to have blocked, check that the server is up"); //$NON-NLS-1$
+                        renderer.getContext().setStatusMessage(
+                                "Timed out while rendering this layer.  Seems to have blocked, check that the server is up"); //$NON-NLS-1$
                     }
                 }
                 return;
@@ -160,7 +148,7 @@ public class RenderExecutorComposite extends RenderExecutorMultiLayer {
          * @see org.locationtech.udig.project.internal.render.impl.RenderJob#startRendering()
          */
         @Override
-        protected void startRendering( Envelope bounds, IProgressMonitor monitor ) throws Throwable {
+        protected void startRendering(Envelope bounds, IProgressMonitor monitor) throws Throwable {
             // need to show that we are in update just in case a renderer triggers a state event
             // in the RenderExecutor.render() method.
             synchronized (getExecutor()) {
@@ -177,7 +165,7 @@ public class RenderExecutorComposite extends RenderExecutorMultiLayer {
      * <p>
      * It will also set some time out states so the screen is not hammered with refreshes as the
      * children are busy.
-     * 
+     *
      * @author jeichar
      * @since 0.6.0
      */
@@ -185,10 +173,10 @@ public class RenderExecutorComposite extends RenderExecutorMultiLayer {
 
         /**
          * Construct <code>CompositeRendererListener</code>.
-         * 
+         *
          * @param executor
          */
-        CompositeRendererListener( RenderExecutorComposite executor ) {
+        CompositeRendererListener(RenderExecutorComposite executor) {
             super(executor);
         }
 
@@ -200,8 +188,8 @@ public class RenderExecutorComposite extends RenderExecutorMultiLayer {
          * @see org.locationtech.udig.project.internal.render.impl.RenderExecutorMultiLayer.MultiLayerRendererListener#stateChanged(org.eclipse.emf.common.notify.Notification)
          */
         @Override
-        protected void stateChanged( Notification msg ) {
-            switch( msg.getNewIntValue() ) {
+        protected void stateChanged(Notification msg) {
+            switch (msg.getNewIntValue()) {
             case Renderer.RENDERING:
                 getExecutor().resetTimeout();
                 synchronized (getExecutor()) {
@@ -218,8 +206,8 @@ public class RenderExecutorComposite extends RenderExecutorMultiLayer {
                             executor.setState(Renderer.DONE);
                         }
                         if (!isRendering(getExecutor().getRenderer())
-                                || (getExecutor().renderJob.getMonitor() != null && getExecutor().renderJob
-                                        .getMonitor().isCanceled())) {
+                                || (getExecutor().renderJob.getMonitor() != null
+                                        && getExecutor().renderJob.getMonitor().isCanceled())) {
                             getExecutor().notifyAll();
                         }
                     }
@@ -230,7 +218,8 @@ public class RenderExecutorComposite extends RenderExecutorMultiLayer {
                 }
                 break;
             case Renderer.RENDER_REQUEST:
-                //use this block and synchronization, such that we won't lose delivery because of too many rendering calls
+                // use this block and synchronization, such that we won't lose delivery because of
+                // too many rendering calls
                 synchronized (getExecutor()) {
                     boolean oldValue = executor.eDeliver();
                     try {
@@ -295,12 +284,12 @@ public class RenderExecutorComposite extends RenderExecutorMultiLayer {
      * @param renderer2
      * @return
      */
-    static boolean isRendering( CompositeRendererImpl renderer2 ) {
+    static boolean isRendering(CompositeRendererImpl renderer2) {
         Collection<RenderExecutor> executors = renderer2.getRenderExecutors();
-        for( RenderExecutor executor : executors ) {
-            if (executor.getContext().isVisible()
-                    && (executor.getState() == IRenderer.RENDERING
-                            || executor.getState() == IRenderer.STARTING || executor.getState() == IRenderer.RENDER_REQUEST))
+        for (RenderExecutor executor : executors) {
+            if (executor.getContext().isVisible() && (executor.getState() == IRenderer.RENDERING
+                    || executor.getState() == IRenderer.STARTING
+                    || executor.getState() == IRenderer.RENDER_REQUEST))
                 return true;
         }
         return false;
@@ -323,9 +312,9 @@ public class RenderExecutorComposite extends RenderExecutorMultiLayer {
 
     @Override
     protected LayerListener getLayerListener() {
-        return new LayerListener(this){
+        return new LayerListener(this) {
             @Override
-            public void notifyChanged( Notification msg ) {
+            public void notifyChanged(Notification msg) {
                 // do nothingsuper.notifyChanged(msg);
             }
         };
@@ -346,8 +335,8 @@ public class RenderExecutorComposite extends RenderExecutorMultiLayer {
 
     @Override
     protected String getRenderJobName() {
-        return MessageFormat.format(Messages.RenderExecutorImpl_message, new Object[]{getContext()
-                .getMap().getName()});
+        return MessageFormat.format(Messages.RenderExecutorImpl_message,
+                new Object[] { getContext().getMap().getName() });
     }
 
     /**
@@ -355,9 +344,9 @@ public class RenderExecutorComposite extends RenderExecutorMultiLayer {
      */
     public synchronized void refresh() {
         if (refreshJob == null) {
-            refreshJob = new Job(getRenderJobName()){
+            refreshJob = new Job(getRenderJobName()) {
                 @Override
-                protected IStatus run( IProgressMonitor monitor ) {
+                protected IStatus run(IProgressMonitor monitor) {
                     try {
                         ((CompositeRendererJob) renderJob).incrementalUpdate();
                     } catch (Exception e) {
@@ -368,7 +357,7 @@ public class RenderExecutorComposite extends RenderExecutorMultiLayer {
                 }
 
             };
-            refreshJob.setSystem(false);
+            refreshJob.setSystem(RendererUtils.isRendererJobSystemJob());
             refreshJob.setPriority(Job.INTERACTIVE);
         }
         refreshJob.schedule();
@@ -401,8 +390,9 @@ public class RenderExecutorComposite extends RenderExecutorMultiLayer {
     protected synchronized void resetTimeout() {
         timeout = 0;
     }
+
     @Override
-    protected void resyncState( Renderer renderer ) {
+    protected void resyncState(Renderer renderer) {
 
         // FIXME sync sub renderers, witness composite renderer
         //
@@ -413,8 +403,10 @@ public class RenderExecutorComposite extends RenderExecutorMultiLayer {
      * @see org.locationtech.udig.project.internal.render.impl.RenderExecutorImpl#setRenderer(org.locationtech.udig.project.render.Renderer)
      */
     @Override
-    public void setRenderer( Renderer newRenderer ) {
-        updateSystemState(renderJob);
+    public void setRenderer(Renderer newRenderer) {
+        if (renderJob != null) {
+            renderJob.setSystem(RendererUtils.isRendererJobSystemJob());
+        }
         super.setRendererInternal(newRenderer);
     }
 
@@ -423,7 +415,7 @@ public class RenderExecutorComposite extends RenderExecutorMultiLayer {
      */
     @Override
     public void stopRendering() {
-        for( RenderExecutor executor : getRenderer().getRenderExecutors() ) {
+        for (RenderExecutor executor : getRenderer().getRenderExecutors()) {
             executor.stopRendering();
         }
         super.stopRendering();
@@ -433,19 +425,7 @@ public class RenderExecutorComposite extends RenderExecutorMultiLayer {
      * @see org.locationtech.udig.project.internal.render.impl.RenderExecutorImpl#visit(org.locationtech.udig.project.render.ExecutorVisitor)
      */
     @Override
-    public void visit( ExecutorVisitor visitor ) {
+    public void visit(ExecutorVisitor visitor) {
         visitor.visit(this);
-    }
-
-    /**
-     * Sets the system state of the provided job. The setting is read from the preference store
-     * using the {@link PreferenceConstants#P_HIDE_RENDER_JOB} constant.
-     * 
-     * @param job the job whose system state should be updated
-     */
-    private static void updateSystemState(Job job) {
-        boolean hideRenderJob = ProjectPlugin.getPlugin().getPreferenceStore()
-                .getBoolean(PreferenceConstants.P_HIDE_RENDER_JOB);
-        job.setSystem(hideRenderJob);
     }
 }

--- a/plugins/org.locationtech.udig.project/src/org/locationtech/udig/project/internal/render/impl/RenderJob.java
+++ b/plugins/org.locationtech.udig.project/src/org/locationtech/udig/project/internal/render/impl/RenderJob.java
@@ -35,6 +35,7 @@ import org.locationtech.udig.project.internal.render.Renderer;
 import org.locationtech.udig.project.internal.render.SelectionLayer;
 import org.locationtech.udig.project.render.IRenderContext;
 import org.locationtech.udig.project.render.IRenderer;
+import org.locationtech.udig.project.render.RendererUtils;
 import org.locationtech.udig.project.render.displayAdapter.IMapDisplay;
 import org.opengis.referencing.FactoryException;
 import org.opengis.referencing.crs.CoordinateReferenceSystem;
@@ -70,7 +71,7 @@ public class RenderJob extends Job {
 
     protected void init() {
         setRule(new RenderJobRule());
-        setSystem(true);
+        setSystem(RendererUtils.isRendererJobSystemJob());
     }
 
     /**
@@ -361,5 +362,4 @@ public class RenderJob extends Job {
         }
 
     }
-
 }

--- a/plugins/org.locationtech.udig.project/src/org/locationtech/udig/project/preferences/PreferenceConstants.java
+++ b/plugins/org.locationtech.udig.project/src/org/locationtech/udig/project/preferences/PreferenceConstants.java
@@ -10,6 +10,7 @@
  */
 package org.locationtech.udig.project.preferences;
 
+import org.locationtech.udig.project.internal.ProjectPlugin;
 import org.locationtech.udig.project.internal.render.impl.ScaleUtils;
 
 /**
@@ -39,7 +40,7 @@ public final class PreferenceConstants {
     public static final String P_REMOVE_LAYERS = "P_REMOVE_LAYERS"; //$NON-NLS-1$
 
     public static final String P_HIGHLIGHT = "LayerPreferencePage.HighlightBehaviour"; //$NON-NLS-1$
-    
+
     public static final String P_HIGHLIGHT_NONE = "NONE"; //$NON-NLS-1$
     public static final String P_HIGHLIGHT_FOREGROUND = "FOREGROUND"; //$NON-NLS-1$
     public static final String P_HIGHLIGHT_BACKGROUND = "BACKGROUND"; //$NON-NLS-1$
@@ -47,7 +48,7 @@ public final class PreferenceConstants {
     public static final String P_WARN_IRREVERSIBLE_COMMAND = "P_WARN_IRREVERSIBLE_COMMAND"; //$NON-NLS-1$
 
     public static final String P_IRREVERSIBLE_COMMAND_VALUE = "P_IRREVERSIBLE_COMMAND_VALUE"; //$NON-NLS-1$
-    
+
     public static final String P_STYLE_DEFAULT_PERPENDICULAR_OFFSET = "P_STYLE_DEFAULT_PERPENDICULAR_OFFSET"; //$NON-NLS-1$
     public static final String P_LAYER_RESOURCE_CACHING_STRATEGY = "P_LAYER_RESOURCE_CACHING_STRATEGY"; //$NON-NLS-1$
 
@@ -64,6 +65,15 @@ public final class PreferenceConstants {
      * shown in progress view and are not hidden.
      * <p>
      * If the property is <code>true</code> then jobs are not shown in Progress View.
+     * </br>
+     * Use</br>
+     *
+     * <code>
+     *    {@value ProjectPlugin#ID}/{@value #P_HIDE_RENDER_JOB}=true
+     * </code>
+     *</br>
+     * to configure in <code>.options</code> file.
+     * </p>
      */
     public static final String P_HIDE_RENDER_JOB = "HIDE_RENDER_JOB"; //$NON-NLS-1$
 
@@ -71,11 +81,11 @@ public final class PreferenceConstants {
      * The property value for the preferred scale to ZOOM IN when extents of the layer
      * are not really correct or too small to be zoomed and displayed.
      * <p>
-     * The example: only one point exists in the layer and its extents are like 
+     * The example: only one point exists in the layer and its extents are like
      * (Xpoint, Ypoint, Xpoint, Ypoint) - so extents are collapsed to the point.
      * <p>
      * Used in "Zoom to extents" action.
-     * 
+     *
      */
     public static final String P_MINIMUM_ZOOM_SCALE = "P_MINIMUM_ZOOM_SCALE"; //$NON-NLS-1$
 
@@ -85,10 +95,10 @@ public final class PreferenceConstants {
      * <p>
      * This is a customization property to avoid drawback effects because of non-uniform and not complete
      * implementation of feature events notifiers and bugs in rendering workflow.
-     * 
+     *
      * The idea is to get the up-to-date picture with all changes in the layer no matter of feature
      * events that might cause refreshing only its bounding box.
-     * 
+     *
      */
     public static final String P_FEATURE_EVENT_REFRESH_ALL = "P_FEATURE_EVENT_REFRESH_ALL"; //$NON-NLS-1$
 

--- a/plugins/org.locationtech.udig.project/src/org/locationtech/udig/project/render/RendererUtils.java
+++ b/plugins/org.locationtech.udig.project/src/org/locationtech/udig/project/render/RendererUtils.java
@@ -1,0 +1,33 @@
+/**
+ * uDig - User Friendly Desktop Internet GIS client
+ * http://udig.refractions.net
+ * (C) 2021, Refractions Research Inc.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * (http://www.eclipse.org/legal/epl-v10.html), and the Refractions BSD
+ * License v1.0 (http://udig.refractions.net/files/bsd3-v10.html).
+ */
+package org.locationtech.udig.project.render;
+
+import org.locationtech.udig.project.internal.ProjectPlugin;
+import org.locationtech.udig.project.preferences.PreferenceConstants;
+
+/**
+ * Class that provides common utility methods for renderer implementations
+ *
+ */
+public final class RendererUtils {
+
+    private RendererUtils() {
+    }
+
+    /**
+     * @return true if renderer Jobs should be System-Jobs to avoid continuously showing 'Rendering
+     *         Map' in Progress View on streamed updates on Layer Data source.
+     */
+    public static boolean isRendererJobSystemJob() {
+        return ProjectPlugin.getPlugin().getPreferenceStore()
+                .getBoolean(PreferenceConstants.P_HIDE_RENDER_JOB);
+    }
+}


### PR DESCRIPTION
if the job is a system job, its not displayed in progress-view anymore for default. In Progress Views its possible to allow to show system jobs (and sleeping jobs) again

![grafik](https://user-images.githubusercontent.com/644229/141966264-3b314c9e-b9a0-457c-8b6e-b1622e21ed26.png)

to configure it just use `.options` files it installation folder with 

`org.locationtech.udig.project/HIDE_RENDER_JOB=true`

is present.

Default behavior is as before : Jobs are still shown in Progress-View