### PR TITLE
Replace several deprecated method calls

### DIFF
--- a/plugins/org.locationtech.udig.browser/src/org/locationtech/udig/browser/ExternalCatalogueImportPageDescriptor.java
+++ b/plugins/org.locationtech.udig.browser/src/org/locationtech/udig/browser/ExternalCatalogueImportPageDescriptor.java
@@ -1,7 +1,7 @@
-/*
- *    uDig - User Friendly Desktop Internet GIS client
- *    http://udig.refractions.net
- *    (C) 2012, Refractions Research Inc.
+/**
+ * uDig - User Friendly Desktop Internet GIS client
+ * http://udig.refractions.net
+ * (C) 2012, Refractions Research Inc.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -21,20 +21,20 @@ import org.eclipse.ui.plugin.AbstractUIPlugin;
  * <p>
  *
  * </p>
+ *
  * @author mleslie
  * @since 1.0.0
  */
-public class ExternalCatalogueImportPageDescriptor 
-        implements ExternalCatalogueImportDescriptor {
+public class ExternalCatalogueImportPageDescriptor implements ExternalCatalogueImportDescriptor {
     IConfigurationElement element;
-    
+
     /**
      * @param element
      */
     public ExternalCatalogueImportPageDescriptor(IConfigurationElement element) {
         this.element = element;
     }
-    
+
     /**
      *
      * @return selected import page
@@ -42,9 +42,9 @@ public class ExternalCatalogueImportPageDescriptor
      */
     public ExternalCatalogueImportPage createImportPage() throws CoreException {
         IConfigurationElement[] childs = element.getChildren("externalCataloguePage"); //$NON-NLS-1$
-        ExternalCatalogueImportPage page = 
-            (ExternalCatalogueImportPage)childs[0].createExecutableExtension("class"); //$NON-NLS-1$
-        
+        ExternalCatalogueImportPage page = (ExternalCatalogueImportPage) childs[0]
+                .createExecutableExtension("class"); //$NON-NLS-1$
+
         page.setTitle(getLabel());
         page.setDescription(getDescription());
         page.setImageDescriptor(getDescriptionImage());
@@ -53,66 +53,72 @@ public class ExternalCatalogueImportPageDescriptor
         return page;
     }
 
+    @Override
     public String getLabel() {
-        if(element.getAttribute("name") == null) { //$NON-NLS-1$
+        if (element.getAttribute("name") == null) { //$NON-NLS-1$
             return ""; //$NON-NLS-1$
         }
         return element.getAttribute("name"); //$NON-NLS-1$
     }
-    
+
+    @Override
     public String getViewName() {
-        if(element.getAttribute("viewName") == null) { //$NON-NLS-1$
+        if (element.getAttribute("viewName") == null) { //$NON-NLS-1$
             return ""; //$NON-NLS-1$
         }
         return element.getAttribute("viewName"); //$NON-NLS-1$
     }
-    
+
+    @Override
     public String getDescription() {
         String desc = element.getAttribute("description"); //$NON-NLS-1$
         if (desc == null)
             return ""; //$NON-NLS-1$
-        
+
         return desc.trim();
     }
-    
+
+    @Override
     public String getID() {
         return element.getAttribute("id"); //$NON-NLS-1$
     }
-    
+
     /**
      *
      * @return descriptor of the banner image
      */
     public ImageDescriptor getImage() {
-        String ns = element.getNamespace();
+        String ns = element.getNamespaceIdentifier();
         String banner = element.getAttribute("image"); //$NON-NLS-1$
-        
+
         if (banner == null)
             return null;
-        
-        return AbstractUIPlugin.imageDescriptorFromPlugin(ns,banner);
+
+        return AbstractUIPlugin.imageDescriptorFromPlugin(ns, banner);
     }
-    
+
+    @Override
     public ImageDescriptor getIcon() {
-        String ns = element.getNamespace();
+        String ns = element.getNamespaceIdentifier();
         String banner = element.getAttribute("icon"); //$NON-NLS-1$
-        
+
         if (banner == null)
             return null;
-        
-        return AbstractUIPlugin.imageDescriptorFromPlugin(ns,banner);
+
+        return AbstractUIPlugin.imageDescriptorFromPlugin(ns, banner);
     }
-    
+
+    @Override
     public ImageDescriptor getDescriptionImage() {
-        String ns = element.getNamespace();
+        String ns = element.getNamespaceIdentifier();
         String banner = element.getAttribute("banner"); //$NON-NLS-1$
-        
+
         if (banner == null)
             return null;
-        
-        return AbstractUIPlugin.imageDescriptorFromPlugin(ns,banner);
+
+        return AbstractUIPlugin.imageDescriptorFromPlugin(ns, banner);
     }
-    
+
     /**
      *
      * @return Service type
@@ -120,34 +126,33 @@ public class ExternalCatalogueImportPageDescriptor
     public String getServiceType() {
         return element.getAttribute("type"); //$NON-NLS-1$
     }
-    
+
     @Override
     public boolean equals(Object obj) {
-        if (this == obj) 
+        if (this == obj)
             return true;
-        
+
         if (obj instanceof ExternalCatalogueImportPageDescriptor) {
-            ExternalCatalogueImportPageDescriptor descriptor = 
-                (ExternalCatalogueImportPageDescriptor)obj;
-            
-            return getID() != null && 
-                getID().equals(descriptor.getID());
+            ExternalCatalogueImportPageDescriptor descriptor = (ExternalCatalogueImportPageDescriptor) obj;
+
+            return getID() != null && getID().equals(descriptor.getID());
         }
-        
+
         return false;
     }
-    
+
     @Override
     public int hashCode() {
-        if (getID() == null) 
+        if (getID() == null)
             return "".hashCode(); //$NON-NLS-1$
         return getID().hashCode();
     }
 
+    @Override
     public LocationListener getListener() {
         LocationListener blah = null;
         try {
-            blah = (LocationListener)element.createExecutableExtension("listener"); //$NON-NLS-1$
+            blah = (LocationListener) element.createExecutableExtension("listener"); //$NON-NLS-1$
         } catch (CoreException e) {
             //
         }

--- a/plugins/org.locationtech.udig.browser/src/org/locationtech/udig/browser/ui/BrowserSelectionPage.java
+++ b/plugins/org.locationtech.udig.browser/src/org/locationtech/udig/browser/ui/BrowserSelectionPage.java
@@ -299,7 +299,7 @@ public class BrowserSelectionPage extends WizardSelectionPage implements ISelect
             d.setDescription(element.getAttribute("description")); //$NON-NLS-1$
             d.setListener(element.getAttribute("listener")); //$NON-NLS-1$
             d.setViewName(element.getAttribute("viewName")); //$NON-NLS-1$
-            String ns = element.getNamespace();
+            String ns = element.getNamespaceIdentifier();
             String banner = element.getAttribute("image"); //$NON-NLS-1$
 
             if (banner != null)

--- a/plugins/org.locationtech.udig.context/src/org/locationtech/udig/context/internal/ContextExportWizard.java
+++ b/plugins/org.locationtech.udig.context/src/org/locationtech/udig/context/internal/ContextExportWizard.java
@@ -1,7 +1,7 @@
-/*
- *    uDig - User Friendly Desktop Internet GIS client
- *    http://udig.refractions.net
- *    (C) 2012, Refractions Research Inc.
+/**
+ * uDig - User Friendly Desktop Internet GIS client
+ * http://udig.refractions.net
+ * (C) 2012, Refractions Research Inc.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -16,18 +16,10 @@ import java.io.FileWriter;
 import java.io.IOException;
 import java.io.Writer;
 import java.net.URI;
+import java.util.Calendar;
 import java.util.Collections;
-import java.util.Date;
 import java.util.Iterator;
 import java.util.List;
-import java.util.Set;
-
-import org.locationtech.udig.context.ContextPlugin;
-import org.locationtech.udig.project.ILayer;
-import org.locationtech.udig.project.IMap;
-import org.locationtech.udig.project.Interaction;
-import org.locationtech.udig.project.render.IViewportModel;
-import org.locationtech.udig.project.ui.ApplicationGIS;
 
 import org.eclipse.jface.viewers.IStructuredSelection;
 import org.eclipse.jface.wizard.Wizard;
@@ -35,181 +27,194 @@ import org.eclipse.ui.IExportWizard;
 import org.eclipse.ui.IWorkbench;
 import org.geotools.data.ResourceInfo;
 import org.geotools.data.ServiceInfo;
+import org.geotools.data.wfs.WFSDataStore;
 import org.geotools.ows.wms.Layer;
 import org.geotools.ows.wms.StyleImpl;
 import org.geotools.ows.wms.WMSCapabilities;
-import org.geotools.data.wfs.WFSDataStore;
-
 import org.geotools.ows.wms.WebMapServer;
+import org.locationtech.jts.geom.Envelope;
+import org.locationtech.udig.context.ContextPlugin;
+import org.locationtech.udig.project.ILayer;
+import org.locationtech.udig.project.IMap;
+import org.locationtech.udig.project.Interaction;
+import org.locationtech.udig.project.render.IViewportModel;
+import org.locationtech.udig.project.ui.ApplicationGIS;
 import org.opengis.feature.simple.SimpleFeatureType;
 import org.opengis.metadata.Identifier;
 import org.opengis.referencing.crs.CoordinateReferenceSystem;
 
-import org.locationtech.jts.geom.Envelope;
-
 public class ContextExportWizard extends Wizard implements IExportWizard {
 
     IMap selection;
+
     MapExportPage page;
-    
+
     public ContextExportWizard() {
         super();
-        setNeedsProgressMonitor( true ); // monitor used for processing
+        setNeedsProgressMonitor(true); // monitor used for processing
     }
 
     @Override
     public boolean performFinish() {
         final File file = page.file;
-        if( file == null ) return false;
-        
-        if( file.exists() ){
-            if( page.overwriteExistingFileCheckbox.getSelection() ){
+        if (file == null)
+            return false;
+
+        if (file.exists()) {
+            if (page.overwriteExistingFileCheckbox.getSelection()) {
                 file.delete();
-            }
-            else {
-                page.setErrorMessage(Messages.ContextExportWizard_prompt_error_fileExists); 
+            } else {
+                page.setErrorMessage(Messages.ContextExportWizard_prompt_error_fileExists);
                 return false;
             }
         }
         try {
-            export( page.selectedMap, file );
-        }
-        catch( IOException io ){
-            page.setErrorMessage( io.getLocalizedMessage() );
+            export(page.selectedMap, file);
+        } catch (IOException io) {
+            page.setErrorMessage(io.getLocalizedMessage());
             return false;
-        }  
-        page.setMessage(Messages.ContextExportWizard_prompt_done); 
+        }
+        page.setMessage(Messages.ContextExportWizard_prompt_done);
         return true;
     }
 
-    public static void export( IMap map, File file ) throws IOException{
+    public static void export(IMap map, File file) throws IOException {
         file.createNewFile();
-        BufferedWriter out = new BufferedWriter( new FileWriter( file ) );
-        writeContext( map, out );
-        out.close();   
+        BufferedWriter out = new BufferedWriter(new FileWriter(file));
+        writeContext(map, out);
+        out.close();
     }
-    static void writeContext( IMap map, BufferedWriter out ) throws IOException {
-        writeHeader( map, out );
-        writeGeneral( map, out );
-        append( 2, out,   "<ResourceList>");         //$NON-NLS-1$
-        for( ILayer layer : map.getMapLayers() ){
+
+    static void writeContext(IMap map, BufferedWriter out) throws IOException {
+        writeHeader(map, out);
+        writeGeneral(map, out);
+        append(2, out, "<ResourceList>"); //$NON-NLS-1$
+        for (ILayer layer : map.getMapLayers()) {
             try {
-                if( layer.isType( Layer.class ) ){
-                    writeLayer( layer, out );
+                if (layer.isType(Layer.class)) {
+                    writeLayer(layer, out);
+                } else if (layer.isType(WFSDataStore.class)) {
+                    writeFeatureType(layer, out);
+                } else {
+                    // n/a
                 }
-                else if( layer.isType( WFSDataStore.class ) ){                    
-                    writeFeatureType( layer, out );
-                }
-                else {
-                    // n/a 
-                }
-                    
-            }
-            catch( IOException io){
+
+            } catch (IOException io) {
                 // skip - unable to figure out details ...
             }
         }
-        append( 2, out,   "</ResourceList>"); //$NON-NLS-1$
-        append( 0, out, "</OWSContext>"); //$NON-NLS-1$
+        append(2, out, "</ResourceList>"); //$NON-NLS-1$
+        append(0, out, "</OWSContext>"); //$NON-NLS-1$
     }
- 
-    private static void append( int indent, Writer out, String txt ) throws IOException{
-        out.append( "                                       ".substring(0,indent)); //$NON-NLS-1$
-        out.append( txt );
-        out.append("\n");//$NON-NLS-1$
-    }   
 
-    private static void writeFeatureType( ILayer layer, BufferedWriter out ) throws IOException {
-        WFSDataStore wfs = (WFSDataStore) layer.getResource( WFSDataStore.class, null );
+    private static void append(int indent, Writer out, String txt) throws IOException {
+        out.append("                                       ".substring(0, indent)); //$NON-NLS-1$
+        out.append(txt);
+        out.append("\n");//$NON-NLS-1$
+    }
+
+    private static void writeFeatureType(ILayer layer, BufferedWriter out) throws IOException {
+        WFSDataStore wfs = layer.getResource(WFSDataStore.class, null);
         SimpleFeatureType type = layer.getSchema();
         String typeName = type.getName().getLocalPart();
-        
+
         int hidden = layer.isVisible() ? 1 : 0;
         ServiceInfo serviceInfo = wfs.getInfo();
-		String title = serviceInfo.getTitle();
+        String title = serviceInfo.getTitle();
         String version = "1.0.0"; // only known entry at this time //$NON-NLS-1$
         URI source = serviceInfo.getSource();
-        String get = source == null? "" : source.toString();
-        
+        String get = source == null ? "" : source.toString(); //$NON-NLS-1$
+
         ResourceInfo resourceInfo = wfs.getFeatureSource(typeName).getInfo();
-        append( 4, out, "<SimpleFeatureType hidden=\""+ hidden +"\">" ); //$NON-NLS-1$ //$NON-NLS-2$
-        append( 6, out,   "<Server service=\"OGC:WFS\" title=\""+title+"\" version=\""+version+"\">" ); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
-        append( 8, out,     "<OnlineResource method=\"GET\" xlink:href=\""+get+"\" xlink:type=\"simple\"/>" ); //$NON-NLS-1$ //$NON-NLS-2$
-        append( 6, out,   "</Server>" ); //$NON-NLS-1$
-        append( 6, out,   "<Name>"+typeName+"</Name>"); //$NON-NLS-1$ //$NON-NLS-2$
-        append( 6, out,   "<Title>"+resourceInfo.getTitle()+"</Title>");     //$NON-NLS-1$ //$NON-NLS-2$
-		//if( !Double.isNaN( layer.getMinScaleDenominator() ))
-//        append( 6, out,   "<sld:MinScaleDenominator>"+layer.getMinScaleDenominator()+"</sld:MinScaleDenominator>");
-//if( !Double.isNaN( layer.getMaxScaleDenominator() ))
-//        append( 6, out,   "<sld:MinScaleDenominator>"+layer.getMaxScaleDenominator()+"</sld:MinScaleDenominator>");
-        String SRS="EPSG:4326";
+        append(4, out, "<SimpleFeatureType hidden=\"" + hidden + "\">"); //$NON-NLS-1$ //$NON-NLS-2$
+        append(6, out,
+                "<Server service=\"OGC:WFS\" title=\"" + title + "\" version=\"" + version + "\">"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
+        append(8, out, "<OnlineResource method=\"GET\" xlink:href=\"" + get //$NON-NLS-1$
+                + "\" xlink:type=\"simple\"/>"); //$NON-NLS-1$
+        append(6, out, "</Server>"); //$NON-NLS-1$
+        append(6, out, "<Name>" + typeName + "</Name>"); //$NON-NLS-1$ //$NON-NLS-2$
+        append(6, out, "<Title>" + resourceInfo.getTitle() + "</Title>"); //$NON-NLS-1$ //$NON-NLS-2$
+        // if( !Double.isNaN( layer.getMinScaleDenominator() ))
+        // append( 6, out,
+        // "<sld:MinScaleDenominator>"+layer.getMinScaleDenominator()+"</sld:MinScaleDenominator>");
+        // if( !Double.isNaN( layer.getMaxScaleDenominator() ))
+        // append( 6, out,
+        // "<sld:MinScaleDenominator>"+layer.getMaxScaleDenominator()+"</sld:MinScaleDenominator>");
+        String SRS = "EPSG:4326"; //$NON-NLS-1$
         CoordinateReferenceSystem crs = resourceInfo.getCRS();
-        //TODO: anyone knows how to get the urn for the crs object?
-		append( 6, out,   "<SRS>"+ SRS +"</SRS>"); //$NON-NLS-1$ //$NON-NLS-2$
-        append( 4, out, "</SimpleFeatureType>" ); //$NON-NLS-1$
+        // TODO: anyone knows how to get the urn for the CRS object?
+        append(6, out, "<SRS>" + SRS + "</SRS>"); //$NON-NLS-1$ //$NON-NLS-2$
+        append(4, out, "</SimpleFeatureType>"); //$NON-NLS-1$
     }
 
-    private static void writeLayer( ILayer layer, BufferedWriter out ) throws IOException {
-        Layer wmsLayer = layer.getResource( Layer.class, null );
-        WebMapServer wms = layer.getResource( WebMapServer.class, null );
+    private static void writeLayer(ILayer layer, BufferedWriter out) throws IOException {
+        Layer wmsLayer = layer.getResource(Layer.class, null);
+        WebMapServer wms = layer.getResource(WebMapServer.class, null);
         WMSCapabilities caps = wms.getCapabilities();
         String version = caps.getVersion();
-        
+
         String title = wms.getCapabilities().getService().getTitle();
         int hidden = layer.isVisible() ? 1 : 0;
         int info = layer.getInteraction(Interaction.INFO) ? 1 : 0;
         String get = caps.getRequest().getGetCapabilities().getGet().toExternalForm();
-System.out.println(get); if (get.endsWith("&")) get = get.substring(0,get.length()-1); //$NON-NLS-1$
-        append( 4, out, "<Layer hidden=\""+ hidden +"\" queryable=\""+info+"\">" ); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
-        append( 6, out,   "<Server service=\"OGC:WMS\" title=\""+title+"\" version=\""+version+"\">" ); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
-        append( 8, out,     "<OnlineResource method=\"GET\" xlink:href=\""+get+"\" xlink:type=\"simple\"/>" ); //$NON-NLS-1$ //$NON-NLS-2$
-        append( 6, out,   "</Server>" ); //$NON-NLS-1$
-        append( 6, out,   "<Name>"+wmsLayer.getName()+"</Name>"); //$NON-NLS-1$ //$NON-NLS-2$
-        append( 6, out,   "<Title>"+wmsLayer.getTitle()+"</Title>");                //$NON-NLS-1$ //$NON-NLS-2$
-        if( !Double.isNaN( wmsLayer.getScaleDenominatorMin() ))
-            append( 6, out,   "<sld:MinScaleDenominator>"+wmsLayer.getScaleDenominatorMin()+"</sld:MinScaleDenominator>");         //$NON-NLS-1$ //$NON-NLS-2$
-        if( !Double.isNaN( wmsLayer.getScaleDenominatorMax() ))
-            append( 6, out,   "<sld:MaxScaleDenominator>"+wmsLayer.getScaleDenominatorMax()+"</sld:MaxScaleDenominator>");         //$NON-NLS-1$ //$NON-NLS-2$
-        for( String srs : (Set<String>) wmsLayer.getSrs() ){
-            append( 6, out,   "<SRS>"+srs+"</SRS>"); //$NON-NLS-1$ //$NON-NLS-2$
+        System.out.println(get);
+        if (get.endsWith("&")) //$NON-NLS-1$
+            get = get.substring(0, get.length() - 1);
+        append(4, out, "<Layer hidden=\"" + hidden + "\" queryable=\"" + info + "\">"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
+        append(6, out,
+                "<Server service=\"OGC:WMS\" title=\"" + title + "\" version=\"" + version + "\">"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
+        append(8, out, "<OnlineResource method=\"GET\" xlink:href=\"" + get //$NON-NLS-1$
+                + "\" xlink:type=\"simple\"/>"); //$NON-NLS-1$
+        append(6, out, "</Server>"); //$NON-NLS-1$
+        append(6, out, "<Name>" + wmsLayer.getName() + "</Name>"); //$NON-NLS-1$ //$NON-NLS-2$
+        append(6, out, "<Title>" + wmsLayer.getTitle() + "</Title>"); //$NON-NLS-1$ //$NON-NLS-2$
+        if (!Double.isNaN(wmsLayer.getScaleDenominatorMin()))
+            append(6, out, "<sld:MinScaleDenominator>" + wmsLayer.getScaleDenominatorMin() //$NON-NLS-1$
+                    + "</sld:MinScaleDenominator>"); //$NON-NLS-1$
+        if (!Double.isNaN(wmsLayer.getScaleDenominatorMax()))
+            append(6, out, "<sld:MaxScaleDenominator>" + wmsLayer.getScaleDenominatorMax() //$NON-NLS-1$
+                    + "</sld:MaxScaleDenominator>"); //$NON-NLS-1$
+        for (String srs : wmsLayer.getSrs()) {
+            append(6, out, "<SRS>" + srs + "</SRS>"); //$NON-NLS-1$ //$NON-NLS-2$
         }
-        append( 6, out,   "<FormatList>"); //$NON-NLS-1$
-        
-boolean first = true; // TODO: look up preferences?
-for( String format : caps.getRequest().getGetMap().getFormats() ){
-    if( first ){
-        append( 8, out,     "<Format current=\"1\">"+format+"</Format>");                 //$NON-NLS-1$ //$NON-NLS-2$
-        first = false;
-    }
-        append( 8, out,   "<Format>"+format+"</Format>");     //$NON-NLS-1$ //$NON-NLS-2$
-}
-        append( 6, out,   "</FormatList>"); //$NON-NLS-1$
-        
+        append(6, out, "<FormatList>"); //$NON-NLS-1$
+
+        boolean first = true; // TODO: look up preferences?
+        for (String format : caps.getRequest().getGetMap().getFormats()) {
+            if (first) {
+                append(8, out, "<Format current=\"1\">" + format + "</Format>"); //$NON-NLS-1$ //$NON-NLS-2$
+                first = false;
+            }
+            append(8, out, "<Format>" + format + "</Format>"); //$NON-NLS-1$ //$NON-NLS-2$
+        }
+        append(6, out, "</FormatList>"); //$NON-NLS-1$
+
         first = true; // TODO: look up on styleblackboard?
-        append( 6, out,   "<StyleList>"); //$NON-NLS-1$
-        Object styles=wmsLayer.getStyles();
+        append(6, out, "<StyleList>"); //$NON-NLS-1$
+        Object styles = wmsLayer.getStyles();
         List list;
-        if( styles instanceof String )
-            list=Collections.singletonList(styles);
-        else if( styles instanceof List )
-            list=(List)styles;
+        if (styles instanceof String)
+            list = Collections.singletonList(styles);
+        else if (styles instanceof List)
+            list = (List) styles;
         else
             list = Collections.emptyList();
-        for( Iterator<Object> iter = list.iterator(); iter.hasNext(); ) {
-            Object next=iter.next();
-            if( next instanceof String ){
-                String style=(String)next;
-                first=writeStyle(style, style, first, out);
-            }else if( next instanceof StyleImpl ){
-                StyleImpl style=(StyleImpl)next;
+        for (Iterator<Object> iter = list.iterator(); iter.hasNext();) {
+            Object next = iter.next();
+            if (next instanceof String) {
+                String style = (String) next;
+                first = writeStyle(style, style, first, out);
+            } else if (next instanceof StyleImpl) {
+                StyleImpl style = (StyleImpl) next;
                 writeStyle(style.getName(), style.getTitle().toString(), first, out);
             }
         }
         append(6, out, "</StyleList>"); //$NON-NLS-1$
-        append( 4, out, "</Layer>" );                 //$NON-NLS-1$
+        append(4, out, "</Layer>"); //$NON-NLS-1$
     }
-        
-    private static boolean writeStyle(String name, String title, boolean first, Writer out) throws IOException{
+
+    private static boolean writeStyle(String name, String title, boolean first, Writer out)
+            throws IOException {
         if (first) {
             append(8, out, "<Style current=\"1\">"); //$NON-NLS-1$
         } else {
@@ -222,63 +227,68 @@ for( String format : caps.getRequest().getGetMap().getFormats() ){
     }
 
     /** TODO: Test me ! And move me to CRS utility class */
-    private static String srs( CoordinateReferenceSystem crs ){
-        if( crs != null && crs.getIdentifiers() != null )
-            for( Identifier id : crs.getIdentifiers() ){
+    private static String srs(CoordinateReferenceSystem crs) {
+        if (crs != null && crs.getIdentifiers() != null)
+            for (Identifier id : crs.getIdentifiers()) {
                 String srs = id.toString();
-                if( srs.startsWith( "EPSG" ) ) return srs;             //$NON-NLS-1$
+                if (srs.startsWith("EPSG")) //$NON-NLS-1$
+                    return srs;
             }
         return "EPSG:4326"; //$NON-NLS-1$
     }
-    private static void writeGeneral( IMap map, BufferedWriter out ) throws IOException  {
+
+    private static void writeGeneral(IMap map, BufferedWriter out) throws IOException {
         IViewportModel view = map.getViewportModel();
         int w = 640;
-        int h = (int) ( ((double)w) * view.getAspectRatio() );
+        int h = (int) ((w) * view.getAspectRatio());
         Envelope bbox = view.getBounds();
-        CoordinateReferenceSystem crs = view.getCRS();
         String user = System.getenv("user.name"); //$NON-NLS-1$
-        
-        append( 2, out, "<General>"); //$NON-NLS-1$
-        append( 4, out,   "<Window height=\""+h+"\" width=\""+w+"\"/>"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
-        append( 4, out,   "<ows:BoundingBox crs=\""+srs( view.getCRS() )+ "\">" ); //$NON-NLS-1$ //$NON-NLS-2$
-        append( 6, out,      "<ows:LowerCorner>"+bbox.getMinX()+" "+bbox.getMinY()+"</ows:LowerCorner>"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
-        append( 6, out,      "<ows:UpperCorner>"+bbox.getMaxX()+" "+bbox.getMaxY()+"</ows:UpperCorner>"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
-        append( 4, out,   "</ows:BoundingBox>"); //$NON-NLS-1$
-        append( 4, out,   "<Title>"+map.getName()+"</Title>"); //$NON-NLS-1$ //$NON-NLS-2$
-        append( 4, out,   "<ows:ServiceProvider>");         //$NON-NLS-1$
-        append( 6, out,      "<ows:ProviderName>OWS-3 GeoDSS Thread</ows:ProviderName>"); //$NON-NLS-1$
-        append( 6, out,      "<ows:ServiceContact>"); //$NON-NLS-1$
-        append( 8, out,      "<ows:IndividualName>"+user+"</ows:IndividualName>"); //$NON-NLS-1$ //$NON-NLS-2$
-        append( 6, out,      "</ows:ServiceContact>"); //$NON-NLS-1$
-        append( 4, out,   "</ows:ServiceProvider>"); //$NON-NLS-1$
-        append( 2, out, "</General>"); //$NON-NLS-1$
+
+        append(2, out, "<General>"); //$NON-NLS-1$
+        append(4, out, "<Window height=\"" + h + "\" width=\"" + w + "\"/>"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
+        append(4, out, "<ows:BoundingBox crs=\"" + srs(view.getCRS()) + "\">"); //$NON-NLS-1$ //$NON-NLS-2$
+        append(6, out,
+                "<ows:LowerCorner>" + bbox.getMinX() + " " + bbox.getMinY() + "</ows:LowerCorner>"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
+        append(6, out,
+                "<ows:UpperCorner>" + bbox.getMaxX() + " " + bbox.getMaxY() + "</ows:UpperCorner>"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
+        append(4, out, "</ows:BoundingBox>"); //$NON-NLS-1$
+        append(4, out, "<Title>" + map.getName() + "</Title>"); //$NON-NLS-1$ //$NON-NLS-2$
+        append(4, out, "<ows:ServiceProvider>"); //$NON-NLS-1$
+        append(6, out, "<ows:ProviderName>OWS-3 GeoDSS Thread</ows:ProviderName>"); //$NON-NLS-1$
+        append(6, out, "<ows:ServiceContact>"); //$NON-NLS-1$
+        append(8, out, "<ows:IndividualName>" + user + "</ows:IndividualName>"); //$NON-NLS-1$ //$NON-NLS-2$
+        append(6, out, "</ows:ServiceContact>"); //$NON-NLS-1$
+        append(4, out, "</ows:ServiceProvider>"); //$NON-NLS-1$
+        append(2, out, "</General>"); //$NON-NLS-1$
     }
 
-    private static void writeHeader( IMap map, BufferedWriter out ) throws IOException {
-        Date now = new Date();
-        String id = "geodss."+now.getYear()+now.getMonth()+now.getDay()+now.getHours()+now.getMinutes(); //$NON-NLS-1$
-        
-        append( 0, out, "<OWSContext id=\""+id+"\" version=\"0.0.13\" "); //$NON-NLS-1$ //$NON-NLS-2$
-        append( 0, out, "    xmlns=\"http://www.opengis.net/oc\""); //$NON-NLS-1$
-        append( 0, out, "    xmlns:ogc=\"http://www.opengis.net/ogc\""); //$NON-NLS-1$
-        append( 0, out, "    xmlns:ows=\"http://www.opengis.net/ows\""); //$NON-NLS-1$
-        append( 0, out, "    xmlns:param=\"http;//www.opengis.net/param\""); //$NON-NLS-1$
-        append( 0, out, "    xmlns:sld=\"http://www.opengis.net/sld\""); //$NON-NLS-1$
-        append( 0, out, "    xmlns:xlink=\"http://www.w3.org/1999/xlink\""); //$NON-NLS-1$
-        append( 0, out, "    xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\""); //$NON-NLS-1$
-        append( 0, out, "    xsi:schemaLocation=\"http://www.opengis.net/oc oc_0_0_13.xsd\"" ); //$NON-NLS-1$
-        append( 0, out, "    >"); //$NON-NLS-1$
+    private static void writeHeader(IMap map, BufferedWriter out) throws IOException {
+        Calendar now = Calendar.getInstance();
+        String id = "geodss." + now.get(Calendar.YEAR) + now.get(Calendar.MONTH) //$NON-NLS-1$
+                + now.get(Calendar.DAY_OF_MONTH) + now.get(Calendar.HOUR_OF_DAY)
+                + now.get(Calendar.MINUTE);
+
+        append(0, out, "<OWSContext id=\"" + id + "\" version=\"0.0.13\" "); //$NON-NLS-1$ //$NON-NLS-2$
+        append(0, out, "    xmlns=\"http://www.opengis.net/oc\""); //$NON-NLS-1$
+        append(0, out, "    xmlns:ogc=\"http://www.opengis.net/ogc\""); //$NON-NLS-1$
+        append(0, out, "    xmlns:ows=\"http://www.opengis.net/ows\""); //$NON-NLS-1$
+        append(0, out, "    xmlns:param=\"http;//www.opengis.net/param\""); //$NON-NLS-1$
+        append(0, out, "    xmlns:sld=\"http://www.opengis.net/sld\""); //$NON-NLS-1$
+        append(0, out, "    xmlns:xlink=\"http://www.w3.org/1999/xlink\""); //$NON-NLS-1$
+        append(0, out, "    xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\""); //$NON-NLS-1$
+        append(0, out, "    xsi:schemaLocation=\"http://www.opengis.net/oc oc_0_0_13.xsd\""); //$NON-NLS-1$
+        append(0, out, "    >"); //$NON-NLS-1$
     }
 
     /**
-     * Note given the restriction we placed on the selection
-     * we can expect the structured selection to provide us with
-     * an IMap.
+     * Note given the restriction we placed on the selection we can expect the structured selection
+     * to provide us with an IMap.
      */
-    public void init( IWorkbench workbench, IStructuredSelection selection ) {
-        if( selection != null ){
+    @Override
+    public void init(IWorkbench workbench, IStructuredSelection selection) {
+        if (selection != null) {
             Object obj = selection.getFirstElement();
-            if( obj != null && obj instanceof IMap){
+            if (obj != null && obj instanceof IMap) {
                 this.selection = (IMap) obj;
             }
         }
@@ -286,14 +296,17 @@ for( String format : caps.getRequest().getGetMap().getFormats() ){
         // etc ...
         //
     }
-    
+
+    @Override
     public void addPages() {
         super.addPages();
-        
-        if( ApplicationGIS.getActiveMap() == ApplicationGIS.NO_MAP){            
-            return; // no pages no go!            
+
+        if (ApplicationGIS.getActiveMap() == ApplicationGIS.NO_MAP) {
+            return; // no pages no go!
         }
-        page = new MapExportPage(Messages.ContextExportWizard_page_name, Messages.ContextExportWizard_page_title, ContextPlugin.getImageDescriptor("icons/wizban/import_owscontext_wiz_gif" ));    //$NON-NLS-1$
-        addPage( page );
+        page = new MapExportPage(Messages.ContextExportWizard_page_name,
+                Messages.ContextExportWizard_page_title,
+                ContextPlugin.getImageDescriptor("icons/wizban/import_owscontext_wiz_gif")); //$NON-NLS-1$
+        addPage(page);
     }
 }

--- a/plugins/org.locationtech.udig.feature.editor/src/org/locationtech/udig/feature/editor/AbstractPageBookView.java
+++ b/plugins/org.locationtech.udig.feature.editor/src/org/locationtech/udig/feature/editor/AbstractPageBookView.java
@@ -19,7 +19,7 @@ import java.util.Set;
 
 import org.eclipse.core.commands.common.EventManager;
 import org.eclipse.core.runtime.IAdaptable;
-import org.eclipse.core.runtime.Platform;
+import org.eclipse.core.runtime.SafeRunner;
 import org.eclipse.jface.action.IAction;
 import org.eclipse.jface.util.IPropertyChangeListener;
 import org.eclipse.jface.util.PropertyChangeEvent;
@@ -502,7 +502,7 @@ abstract class AbstractPageBookView<K> extends ViewPart {
             Object[] listeners = getListeners();
             for (int i = 0; i < listeners.length; ++i) {
                 final ISelectionChangedListener l = (ISelectionChangedListener) listeners[i];
-                Platform.run(new SafeRunnable() {
+                SafeRunner.run(new SafeRunnable() {
                     @Override
                     public void run() {
                         l.selectionChanged(event);

--- a/plugins/org.locationtech.udig.info/src/org/locationtech/udig/tool/info/internal/InfoView2.java
+++ b/plugins/org.locationtech.udig.info/src/org/locationtech/udig/tool/info/internal/InfoView2.java
@@ -221,7 +221,7 @@ public class InfoView2 extends SearchPart {
             Image image = registry.get(key);
             if (image == null) {
                 ImageDescriptor icon;
-                icon = (ImageDescriptor) layer.getProperties().get("generated icon"); //$NON-NLS-1$
+                icon = (ImageDescriptor) layer.getBlackboard().get("generated icon"); //$NON-NLS-1$
                 if (icon == null) {
                     icon = layer.getIcon();
                 }

--- a/plugins/org.locationtech.udig.project.tests/src/org/locationtech/udig/project/internal/render/impl/RenderExecutorTest.java
+++ b/plugins/org.locationtech.udig.project.tests/src/org/locationtech/udig/project/internal/render/impl/RenderExecutorTest.java
@@ -26,7 +26,7 @@ import javax.swing.JFrame;
 import javax.swing.JPanel;
 
 import org.eclipse.core.runtime.NullProgressMonitor;
-import org.eclipse.core.runtime.Platform;
+import org.eclipse.core.runtime.jobs.Job;
 import org.geotools.referencing.crs.DefaultEngineeringCRS;
 import org.geotools.styling.Style;
 import org.geotools.styling.StyleBuilder;
@@ -151,7 +151,7 @@ public class RenderExecutorTest extends AbstractProjectTestCase {
         ex.setRenderBounds(new Envelope(minx, maxx, miny, maxy));
         ex.render();
 
-        Platform.getJobManager().join(map.getRenderManager(), new NullProgressMonitor());
+        Job.getJobManager().join(map.getRenderManager(), new NullProgressMonitor());
 
         showImage("testRenderEnvelopeIProgressMonitor", image); //$NON-NLS-1$
         testImage(image, false, minx, 512 - maxy, maxx, 512 - miny);
@@ -196,7 +196,7 @@ public class RenderExecutorTest extends AbstractProjectTestCase {
         ex.setRenderBounds(new Rectangle(minx, miny, maxx - minx, maxy - miny));
         ex.render();
 
-        Platform.getJobManager().join(map.getRenderManager(), new NullProgressMonitor());
+        Job.getJobManager().join(map.getRenderManager(), new NullProgressMonitor());
 
         BufferedImage image2 = ex.getContext().getImage(w, h);
         assertEquals(image, image2);
@@ -246,7 +246,7 @@ public class RenderExecutorTest extends AbstractProjectTestCase {
 
         map.getRenderManagerInternal().getRenderExecutor().render();
 
-        Platform.getJobManager().join(map.getRenderManager(), new NullProgressMonitor());
+        Job.getJobManager().join(map.getRenderManager(), new NullProgressMonitor());
 
         BufferedImage image2 = ex.getContext().getImage(w, h);
         assertEquals(image, image2);
@@ -276,7 +276,7 @@ public class RenderExecutorTest extends AbstractProjectTestCase {
         ex.setRenderBounds(new Envelope(minx, maxx, miny, maxy));
         ex.render();
 
-        Platform.getJobManager().join(map.getRenderManager(), new NullProgressMonitor());
+        Job.getJobManager().join(map.getRenderManager(), new NullProgressMonitor());
 
         BufferedImage image2 = ex.getContext().getImage();
         assertEquals(image, image2);
@@ -293,7 +293,7 @@ public class RenderExecutorTest extends AbstractProjectTestCase {
         graphics.dispose();
         ex.setRenderBounds(new Envelope(minx, maxx, miny, maxy));
         ex.render();
-        Platform.getJobManager().join(map.getRenderManager(), new NullProgressMonitor());
+        Job.getJobManager().join(map.getRenderManager(), new NullProgressMonitor());
 
         testImage(image, false, 0, 0, 512, 512);
     }

--- a/plugins/org.locationtech.udig.project.ui/src/org/locationtech/udig/project/ui/internal/tool/display/CursorProxy.java
+++ b/plugins/org.locationtech.udig.project.ui/src/org/locationtech/udig/project/ui/internal/tool/display/CursorProxy.java
@@ -1,7 +1,7 @@
-/*
- *    uDig - User Friendly Desktop Internet GIS client
- *    http://udig.refractions.net
- *    (C) 2012, Refractions Research Inc.
+/**
+ * uDig - User Friendly Desktop Internet GIS client
+ * http://udig.refractions.net
+ * (C) 2012, Refractions Research Inc.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -20,48 +20,51 @@ import org.eclipse.ui.plugin.AbstractUIPlugin;
 import org.locationtech.udig.project.ui.tool.ModalTool;
 
 /**
- * The cursor proxy allows for tool cursor images  to be loaded lazily. It acts as a proxy
- * for cursor image of the tool until the image is really needed to be displayed.
- * 
+ * The cursor proxy allows for tool cursor images to be loaded lazily. It acts as a proxy for cursor
+ * image of the tool until the image is really needed to be displayed.
+ *
  * @author Vitalus
  * @since UDIG 1.1
  *
  */
 public class CursorProxy {
-	
-    private volatile Cursor cursor;
-    private String imagePath;
-    private String hotspotX;
-    private String hotspotY;
-    private String cursorID;
-    private String pluginID;
 
+    private volatile Cursor cursor;
+
+    private String imagePath;
+
+    private String hotspotX;
+
+    private String hotspotY;
+
+    private String cursorID;
+
+    private String pluginID;
 
     /**
      * The constructor to create custom cursor proxy from extention.
-     * 
+     *
      * @param configuration
      */
-    public CursorProxy( IConfigurationElement configuration ) {
+    public CursorProxy(IConfigurationElement configuration) {
         if (configuration != null) {
             imagePath = configuration.getAttribute("image"); //$NON-NLS-1$
             hotspotX = configuration.getAttribute("hotspotX"); //$NON-NLS-1$
             hotspotY = configuration.getAttribute("hotspotY"); //$NON-NLS-1$
             cursorID = configuration.getAttribute("id"); //$NON-NLS-1$
-            pluginID = configuration.getNamespace();
+            pluginID = configuration.getNamespaceIdentifier();
         } else {
             cursorID = ModalTool.DEFAULT_CURSOR;
         }
     }
-    
+
     /**
-     * Returns cursor ID declared in extention point. 
-     * ID is unique in extention registry.
-     * 
+     * Returns cursor ID declared in extention point. ID is unique in extention registry.
+     *
      * @return
      */
-    public String getID(){
-    	return cursorID;
+    public String getID() {
+        return cursorID;
     }
 
     /**
@@ -91,8 +94,8 @@ public class CursorProxy {
                         if (imageDescriptor == null || imageDescriptor.getImageData() == null)
                             cursor = getSystemCursor(cursorID);
                         else
-                            cursor = new Cursor(Display.getDefault(), imageDescriptor
-                                    .getImageData(), x, y);
+                            cursor = new Cursor(Display.getDefault(),
+                                    imageDescriptor.getImageData(), x, y);
                     }
                 }
             }
@@ -102,17 +105,17 @@ public class CursorProxy {
     }
 
     /**
-     * Returns system cursor object based on constants from <code>ModalTool</code>
-     * interface. These constants are mapped to SWT cursor constants.
-     * 
+     * Returns system cursor object based on constants from <code>ModalTool</code> interface. These
+     * constants are mapped to SWT cursor constants.
+     *
      * @param systemCursorID
      * @return
      */
-    static Cursor getSystemCursor( String systemCursorID ) {
-    	Display display = PlatformUI.getWorkbench().getDisplay();
+    static Cursor getSystemCursor(String systemCursorID) {
+        Display display = PlatformUI.getWorkbench().getDisplay();
         if (systemCursorID == null)
             return display.getSystemCursor(SWT.CURSOR_ARROW);
-        
+
         if (systemCursorID.equals(ModalTool.CROSSHAIR_CURSOR))
             return display.getSystemCursor(SWT.CURSOR_CROSS);
         if (systemCursorID.equals(ModalTool.E_RESIZE_CURSOR))
@@ -139,10 +142,10 @@ public class CursorProxy {
             return display.getSystemCursor(SWT.CURSOR_SIZESW);
         if (systemCursorID.equals(ModalTool.WAIT_CURSOR))
             return display.getSystemCursor(SWT.CURSOR_WAIT);
-        
-        if(systemCursorID.equals(ModalTool.NO_CURSOR))
-        	return display.getSystemCursor(SWT.CURSOR_NO);
-        
+
+        if (systemCursorID.equals(ModalTool.NO_CURSOR))
+            return display.getSystemCursor(SWT.CURSOR_NO);
+
         return display.getSystemCursor(SWT.CURSOR_ARROW);
     }
 

--- a/plugins/org.locationtech.udig.project.ui/src/org/locationtech/udig/project/ui/internal/tool/display/ToolCategory.java
+++ b/plugins/org.locationtech.udig.project.ui/src/org/locationtech/udig/project/ui/internal/tool/display/ToolCategory.java
@@ -1,7 +1,7 @@
-/*
- *    uDig - User Friendly Desktop Internet GIS client
- *    http://udig.refractions.net
- *    (C) 2004, Refractions Research Inc.
+/**
+ * uDig - User Friendly Desktop Internet GIS client
+ * http://udig.refractions.net
+ * (C) 2004, Refractions Research Inc.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -27,21 +27,25 @@ import org.locationtech.udig.project.ui.tool.IToolManager;
 
 /**
  * Representation of a category, this is a UI construct.
- * 
+ *
  * @author jeichar
  * @since 0.9.0
  */
 public abstract class ToolCategory implements Iterable<ModalItem> {
     /** The list of items in the category */
-    public List<ModalItem> items = new LinkedList<ModalItem>();
+    public List<ModalItem> items = new LinkedList<>();
 
     /** The tool manager instance */
     protected IToolManager manager;
+
     /** id of the category */
     protected String id;
+
     /** name of the category */
     protected String name;
+
     private String commandId;
+
     private ImageDescriptor icon;
 
     private boolean handlersSet = false;
@@ -50,39 +54,40 @@ public abstract class ToolCategory implements Iterable<ModalItem> {
 
     /**
      * Construct <code>ToolCategory</code>.
-     * 
-     * @param element the configurationelement that declares the category
+     *
+     * @param element the configuration element that declares the category
      * @param manager the containing manager
      */
-    protected ToolCategory( IConfigurationElement element, IToolManager manager ) {
+    protected ToolCategory(IConfigurationElement element, IToolManager manager) {
         id = element.getAttribute("id"); //$NON-NLS-1$
         commandId = element.getAttribute("commandId"); //$NON-NLS-1$
         name = element.getAttribute("name"); //$NON-NLS-1$
         String iconPath = element.getAttribute("icon"); //$NON-NLS-1$
         if (iconPath != null)
-            icon = AbstractUIPlugin.imageDescriptorFromPlugin(element.getNamespace(), iconPath);
-        this.element=element;
+            icon = AbstractUIPlugin.imageDescriptorFromPlugin(element.getNamespaceIdentifier(),
+                    iconPath);
+        this.element = element;
         this.manager = manager;
     }
 
     /**
      * Construct <code>ToolCategory2</code>.
-     * 
+     *
      * @param manager
      */
-    public ToolCategory( IToolManager manager ) {
+    public ToolCategory(IToolManager manager) {
         this.manager = manager;
-        id = Messages.ToolCategory_other; 
-        name = Messages.ToolCategory_other_menu; 
+        id = Messages.ToolCategory_other;
+        name = Messages.ToolCategory_other_menu;
         icon = null;
         commandId = null;
     }
 
-    public void dispose( IActionBars bars ) {
-        for( Iterator<ModalItem> iter = items.iterator(); iter.hasNext(); ) {
+    public void dispose(IActionBars bars) {
+        for (Iterator<ModalItem> iter = items.iterator(); iter.hasNext();) {
             ModalItem item = iter.next();
             List<CurrentContributionItem> contributions = item.getContributions();
-            for( CurrentContributionItem item2 : contributions ) {
+            for (CurrentContributionItem item2 : contributions) {
                 bars.getMenuManager().remove(item2);
                 bars.getToolBarManager().remove(item2);
                 bars.getStatusLineManager().remove(item2);
@@ -93,25 +98,27 @@ public abstract class ToolCategory implements Iterable<ModalItem> {
 
     /**
      * Add an item to the category
-     * 
+     *
      * @param item the new item
      */
-    public void add( ModalItem item ) {
+    public void add(ModalItem item) {
         items.add(item);
     }
 
     /**
      * @return an iterator that iterates through the items in the category
      */
+    @Override
     public Iterator<ModalItem> iterator() {
         return items.iterator();
     }
 
     /**
      * Sets the commandHandler for this category.
-     * @param ids 
+     *
+     * @param ids
      */
-    public void setCommandHandlers( ICommandService service ) {
+    public void setCommandHandlers(ICommandService service) {
 
         if (!handlersSet) {
             if (commandId != null) {
@@ -125,30 +132,32 @@ public abstract class ToolCategory implements Iterable<ModalItem> {
 
     /**
      * Gets the command handler for the category.
-     * 
+     *
      * @return the command handler for the category.
      */
     protected abstract IHandler getHandler();
 
     /**
      * Gets the icon for the category.
-     * 
+     *
      * @return the icon for the category.
      */
     public ImageDescriptor getIcon() {
         return icon;
     }
+
     /**
      * Returns the id of the category
-     * 
+     *
      * @return the id of the category
      */
     public String getId() {
         return id;
     }
+
     /**
      * Returns the name of the category
-     * 
+     *
      * @return the name of the category
      */
     public String getName() {

--- a/plugins/org.locationtech.udig.project/src/org/locationtech/udig/project/ILayer.java
+++ b/plugins/org.locationtech.udig.project/src/org/locationtech/udig/project/ILayer.java
@@ -398,7 +398,7 @@ public interface ILayer extends ILegendItem, Comparable<ILayer> {
      * </p>
      *
      * @return Blackboard used for lightweight collaboration.
-     * @deprecated
+     * @deprecated Use {@link ILayer#getBlackboard} instead
      */
     @Deprecated
     IBlackboard getProperties();

--- a/plugins/org.locationtech.udig.project/src/org/locationtech/udig/project/internal/Layer.java
+++ b/plugins/org.locationtech.udig.project/src/org/locationtech/udig/project/internal/Layer.java
@@ -36,6 +36,7 @@ import org.opengis.referencing.crs.CoordinateReferenceSystem;
 
 /**
  * Read/Write interface for layers
+ *
  * @author Jesse
  * @since 1.0.0
  * @model
@@ -52,9 +53,10 @@ public interface Layer
     public ContextModel getContextModel();
 
     /**
-     * Sets the value of the '{@link org.locationtech.udig.project.internal.Layer#getContextModel <em>Context Model</em>}' container reference.
-     * <!-- begin-user-doc --> TODO: Remove Context Model (1 to 1 relationship
-     * does not added anything) <!-- end-user-doc -->
+     * Sets the value of the '{@link org.locationtech.udig.project.internal.Layer#getContextModel
+     * <em>Context Model</em>}' container reference. <!-- begin-user-doc --> TODO: Remove Context
+     * Model (1 to 1 relationship does not added anything) <!-- end-user-doc -->
+     *
      * @param value the new value of the '<em>Context Model</em>' container reference.
      * @see #getContextModel()
      * @generated
@@ -75,7 +77,8 @@ public interface Layer
      * </p>
      * XXX: Consider making use of the General Purpose Blackboard
      *
-     * @return Filter indicating the selected features. Filter.EXCLUDE indicates no selected Features.
+     * @return Filter indicating the selected features. Filter.EXCLUDE indicates no selected
+     *         Features.
      * @uml.property name="filter"
      * @model transient="true" dataType="org.opengis.filter.Filter"
      */
@@ -83,8 +86,9 @@ public interface Layer
     Filter getFilter();
 
     /**
-     * Sets the value of the '{@link org.locationtech.udig.project.internal.Layer#getFilter <em>Filter</em>}' attribute.
-     * <!-- begin-user-doc --> <!-- end-user-doc -->
+     * Sets the value of the '{@link org.locationtech.udig.project.internal.Layer#getFilter
+     * <em>Filter</em>}' attribute. <!-- begin-user-doc --> <!-- end-user-doc -->
+     *
      * @param value the new value of the '<em>Filter</em>' attribute.
      * @see #getFilter()
      * @generated
@@ -92,9 +96,9 @@ public interface Layer
     void setFilter(Filter value);
 
     /**
-     * Sets the spatial bounds of this layer. This property is normally
-     * derived from the {@link IGeoResourceInfo} but this provides an override. This
-     * will affect the "Zoom to Extent" and "Zoom to Layer" actions.
+     * Sets the spatial bounds of this layer. This property is normally derived from the
+     * {@link IGeoResourceInfo} but this provides an override. This will affect the "Zoom to Extent"
+     * and "Zoom to Layer" actions.
      *
      * @param bounds a ReferencedEnvelope indicating the new bounds for the layer
      */
@@ -115,10 +119,10 @@ public interface Layer
     public StyleBlackboard getStyleBlackboard();
 
     /**
-     * Sets the value of the '{@link org.locationtech.udig.project.internal.Layer#getStyleBlackboard <em>Style Blackboard</em>}'
-     * containment reference. <!-- begin-user-doc --> Note: The Rendering Process will be restarted
-     * as appearance information changes, this is usual limited to a single Layer. <!-- end-user-doc
-     * -->
+     * Sets the value of the '{@link org.locationtech.udig.project.internal.Layer#getStyleBlackboard
+     * <em>Style Blackboard</em>}' containment reference. <!-- begin-user-doc --> Note: The
+     * Rendering Process will be restarted as appearance information changes, this is usual limited
+     * to a single Layer. <!-- end-user-doc -->
      *
      * @param value the new value of the '<em>Style Blackboard</em>' containment reference.
      * @see #getStyleBlackboard()
@@ -135,8 +139,9 @@ public interface Layer
     public int getZorder();
 
     /**
-     * Sets the value of the '{@link org.locationtech.udig.project.internal.Layer#getZorder <em>Zorder</em>}' attribute.
-     * <!-- begin-user-doc --> <!-- end-user-doc -->
+     * Sets the value of the '{@link org.locationtech.udig.project.internal.Layer#getZorder
+     * <em>Zorder</em>}' attribute. <!-- begin-user-doc --> <!-- end-user-doc -->
+     *
      * @param value the new value of the '<em>Zorder</em>' attribute.
      * @see #getZorder()
      * @generated
@@ -157,8 +162,8 @@ public interface Layer
     public int getStatus();
 
     /**
-     * Sets the value of the '{@link org.locationtech.udig.project.internal.Layer#getStatus <em>Status</em>}' attribute.
-     * <!-- begin-user-doc --> Indication of Layer status.
+     * Sets the value of the '{@link org.locationtech.udig.project.internal.Layer#getStatus
+     * <em>Status</em>}' attribute. <!-- begin-user-doc --> Indication of Layer status.
      * <p>
      * This is used to provide feedback for a Layers rendering status.
      * </p>
@@ -192,13 +197,13 @@ public interface Layer
     public Map<Interaction, Boolean> getInteractionMap();
 
     /**
-     * Returns the value of the '<em><b>Shown</b></em>' attribute.
-     * <!-- begin-user-doc -->
+     * Returns the value of the '<em><b>Shown</b></em>' attribute. <!-- begin-user-doc -->
      * <p>
-     * If the meaning of the '<em>Shown</em>' attribute isn't clear,
-     * there really should be more of a description here...
+     * If the meaning of the '<em>Shown</em>' attribute isn't clear, there really should be more of
+     * a description here...
      * </p>
      * <!-- end-user-doc -->
+     *
      * @return the value of the '<em>Shown</em>' attribute.
      * @see #setShown(boolean)
      * @see org.locationtech.udig.project.internal.ProjectPackage#getLayer_Shown()
@@ -209,9 +214,9 @@ public interface Layer
     boolean isShown();
 
     /**
-     * Sets the value of the '{@link org.locationtech.udig.project.internal.Layer#isShown <em>Shown</em>}' attribute.
-     * <!-- begin-user-doc -->
-     * <!-- end-user-doc -->
+     * Sets the value of the '{@link org.locationtech.udig.project.internal.Layer#isShown
+     * <em>Shown</em>}' attribute. <!-- begin-user-doc --> <!-- end-user-doc -->
+     *
      * @param value the new value of the '<em>Shown</em>' attribute.
      * @see #isShown()
      * @generated
@@ -247,9 +252,11 @@ public interface Layer
     public boolean isSelectable();
 
     /**
-     * Sets the value of the '{@link org.locationtech.udig.project.internal.Layer#isSelectable <em>Selectable</em>}' attribute.
-     * <!-- begin-user-doc --> Used by the user to control which layers are selectable,
-     * may be ignored for GeoResources that do not support editing. <!-- end-user-doc -->
+     * Sets the value of the '{@link org.locationtech.udig.project.internal.Layer#isSelectable
+     * <em>Selectable</em>}' attribute. <!-- begin-user-doc --> Used by the user to control which
+     * layers are selectable, may be ignored for GeoResources that do not support editing. <!--
+     * end-user-doc -->
+     *
      * @param value the new value of the '<em>Selectable</em>' attribute.
      * @see #isSelectable()
      * @deprecated use setInteraction(Interaction.SELECT, value)
@@ -268,8 +275,9 @@ public interface Layer
     public String getName();
 
     /**
-     * Sets the value of the '{@link org.locationtech.udig.project.internal.Layer#getName <em>Name</em>}' attribute.
-     * <!-- begin-user-doc --> <!-- end-user-doc -->
+     * Sets the value of the '{@link org.locationtech.udig.project.internal.Layer#getName
+     * <em>Name</em>}' attribute. <!-- begin-user-doc --> <!-- end-user-doc -->
+     *
      * @param value the new value of the '<em>Name</em>' attribute.
      * @see #getName()
      * @generated
@@ -284,8 +292,9 @@ public interface Layer
     CatalogRef getCatalogRef();
 
     /**
-     * Sets the value of the '{@link org.locationtech.udig.project.internal.Layer#getCatalogRef <em>Catalog Ref</em>}' attribute.
-     * <!-- begin-user-doc --> <!-- end-user-doc -->
+     * Sets the value of the '{@link org.locationtech.udig.project.internal.Layer#getCatalogRef
+     * <em>Catalog Ref</em>}' attribute. <!-- begin-user-doc --> <!-- end-user-doc -->
+     *
      * @param value the new value of the '<em>Catalog Ref</em>' attribute.
      * @see #getCatalogRef()
      * @generated
@@ -303,8 +312,9 @@ public interface Layer
     public URL getID();
 
     /**
-     * Sets the value of the '{@link org.locationtech.udig.project.internal.Layer#getID <em>ID</em>}' attribute.
-     * <!-- begin-user-doc --> <!-- end-user-doc -->
+     * Sets the value of the '{@link org.locationtech.udig.project.internal.Layer#getID
+     * <em>ID</em>}' attribute. <!-- begin-user-doc --> <!-- end-user-doc -->
+     *
      * @param value the new value of the '<em>ID</em>' attribute.
      * @see #getID()
      * @generated
@@ -322,8 +332,9 @@ public interface Layer
     public boolean isVisible();
 
     /**
-     * Sets the value of the '{@link org.locationtech.udig.project.internal.Layer#isVisible <em>Visible</em>}' attribute.
-     * <!-- begin-user-doc --> <!-- end-user-doc -->
+     * Sets the value of the '{@link org.locationtech.udig.project.internal.Layer#isVisible
+     * <em>Visible</em>}' attribute. <!-- begin-user-doc --> <!-- end-user-doc -->
+     *
      * @param value the new value of the '<em>Visible</em>' attribute.
      * @see #isVisible()
      * @generated
@@ -339,8 +350,9 @@ public interface Layer
     public IGeoResource getGeoResource();
 
     /**
-     * Sets the value of the '{@link org.locationtech.udig.project.internal.Layer#getGeoResource <em>Geo Resource</em>}' attribute.
-     * <!-- begin-user-doc --> <!-- end-user-doc -->
+     * Sets the value of the '{@link org.locationtech.udig.project.internal.Layer#getGeoResource
+     * <em>Geo Resource</em>}' attribute. <!-- begin-user-doc --> <!-- end-user-doc -->
+     *
      * @param value the new value of the '<em>Geo Resource</em>' attribute.
      * @see #getGeoResource()
      * @generated
@@ -370,9 +382,9 @@ public interface Layer
     public ImageDescriptor getIcon();
 
     /**
-     * Sets the value of the '{@link org.locationtech.udig.project.internal.Layer#getIcon <em>Icon</em>}' attribute.
-     * <!-- begin-user-doc -->
-     * <!-- end-user-doc -->
+     * Sets the value of the '{@link org.locationtech.udig.project.internal.Layer#getIcon
+     * <em>Icon</em>}' attribute. <!-- begin-user-doc --> <!-- end-user-doc -->
+     *
      * @param value the new value of the '<em>Icon</em>' attribute.
      * @see #getIcon()
      * @generated
@@ -423,8 +435,9 @@ public interface Layer
     CoordinateReferenceSystem getCRS();
 
     /**
-     * Sets the value of the '{@link org.locationtech.udig.project.internal.Layer#getCRS <em>CRS</em>}' attribute.
-     * <!-- begin-user-doc --> <!-- end-user-doc -->
+     * Sets the value of the '{@link org.locationtech.udig.project.internal.Layer#getCRS
+     * <em>CRS</em>}' attribute. <!-- begin-user-doc --> <!-- end-user-doc -->
+     *
      * @param value the new value of the '<em>CRS</em>' attribute.
      * @see #getCRS()
      * @generated
@@ -465,8 +478,9 @@ public interface Layer
     ColourScheme getColourScheme();
 
     /**
-     * Sets the value of the '{@link org.locationtech.udig.project.internal.Layer#getColourScheme <em>Colour Scheme</em>}' attribute.
-     * <!-- begin-user-doc --> <!-- end-user-doc -->
+     * Sets the value of the '{@link org.locationtech.udig.project.internal.Layer#getColourScheme
+     * <em>Colour Scheme</em>}' attribute. <!-- begin-user-doc --> <!-- end-user-doc -->
+     *
      * @param value the new value of the '<em>Colour Scheme</em>' attribute.
      * @see #getColourScheme()
      * @generated
@@ -481,8 +495,9 @@ public interface Layer
     Color getDefaultColor();
 
     /**
-     * Sets the value of the '{@link org.locationtech.udig.project.internal.Layer#getDefaultColor <em>Default Color</em>}' attribute.
-     * <!-- begin-user-doc --> <!-- end-user-doc -->
+     * Sets the value of the '{@link org.locationtech.udig.project.internal.Layer#getDefaultColor
+     * <em>Default Color</em>}' attribute. <!-- begin-user-doc --> <!-- end-user-doc -->
+     *
      * @param value the new value of the '<em>Default Color</em>' attribute.
      * @see #getDefaultColor()
      * @generated
@@ -507,15 +522,16 @@ public interface Layer
     public Set<Range> getScaleRange();
 
     /**
-     * Gets the min scale.  Will never return Double.NaN or 0
+     * Gets the min scale. Will never return Double.NaN or 0
+     *
      * @see #getScaleRange()
      * @model
      */
     public double getMinScaleDenominator();
 
     /**
-     * Sets the min scale.  If <= 0 or Double.NaN then it indicates that the scale calculated from the style or IGeoResource (such as WMS)
-     * should be returned.
+     * Sets the min scale. If <= 0 or Double.NaN then it indicates that the scale calculated from
+     * the style or IGeoResource (such as WMS) should be returned.
      *
      * @param value the new value of the '<em>Min Scale Denominator</em>' attribute.
      * @see #getMinScaleDenominator()
@@ -523,15 +539,17 @@ public interface Layer
     public void setMinScaleDenominator(double value);
 
     /**
-     * Gets the min scale.  Will never return Double.NaN or 0
+     * Gets the min scale. Will never return Double.NaN or 0
+     *
      * @see #getScaleRange()
      * @model
      */
     public double getMaxScaleDenominator();
 
     /**
-     * Sets the max scale.  If <= 0 or Double.NaN then it indicates that the scale calculated from the style or IGeoResource (such as WMS)
-     * should be returned.
+     * Sets the max scale. If <= 0 or Double.NaN then it indicates that the scale calculated from
+     * the style or IGeoResource (such as WMS) should be returned.
+     *
      * @param value the new value of the '<em>Max Scale Denominator</em>' attribute.
      * @see #getMaxScaleDenominator()
      */

--- a/plugins/org.locationtech.udig.project/src/org/locationtech/udig/project/internal/impl/BlackboardImpl.java
+++ b/plugins/org.locationtech.udig.project/src/org/locationtech/udig/project/internal/impl/BlackboardImpl.java
@@ -75,6 +75,7 @@ public class BlackboardImpl extends EObjectImpl implements Blackboard {
     /**
      * The cached value of the '{@link #getEntries() <em>Entries</em>}' containment reference list.
      * <!-- begin-user-doc --> <!-- end-user-doc -->
+     *
      * @see #getEntries()
      * @generated
      * @ordered
@@ -83,6 +84,7 @@ public class BlackboardImpl extends EObjectImpl implements Blackboard {
 
     /**
      * <!-- begin-user-doc --> <!-- end-user-doc -->
+     *
      * @generated
      */
     protected BlackboardImpl() {
@@ -91,6 +93,7 @@ public class BlackboardImpl extends EObjectImpl implements Blackboard {
 
     /**
      * <!-- begin-user-doc --> <!-- end-user-doc -->
+     *
      * @generated
      */
     @Override
@@ -100,6 +103,7 @@ public class BlackboardImpl extends EObjectImpl implements Blackboard {
 
     /**
      * <!-- begin-user-doc --> <!-- end-user-doc -->
+     *
      * @generated
      */
     @Override
@@ -113,6 +117,7 @@ public class BlackboardImpl extends EObjectImpl implements Blackboard {
 
     /**
      * <!-- begin-user-doc --> <!-- end-user-doc -->
+     *
      * @generated
      */
     @Override
@@ -127,6 +132,7 @@ public class BlackboardImpl extends EObjectImpl implements Blackboard {
 
     /**
      * <!-- begin-user-doc --> <!-- end-user-doc -->
+     *
      * @generated
      */
     @Override
@@ -140,6 +146,7 @@ public class BlackboardImpl extends EObjectImpl implements Blackboard {
 
     /**
      * <!-- begin-user-doc --> <!-- end-user-doc -->
+     *
      * @generated
      */
     @SuppressWarnings("unchecked")
@@ -156,6 +163,7 @@ public class BlackboardImpl extends EObjectImpl implements Blackboard {
 
     /**
      * <!-- begin-user-doc --> <!-- end-user-doc -->
+     *
      * @generated
      */
     @Override
@@ -170,6 +178,7 @@ public class BlackboardImpl extends EObjectImpl implements Blackboard {
 
     /**
      * <!-- begin-user-doc --> <!-- end-user-doc -->
+     *
      * @generated
      */
     @Override
@@ -248,7 +257,7 @@ public class BlackboardImpl extends EObjectImpl implements Blackboard {
                     }
                 } catch (Exception e) {
                     String msg = "provider exception :" + key; //$NON-NLS-1$
-                    String id = provider.getExtension().getNamespace();
+                    String id = provider.getExtension().getNamespaceIdentifier();
                     IStatus status = new Status(IStatus.WARNING, id, 0, msg, e);
 
                     ProjectPlugin.getPlugin().getLog().log(status);

--- a/plugins/org.locationtech.udig.style.sld/src/org/locationtech/udig/style/sld/SLDConfigurator.java
+++ b/plugins/org.locationtech.udig.style.sld/src/org/locationtech/udig/style/sld/SLDConfigurator.java
@@ -1,7 +1,7 @@
-/*
- *    uDig - User Friendly Desktop Internet GIS client
- *    http://udig.refractions.net
- *    (C) 2012, Refractions Research Inc.
+/**
+ * uDig - User Friendly Desktop Internet GIS client
+ * http://udig.refractions.net
+ * (C) 2012, Refractions Research Inc.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -49,7 +49,7 @@ import org.opengis.feature.simple.SimpleFeatureType;
  * capable of editing individual Symbolizers.
  * </p>
  * <p>
- * 
+ *
  * @author Justin Deoliveira, Refractions Research Inc.
  */
 public class SLDConfigurator extends IStyleConfigurator {
@@ -78,7 +78,8 @@ public class SLDConfigurator extends IStyleConfigurator {
     /**
      * Checks if the layer is a feature layer or if the layer is a wms that supports post.
      */
-    public boolean canStyle( Layer layer ) {
+    @Override
+    public boolean canStyle(Layer layer) {
         if (layer.hasResource(FeatureSource.class))
             return true;
         if (layer.hasResource(org.geotools.ows.wms.Layer.class))
@@ -89,24 +90,27 @@ public class SLDConfigurator extends IStyleConfigurator {
     /**
      * @see org.locationtech.udig.style.IStyleConfigurator#init(org.eclipse.ui.IViewSite)
      */
+    @Override
     public void init() {
         sldContentManager = new SLDContentManager();
 
         // process the extension point and add editors to the tool bar
-        Comparator<Class> compare = new Comparator<Class>(){
-            public int compare( Class a, Class b) {
-                return a.getSimpleName().compareTo( b.getSimpleName() );
-            }                
+        Comparator<Class> compare = new Comparator<Class>() {
+            @Override
+            public int compare(Class a, Class b) {
+                return a.getSimpleName().compareTo(b.getSimpleName());
+            }
         };
-        classToEditors = new TreeMap<Class, List<SLDEditorPart>>( compare );
+        classToEditors = new TreeMap<>(compare);
 
-        ExtensionPointProcessor p = new ExtensionPointProcessor(){
-            public void process( IExtension ext, IConfigurationElement element ) throws Exception {
+        ExtensionPointProcessor p = new ExtensionPointProcessor() {
+            @Override
+            public void process(IExtension ext, IConfigurationElement element) throws Exception {
                 try {
                     SLDEditorPart editor = (SLDEditorPart) element
                             .createExecutableExtension("class"); //$NON-NLS-1$
 
-                    editor.setPluginId(element.getNamespace());
+                    editor.setPluginId(element.getNamespaceIdentifier());
                     editor.setLabel(element.getAttribute("label")); //$NON-NLS-1$
 
                     ImageDescriptor image = editor.createImageDescriptor();
@@ -119,7 +123,7 @@ public class SLDConfigurator extends IStyleConfigurator {
 
                     List<SLDEditorPart> list = classToEditors.get(contentClass);
                     if (list == null) {
-                        list = new ArrayList<SLDEditorPart>();
+                        list = new ArrayList<>();
                         classToEditors.put(contentClass, list);
                     }
                     list.add(editor);
@@ -128,15 +132,11 @@ public class SLDConfigurator extends IStyleConfigurator {
                 }
             }
         };
-        ExtensionPointUtil.process(SLDPlugin.getDefault(),SLDEditorPart.XPID, p);
+        ExtensionPointUtil.process(SLDPlugin.getDefault(), SLDEditorPart.XPID, p);
     }
 
-    /*
-     * (non-Javadoc)
-     * 
-     * @see org.locationtech.udig.style.IStyleConfigurator#createControl(org.eclipse.swt.widgets.Composite)
-     */
-    public void createControl( Composite parent ) {
+    @Override
+    public void createControl(Composite parent) {
         createToolbarItems(); // now we have toolbar items
         editorBook = new PageBook(parent, SWT.NONE);
         editorBook.setVisible(true);
@@ -144,8 +144,8 @@ public class SLDConfigurator extends IStyleConfigurator {
         blank = new Composite(editorBook, SWT.NONE);
         editorBook.showPage(blank);
 
-        for( List<SLDEditorPart> parts : classToEditors.values() ) {
-            for( SLDEditorPart part : parts ) {
+        for (List<SLDEditorPart> parts : classToEditors.values()) {
+            for (SLDEditorPart part : parts) {
                 try {
                     part.createControl(editorBook);
                 } catch (Throwable t) {
@@ -153,11 +153,13 @@ public class SLDConfigurator extends IStyleConfigurator {
                 }
             }
         }
-    }	
+    }
+
     /*
      * Called when new layer and blackbard values are available. <p> This provides update
      * information as a callback (rather than an event listener). </p>
      */
+    @Override
     protected void refresh() {
         Layer layer = getLayer();
         if (!canStyle(layer)) {
@@ -165,24 +167,24 @@ public class SLDConfigurator extends IStyleConfigurator {
         }
         // pull the sld style off the blackboard, and initialize the cm
         Style style = (Style) getStyleBlackboard().get(SLDContent.ID);
-        
+
         // if no style information, create default
         if (style == null) {
             style = SLDContent.createDefaultStyle();
             getStyleBlackboard().put(SLDContent.ID, style);
         }
         sldContentManager.init(SLDContent.getStyleBuilder(), style);
-        
+
         // pull the feature type name out of the layer
         if (layer.getSchema() != null) {
             SimpleFeatureType featureType = layer.getSchema();
-        
-            //set the name of the feature type style for the feature renderer
-            String name = featureType.getName().getLocalPart();
+
+            // set the name of the feature type style for the feature renderer
             sldContentManager.getDefaultFeatureTypeStyle().featureTypeNames().clear();
-            sldContentManager.getDefaultFeatureTypeStyle().featureTypeNames().add(new NameImpl(SLDs.GENERIC_FEATURE_TYPENAME));
+            sldContentManager.getDefaultFeatureTypeStyle().featureTypeNames()
+                    .add(new NameImpl(SLDs.GENERIC_FEATURE_TYPENAME));
         }
-        
+
         // force the toolbar to refresh
         //
         IToolBarManager tbm = getViewSite().getActionBars().getToolBarManager();
@@ -190,14 +192,14 @@ public class SLDConfigurator extends IStyleConfigurator {
         tbm.update(true);
         getViewSite().getActionBars().updateActionBars();
 
-        for( IContributionItem item : tbm.getItems() ) {
+        for (IContributionItem item : tbm.getItems()) {
             ActionContributionItem action = (ActionContributionItem) item;
             action.getAction().setEnabled(action.getAction().isEnabled());
         }
 
-        // focus the active editor if any exisits
+        // focus the active editor if any exists
         SLDEditorPart editor = (SLDEditorPart) editorBook.getData();
-        List<Class> supported = SLD.getSupportedTypes( layer );
+        List<Class> supported = SLD.getSupportedTypes(layer);
         if (editor != null) {
             if (supported.contains(editor.getContentType())) {
                 initEditor(editor);
@@ -206,25 +208,26 @@ public class SLDConfigurator extends IStyleConfigurator {
             }
         }
         // if we get here the current editor wasn't applicable, show first that works
-        for( Class type : classToEditors.keySet() ){
-            if( !supported.contains( type )) continue;
-            
-            for( SLDEditorPart part : classToEditors.get( type ) ){
-                initEditor( part ); // FIXME: we don't want the editor to have content it should not
+        for (Class type : classToEditors.keySet()) {
+            if (!supported.contains(type))
+                continue;
+
+            for (SLDEditorPart part : classToEditors.get(type)) {
+                initEditor(part); // FIXME: we don't want the editor to have content it should not
                 part.reset();
-                editorBook.setData( part );
-                editorBook.showPage( part.getPage() );
-                part.getPage().setVisible( true );
+                editorBook.setData(part);
+                editorBook.showPage(part.getPage());
+                part.getPage().setVisible(true);
                 return;
             }
         }
         editorBook.showPage(blank);
-        
+
     }
 
     protected void createToolbarItems() {
-        toolbarItems = new ArrayList<SLDEditorMenuAction>(); // FIXME!
-        for( Class contentClass : classToEditors.keySet() ) {
+        toolbarItems = new ArrayList<>(); // FIXME!
+        for (Class contentClass : classToEditors.keySet()) {
             List<SLDEditorPart> editors = classToEditors.get(contentClass);
             if (editors == null || editors.isEmpty()) {
                 continue; // skip class with no editors
@@ -242,7 +245,7 @@ public class SLDConfigurator extends IStyleConfigurator {
 
         // add em here
         IToolBarManager tbm = getViewSite().getActionBars().getToolBarManager();
-        for( SLDEditorMenuAction item : toolbarItems ) {
+        for (SLDEditorMenuAction item : toolbarItems) {
             tbm.add(item);
         }
 
@@ -251,14 +254,15 @@ public class SLDConfigurator extends IStyleConfigurator {
     /**
      * Sets the editor up for a reset(). Ensures the editor has content.
      */
-    void initEditor( SLDEditorPart editor ) {
+    void initEditor(SLDEditorPart editor) {
         // enable the symbolizer if necessary
-    	@SuppressWarnings("unchecked") Class<Symbolizer> symbolizerType = editor.getContentType();
-    	
-        Symbolizer content = sldContentManager.getSymbolizer( symbolizerType );
+        @SuppressWarnings("unchecked")
+        Class<Symbolizer> symbolizerType = editor.getContentType();
+
+        Symbolizer content = sldContentManager.getSymbolizer(symbolizerType);
         if (content == null) {
-            sldContentManager.addSymbolizer( symbolizerType );
-            content = (Symbolizer)sldContentManager.getSymbolizer( symbolizerType );
+            sldContentManager.addSymbolizer(symbolizerType);
+            content = sldContentManager.getSymbolizer(symbolizerType);
         }
 
         editor.setStyleBuilder(sldContentManager.getStyleBuilder());
@@ -270,14 +274,13 @@ public class SLDConfigurator extends IStyleConfigurator {
      * Composite action made up of a drop down menu of actions.
      */
     class SLDEditorMenuAction extends Action
-            implements
-                IMenuCreator,
-                Comparable<SLDEditorMenuAction> {
+            implements IMenuCreator, Comparable<SLDEditorMenuAction> {
 
         List<SLDEditorPart> editors;
+
         Menu menu;
 
-        public SLDEditorMenuAction( List<SLDEditorPart> editors ) {
+        public SLDEditorMenuAction(List<SLDEditorPart> editors) {
             this.editors = editors;
 
             setMenuCreator(this);
@@ -291,19 +294,21 @@ public class SLDConfigurator extends IStyleConfigurator {
             return editors.get(0).getContentType();
         }
 
+        @Override
         public void dispose() {
             if (menu != null) {
                 menu.dispose();
-            }            
+            }
         }
 
-        public Menu getMenu( Control parent ) {
+        @Override
+        public Menu getMenu(Control parent) {
             if (menu != null) {
                 menu.dispose();
             }
             menu = new Menu(parent);
 
-            for( SLDEditorPart editor : editors ) {
+            for (SLDEditorPart editor : editors) {
                 Action action = new SLDEditorAction(editor, this);
                 addActionToMenu(menu, action);
             }
@@ -311,22 +316,26 @@ public class SLDConfigurator extends IStyleConfigurator {
             return menu;
         }
 
-        public Menu getMenu( Menu parent ) {
+        @Override
+        public Menu getMenu(Menu parent) {
             return null;
         }
 
-        protected void addActionToMenu( Menu parent, Action action ) {
+        protected void addActionToMenu(Menu parent, Action action) {
             ActionContributionItem item = new ActionContributionItem(action);
             item.fill(parent, -1);
         }
 
-        public int compareTo( SLDEditorMenuAction other ) {
-            return editors.get(0).getContentType().getName().compareTo(
-                    other.editors.get(0).getContentType().getName());
+        @Override
+        public int compareTo(SLDEditorMenuAction other) {
+            return editors.get(0).getContentType().getName()
+                    .compareTo(other.editors.get(0).getContentType().getName());
         }
+
         /**
          * @see org.eclipse.jface.action.Action#isEnabled()
          */
+        @Override
         public boolean isEnabled() {
             Layer layer = getLayer();
             if (layer == null)
@@ -342,9 +351,10 @@ public class SLDConfigurator extends IStyleConfigurator {
     class SLDEditorAction extends Action {
 
         SLDEditorMenuAction parent;
+
         SLDEditorPart editor;
 
-        public SLDEditorAction( SLDEditorPart editor, SLDEditorMenuAction parent ) {
+        public SLDEditorAction(SLDEditorPart editor, SLDEditorMenuAction parent) {
             super();
 
             this.editor = editor;
@@ -354,6 +364,7 @@ public class SLDConfigurator extends IStyleConfigurator {
             setText(editor.getLabel());
         }
 
+        @Override
         public void run() {
             // update the icon to reflect the currently selected editor
             //
@@ -361,8 +372,9 @@ public class SLDConfigurator extends IStyleConfigurator {
 
             if (editor instanceof SLDDisableEditorPart) {
                 // disable the symbolizer
-            	@SuppressWarnings("unchecked") Class<Symbolizer> symbolizer = editor.getContentType();
-                sldContentManager.removeSymbolizer( symbolizer );
+                @SuppressWarnings("unchecked")
+                Class<Symbolizer> symbolizer = editor.getContentType();
+                sldContentManager.removeSymbolizer(symbolizer);
             } else {
                 initEditor(editor);
             }
@@ -377,7 +389,8 @@ public class SLDConfigurator extends IStyleConfigurator {
             editorBook.showPage(page);
             // page.setVisible( true );
         }
-        protected ImageDescriptor getImageDescriptor( SLDEditorPart editor1 ) {
+
+        protected ImageDescriptor getImageDescriptor(SLDEditorPart editor1) {
             return editor1.getImageDescriptor();
         }
     }
@@ -389,39 +402,28 @@ public class SLDConfigurator extends IStyleConfigurator {
 
         private Class<Symbolizer> contentType;
 
-        public SLDDisableEditorPart( Class<Symbolizer> contentType ) {
+        public SLDDisableEditorPart(Class<Symbolizer> contentType) {
             this.contentType = contentType;
             setImageDescriptor(SLD.createDisabledImageDescriptor(contentType));
-            setLabel(Messages.SLDConfigurator_disable); 
+            setLabel(Messages.SLDConfigurator_disable);
         }
 
+        @Override
         public void init() {
             // do nothing
         }
 
-        /*
-         * (non-Javadoc)
-         * 
-         * @see org.locationtech.udig.style.sld.SLDEditorPart#getContentType()
-         */
+        @Override
         public Class getContentType() {
             return contentType;
         }
 
-        /*
-         * (non-Javadoc)
-         * 
-         * @see org.locationtech.udig.style.sld.SLDEditorPart#createPartControl(org.eclipse.swt.widgets.Composite)
-         */
-        protected Control createPartControl( Composite parent ) {
+        @Override
+        protected Control createPartControl(Composite parent) {
             return new Composite(parent, SWT.NONE);
         }
 
-        /*
-         * (non-Javadoc)
-         * 
-         * @see org.locationtech.udig.style.sld.SLDEditorPart#reset()
-         */
+        @Override
         public void reset() {
             // disable the content configurator
             sldContentManager.removeSymbolizer(contentType);

--- a/plugins/org.locationtech.udig.ui/src/org/locationtech/udig/ui/SearchPart.java
+++ b/plugins/org.locationtech.udig.ui/src/org/locationtech/udig/ui/SearchPart.java
@@ -1,4 +1,5 @@
-/* uDig - User Friendly Desktop Internet GIS client
+/**
+ * uDig - User Friendly Desktop Internet GIS client
  * http://udig.refractions.net
  * (C) 2004, Refractions Research Inc.
  *
@@ -14,11 +15,8 @@ import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.CopyOnWriteArrayList;
 
-import org.locationtech.udig.ui.internal.Messages;
-
 import org.eclipse.core.runtime.IProgressMonitor;
 import org.eclipse.core.runtime.IStatus;
-import org.eclipse.core.runtime.Platform;
 import org.eclipse.core.runtime.Status;
 import org.eclipse.core.runtime.jobs.Job;
 import org.eclipse.jface.action.Action;
@@ -45,7 +43,6 @@ import org.eclipse.swt.events.ControlListener;
 import org.eclipse.swt.graphics.Point;
 import org.eclipse.swt.widgets.Composite;
 import org.eclipse.swt.widgets.Display;
-import org.eclipse.swt.widgets.Event;
 import org.eclipse.ui.IActionBars;
 import org.eclipse.ui.IMemento;
 import org.eclipse.ui.IPartListener2;
@@ -54,21 +51,22 @@ import org.eclipse.ui.IWorkbenchPartReference;
 import org.eclipse.ui.PartInitException;
 import org.eclipse.ui.part.ISetSelectionTarget;
 import org.eclipse.ui.part.ViewPart;
+import org.locationtech.udig.ui.internal.Messages;
 
 /**
  * A ViewPart with support for a background "search" process.
  * <p>
- * The part will automatically show the "progress" when the monitored
- * Job(s) are running.
+ * The part will automatically show the "progress" when the monitored Job(s) are running.
  * </p>
+ *
  * @author jgarnett
  * @since 1.0.0
  */
 public class SearchPart extends ViewPart implements ISetSelectionTarget {
-    
+
     /** Viewer for search results List/Tree/Table ... */
     protected StructuredViewer viewer; // often a tree or table viewer
-        
+
     /**
      * Used to cancel current searchMonitor
      * <p>
@@ -76,12 +74,11 @@ public class SearchPart extends ViewPart implements ISetSelectionTarget {
      * </p>
      */
     protected IAction cancel;
-    
+
     /**
      * Used to control search jobs.
      * <p>
-     * Only one "batch" of search jobs is outstanding at anyone
-     * time.
+     * Only one "batch" of search jobs is outstanding at anyone time.
      * </p>
      */
     protected IProgressMonitor searchMonitor;
@@ -90,93 +87,104 @@ public class SearchPart extends ViewPart implements ISetSelectionTarget {
 
     /** Save state here */
     protected IMemento save;
+
     protected Composite parent;
-    
+
     IDialogSettings settings;
-    
+
     /** We need dialog settings for persistence */
-    protected SearchPart( IDialogSettings dialogSettings ) {
+    protected SearchPart(IDialogSettings dialogSettings) {
         settings = dialogSettings;
     }
+
     @Override
-    public void init( IViewSite site, IMemento memento ) throws PartInitException {
+    public void init(IViewSite site, IMemento memento) throws PartInitException {
         super.init(site, memento);
         save = memento;
-    }        
-    
+    }
+
     @Override
-    public void saveState( IMemento memento ) {
-        if ( splitter == null) { // part has not been created
-            if (save != null) { //Keep the old state;
-                memento.putMemento( save );
+    public void saveState(IMemento memento) {
+        if (splitter == null) { // part has not been created
+            if (save != null) { // Keep the old state;
+                memento.putMemento(save);
             }
             return;
-        }        
+        }
     }
+
     private void addResizeListener(Composite parent) {
         parent.addControlListener(new ControlListener() {
+            @Override
             public void controlMoved(ControlEvent e) {
             }
+
+            @Override
             public void controlResized(ControlEvent e) {
                 computeOrientation();
             }
         });
     }
-     
-    protected enum Orientation { VERTICAL, HORIZONTAL, SINGLE, AUTOMATIC };
+
+    protected enum Orientation {
+        VERTICAL, HORIZONTAL, SINGLE, AUTOMATIC
+    };
+
     protected Orientation orientation = Orientation.VERTICAL;
-    
+
     void computeOrientation() {
         saveSplitterRatio();
-        if( save != null ) save.putInteger("orientation", orientation.ordinal() ); //$NON-NLS-1$
-        if ( orientation != Orientation.AUTOMATIC ) {
-            setOrientation( orientation );
-        }
-        else {
-            if (orientation == Orientation.SINGLE ) return;
-            
-            Point size= parent.getSize();
+        if (save != null)
+            save.putInteger("orientation", orientation.ordinal()); //$NON-NLS-1$
+        if (orientation != Orientation.AUTOMATIC) {
+            setOrientation(orientation);
+        } else {
+            if (orientation == Orientation.SINGLE)
+                return;
+
+            Point size = parent.getSize();
             if (size.x != 0 && size.y != 0) {
-                if (size.x > size.y) 
-                    setOrientation( Orientation.HORIZONTAL );
-                else 
-                    setOrientation( Orientation.VERTICAL );
+                if (size.x > size.y)
+                    setOrientation(Orientation.HORIZONTAL);
+                else
+                    setOrientation(Orientation.VERTICAL);
             }
         }
     }
+
     private void saveSplitterRatio() {
-        if (splitter != null && ! splitter.isDisposed()) {
+        if (splitter != null && !splitter.isDisposed()) {
             int[] weigths = splitter.getWeights();
             int ratio = (weigths[0] * 1000) / (weigths[0] + weigths[1]);
-            settings.put( "ratio"+orientation, ratio );             //$NON-NLS-1$
+            settings.put("ratio" + orientation, ratio); //$NON-NLS-1$
         }
     }
+
     private void restoreSplitterRatio() {
         try {
-            Integer ratio= settings.getInt("ratio"+orientation); //$NON-NLS-1$
-            if (ratio == null)
-                return;
-            splitter.setWeights(new int[] {ratio, 1000 - ratio});
-        }
-        catch( NumberFormatException nan ) {
+            Integer ratio = settings.getInt("ratio" + orientation); //$NON-NLS-1$
+            splitter.setWeights(new int[] { ratio, 1000 - ratio });
+        } catch (NumberFormatException nan) {
             // ignore bad setting
         }
     }
-    
+
     Orientation currentOrientation;
+
     private boolean showDetails;
+
     /**
      * called from ToggleOrientationAction (or compute).
-     * 
+     *
      * @param orientation Orientation.HORIZONTAL or Orientation.VERTICAL
      */
     protected void setOrientation(Orientation orientation) {
         if (currentOrientation == orientation) {
             return; // no change needed
         }
-        if (viewer != null && !viewer.getControl().isDisposed() &&
-            splitter != null && !splitter.isDisposed() ) {
-            
+        if (viewer != null && !viewer.getControl().isDisposed() && splitter != null
+                && !splitter.isDisposed()) {
+
             if (orientation == Orientation.SINGLE) {
                 setShowDetails(false);
             } else {
@@ -184,36 +192,42 @@ public class SearchPart extends ViewPart implements ISetSelectionTarget {
                     setShowDetails(true);
                 }
                 boolean horizontal = orientation == Orientation.HORIZONTAL;
-                splitter.setOrientation( horizontal ? SWT.HORIZONTAL : SWT.VERTICAL);
+                splitter.setOrientation(horizontal ? SWT.HORIZONTAL : SWT.VERTICAL);
             }
             splitter.layout();
         }
         updateCheckedState();
 
         currentOrientation = orientation;
-        
+
         restoreSplitterRatio();
     }
+
     private ToggleOrientationAction[] toggleOrientationActions;
+
     private Composite details;
+
     private IPartListener2 partListener;
+
     private void updateCheckedState() {
         for (ToggleOrientationAction toggle : toggleOrientationActions) {
-            toggle.setChecked( orientation == toggle.getOrientation());
+            toggle.setChecked(orientation == toggle.getOrientation());
         }
     }
+
     public void setShowDetails(boolean show) {
         showDetails = show;
         showOrHideDetails();
     }
+
     private void showOrHideDetails() {
         if (showDetails) {
             splitter.setMaximizedControl(null);
         } else {
-            splitter.setMaximizedControl( viewer.getControl() );
+            splitter.setMaximizedControl(viewer.getControl());
         }
     }
-    
+
     /**
      * Creates the SWT controls for this workbench part.
      * <p>
@@ -225,113 +239,138 @@ public class SearchPart extends ViewPart implements ISetSelectionTarget {
      * <li>Create one or more controls within the parent.</li>
      * <li>Set the parent layout as needed.</li>
      * <li>Register any global actions with the <code>IActionService</code>.</li>
-     * <li>Register any popup menus with the <code>IActionService</code>.</li>
-     * <li>Register a selection provider with the <code>ISelectionService</code> (optional).
-     * </li>
+     * <li>Register any pop-up menus with the <code>IActionService</code>.</li>
+     * <li>Register a selection provider with the <code>ISelectionService</code> (optional).</li>
      * </ol>
      * </p>
-     * 
+     *
      * @see org.eclipse.ui.part.WorkbenchPart#createPartControl(org.eclipse.swt.widgets.Composite)
      * @param parent
      */
-    public void createPartControl( Composite aParent ) {
-        parent= aParent;
+    @Override
+    public void createPartControl(Composite aParent) {
+        parent = aParent;
         addResizeListener(parent);
-        
+
         // split
-        splitter = new SashForm( parent, SWT.HORIZONTAL);
+        splitter = new SashForm(parent, SWT.HORIZONTAL);
         // TODO: key listener
-        
-        viewer = createViewer( splitter );
-        viewer.setContentProvider( createContentProvider() );
-        viewer.setLabelProvider( createLabelProvider() );        
-        viewer.addSelectionChangedListener( createSelectionListener() );
+
+        viewer = createViewer(splitter);
+        viewer.setContentProvider(createContentProvider());
+        viewer.setLabelProvider(createLabelProvider());
+        viewer.addSelectionChangedListener(createSelectionListener());
         getSite().setSelectionProvider(viewer);
-        details = createDetails( splitter );
-        
+        details = createDetails(splitter);
+
         initDragAndDrop();
-        
+
         makeActions();
         fillViewMenu();
         fillActionBars();
-        
+
         initOrientation();
-        
+
         if (save != null) {
-            restoreState( save );
+            restoreState(save);
         }
         restoreSplitterRatio();
         addPartListener();
     }
-    
+
     /**
      * You can now restore whatever state you need.
      */
     private void restoreState(IMemento memento) {
         //
     }
-    protected void saveViewSettings() {        
+
+    protected void saveViewSettings() {
         saveSplitterRatio();
-        settings.put( "orientation", orientation.ordinal() );         //$NON-NLS-1$
+        settings.put("orientation", orientation.ordinal()); //$NON-NLS-1$
     }
+
     private void addPartListener() {
         final String ID = getViewSite().getId();
-        partListener= new IPartListener2() {
-                    public void partActivated(IWorkbenchPartReference partRef) { }
-                    public void partBroughtToTop(IWorkbenchPartReference partRef) { }
-                    public void partClosed(IWorkbenchPartReference partRef) {
-                        if (ID.equals(partRef.getId()))
-                            saveViewSettings();
-                    }
-                    public void partDeactivated(IWorkbenchPartReference partRef) {
-                        if (ID.equals(partRef.getId()))
-                            saveViewSettings();
-                    }
-                    public void partOpened(IWorkbenchPartReference partRef) { }
-                    public void partHidden(IWorkbenchPartReference partRef) { }
-                    public void partVisible(IWorkbenchPartReference partRef) { }
-                    public void partInputChanged(IWorkbenchPartReference partRef) { }
-                };
+        partListener = new IPartListener2() {
+            @Override
+            public void partActivated(IWorkbenchPartReference partRef) {
+            }
+
+            @Override
+            public void partBroughtToTop(IWorkbenchPartReference partRef) {
+            }
+
+            @Override
+            public void partClosed(IWorkbenchPartReference partRef) {
+                if (ID.equals(partRef.getId()))
+                    saveViewSettings();
+            }
+
+            @Override
+            public void partDeactivated(IWorkbenchPartReference partRef) {
+                if (ID.equals(partRef.getId()))
+                    saveViewSettings();
+            }
+
+            @Override
+            public void partOpened(IWorkbenchPartReference partRef) {
+            }
+
+            @Override
+            public void partHidden(IWorkbenchPartReference partRef) {
+            }
+
+            @Override
+            public void partVisible(IWorkbenchPartReference partRef) {
+            }
+
+            @Override
+            public void partInputChanged(IWorkbenchPartReference partRef) {
+            }
+        };
         getViewSite().getPage().addPartListener(partListener);
     }
+
     /**
      * Should do the dialog settings thing here ...
      */
     private void initOrientation() {
         orientation = Orientation.AUTOMATIC;
-        if( save != null ) {
-            Integer integer = save.getInteger( "orientation" ); //$NON-NLS-1$
-            if( integer != null ) {
-                orientation = Orientation.values()[ integer ];    
-            }            
+        if (save != null) {
+            Integer integer = save.getInteger("orientation"); //$NON-NLS-1$
+            if (integer != null) {
+                orientation = Orientation.values()[integer];
+            }
         }
 
         // force the update
         currentOrientation = null;
-        setOrientation( orientation );
+        setOrientation(orientation);
     }
+
     /**
      * Subclass should override to provide custom details display.
      * <p>
-     * Many subclasses use PageBook with page selection based on
-     * the selection in the viewer.
+     * Many subclasses use PageBook with page selection based on the selection in the viewer.
      * </p>
+     *
      * @param splitter
      * @return Composite to use for details display
      */
-    protected Composite createDetails( SashForm splitter ) {
-        return new Composite( splitter, SWT.NONE );        
+    protected Composite createDetails(SashForm splitter) {
+        return new Composite(splitter, SWT.NONE);
     }
+
     /**
-     * Subclass can override to return its kind of details,
-     * example a PageBook.
+     * Subclass can override to return its kind of details, example a PageBook.
      *
      * @return
      */
     protected Composite getDetails() {
         return details;
-    }    
-    
+    }
+
     /**
      * Create viewer (default is a ListViewer please override if you want a Tree or Table Viewer.
      * <p>
@@ -341,14 +380,16 @@ public class SearchPart extends ViewPart implements ISetSelectionTarget {
      * <li>viewer.setLabelProvider( createLableProvider() );
      * </ul>
      * This allows people who subclass you to do their own thing.
-     * </p>    
+     * </p>
+     *
      * @param page
      * @return
      */
-    protected StructuredViewer createViewer( Composite parent ) {
-        ListViewer viewer = new ListViewer( parent );
+    protected StructuredViewer createViewer(Composite parent) {
+        ListViewer viewer = new ListViewer(parent);
         return viewer;
     }
+
     /**
      * Default implementation calls showDetail( IStructuredSelection ).
      * <p>
@@ -356,47 +397,53 @@ public class SearchPart extends ViewPart implements ISetSelectionTarget {
      */
     protected ISelectionChangedListener createSelectionListener() {
         return new ISelectionChangedListener() {
-            public void selectionChanged( SelectionChangedEvent event ) {
-                ISelection sel= event.getSelection();
-                if( sel instanceof IStructuredSelection ) {
+            @Override
+            public void selectionChanged(SelectionChangedEvent event) {
+                ISelection sel = event.getSelection();
+                if (sel instanceof IStructuredSelection) {
                     IStructuredSelection selection = (IStructuredSelection) sel;
-                    showDetail( selection.getFirstElement() );
+                    showDetail(selection.getFirstElement());
                 }
-            }            
+            }
         };
     }
-    /** Allows subclass to focus the detail on this selection  */ 
-    protected void showDetail( Object selection ) {
+
+    /** Allows subclass to focus the detail on this selection */
+    protected void showDetail(Object selection) {
         //
     }
 
     /**
-     * Default implementation will work for lists, please overide if
-     * you are into the whole tree thing.
-     * 
+     * Default implementation will work for lists, please override if you are into the whole tree
+     * thing.
+     *
      * @return
      */
     protected IStructuredContentProvider createContentProvider() {
         return new IStructuredContentProvider() {
-            @SuppressWarnings("unchecked")
-            public Object[] getElements( Object inputElement ) {
-                if( inputElement instanceof List ) {
-                    return ((List)inputElement).toArray();
+            @Override
+            public Object[] getElements(Object inputElement) {
+                if (inputElement instanceof List) {
+                    return ((List) inputElement).toArray();
                 }
                 return null;
             }
+
+            @Override
             public void dispose() {
             }
-            public void inputChanged( Viewer viewer, Object oldInput, Object newInput ) {
-                assert( newInput instanceof List );
+
+            @Override
+            public void inputChanged(Viewer viewer, Object oldInput, Object newInput) {
+                assert (newInput instanceof List);
                 // lists don't have events for us to watch
-            }            
+            }
         };
     }
 
     /**
      * LabelProvider; override to take charge of your labels and icons.
-     * 
+     *
      * @return LabelProvider for use with the viewer
      */
     protected IBaseLabelProvider createLabelProvider() {
@@ -404,55 +451,53 @@ public class SearchPart extends ViewPart implements ISetSelectionTarget {
     }
 
     /** Will cancel any outstanding search */
-    synchronized void stopSearch(){        
-        if( searchMonitor != null ){
+    synchronized void stopSearch() {
+        if (searchMonitor != null) {
             IProgressMonitor cancelMonitor = searchMonitor;
-            
+
             searchMonitor = null;
-            cancelMonitor.setCanceled( true );            
-        }        
+            cancelMonitor.setCanceled(true);
+        }
     }
-        
+
     /**
      * Subclass should override to support DnD.
      */
     protected void initDragAndDrop() {
         //
-    }    
+    }
 
     protected void makeActions() {
         cancel = new Action() {
+            @Override
             public void run() {
                 stopSearch();
                 setEnabled(false);
-                //book.showPage( promptPage );                
+                // book.showPage( promptPage );
             }
         };
-        Messages.initAction( cancel, "cancel" ); //$NON-NLS-1$
-        cancel.setEnabled( false );
-        
+        Messages.initAction(cancel, "cancel"); //$NON-NLS-1$
+        cancel.setEnabled(false);
+
         toggleOrientationActions = new ToggleOrientationAction[] {
                 new ToggleOrientationAction(this, Orientation.VERTICAL),
                 new ToggleOrientationAction(this, Orientation.HORIZONTAL),
                 new ToggleOrientationAction(this, Orientation.AUTOMATIC),
-                new ToggleOrientationAction(this, Orientation.SINGLE)
-            };
-        
+                new ToggleOrientationAction(this, Orientation.SINGLE) };
+
     }
-    /**
-    *
-    */
-   protected void fillViewMenu() {
-       IActionBars actionBars = getViewSite().getActionBars();
-       IMenuManager viewMenu = actionBars.getMenuManager();
-       
-       viewMenu.add( cancel );
-       viewMenu.add(new Separator());
-       for (ToggleOrientationAction toggle : toggleOrientationActions) {
-           viewMenu.add( toggle );
-       }
-   }    
-    
+
+    protected void fillViewMenu() {
+        IActionBars actionBars = getViewSite().getActionBars();
+        IMenuManager viewMenu = actionBars.getMenuManager();
+
+        viewMenu.add(cancel);
+        viewMenu.add(new Separator());
+        for (ToggleOrientationAction toggle : toggleOrientationActions) {
+            viewMenu.add(toggle);
+        }
+    }
+
     /**
      * Create toolbar with cancel.
      */
@@ -460,209 +505,226 @@ public class SearchPart extends ViewPart implements ISetSelectionTarget {
         IActionBars actionBars = getViewSite().getActionBars();
         IToolBarManager toolBar = actionBars.getToolBarManager();
 
-        toolBar.add( cancel );
+        toolBar.add(cancel);
     }
-    
-    public void quick( String pattern ) {
+
+    public void quick(String pattern) {
         // search through existing contents based on label?
     }
 
     Object filter = null;
-    Job looking = new Job( getPartName()+"..."){ //$NON-NLS-1$
-        protected IStatus run( IProgressMonitor monitor ) {
-            try {                    
-                final ResultSet set=new ResultSet(SearchPart.this);
-                Display.getDefault().asyncExec(new Runnable(){
+
+    Job looking = new Job(getPartName() + "...") { //$NON-NLS-1$
+        @Override
+        protected IStatus run(IProgressMonitor monitor) {
+            try {
+                final ResultSet set = new ResultSet(SearchPart.this);
+                Display.getDefault().asyncExec(new Runnable() {
+                    @Override
                     public void run() {
-                        viewer.setInput( set.results );
+                        viewer.setInput(set.results);
                     }
-                }); 
-                
-                searchImplementation( filter, monitor, set);
-                
-//                PlatformGIS.runBlockingOperation(new IRunnableWithProgress(){
-//
-//                    public void run( IProgressMonitor monitor ) throws InvocationTargetException, InterruptedException {
-//                        searchImplementation( filter, monitor, set);
-//                    }
-//                    
-//                }, monitor);
-                
-                Display.getDefault().asyncExec(new Runnable(){
+                });
+
+                searchImplementation(filter, monitor, set);
+
+                Display.getDefault().asyncExec(new Runnable() {
+                    @Override
                     public void run() {
                         viewer.setSelection(getSelection(set.results), showSelection());
                     }
-                }); 
+                });
             }
-            
-            catch (Throwable t ) {
-                //book.showPage( promptPage );                    
-            }finally{
-                cancel.setEnabled( false );                    
+
+            catch (Throwable t) {
+                // book.showPage( promptPage );
+            } finally {
+                cancel.setEnabled(false);
             }
-            return Status.OK_STATUS;                
+            return Status.OK_STATUS;
         }
-    }; 
-    
+    };
+
     /**
-     * Called each time data is added to the result set by the search.  Note: Many items or a single item could have been added.
+     * Called each time data is added to the result set by the search. Note: Many items or a single
+     * item could have been added.
      *
-     * @param set the results of the search at the current point. 
+     * @param set the results of the search at the current point.
      * @param newObjects the objects that have been added this time.
      */
-    protected void notifyChange( final ResultSet set, final Collection< ? extends Object> newObjects ) {
-        Display.getDefault().asyncExec(new Runnable(){
+    protected void notifyChange(final ResultSet set,
+            final Collection<? extends Object> newObjects) {
+        Display.getDefault().asyncExec(new Runnable() {
+            @Override
             public void run() {
-                if( !newObjects.isEmpty() )
+                if (!newObjects.isEmpty())
                     viewer.refresh(true);
             }
-        }); 
+        });
     }
 
     /**
-     * Called to determine what object(s) in the input should be the selection in the viewer.  This method is called when the search is complete.
-     * The default selection is the first object in the list.
-     * 
+     * Called to determine what object(s) in the input should be the selection in the viewer. This
+     * method is called when the search is complete. The default selection is the first object in
+     * the list.
+     *
      * @param the complete list of objects in the viewer.
      *
-     * @return the selection that will be set in the viewer.  may be null.
+     * @return the selection that will be set in the viewer. may be null.
      */
     protected ISelection getSelection(List<Object> input) {
-        if( input.size()>0 )
+        if (input.size() > 0)
             return new StructuredSelection(input.get(0));
         else
             return new StructuredSelection();
     }
+
     /**
-     * Returns true if the selection returned by {@link #getNewSelection(List)} should be shown in the viewer.
+     * Returns true if the selection returned by {@link #getNewSelection(List)} should be shown in
+     * the viewer.
      *
-     * @return true if the selection returned by {@link #getNewSelection(List)} should be shown in the viewer.
+     * @return true if the selection returned by {@link #getNewSelection(List)} should be shown in
+     *         the viewer.
      */
     protected boolean showSelection() {
         return true;
     }
 
-    
     /**
      * Search the catalog for text and update view contents
-     * 
+     *
      * @param pattern
      */
-    public void search( final Object newFilter ) {        
-        if ( newFilter== null) {
-            stopSearch();     
-            //book.showPage( promptPage );
+    public void search(final Object newFilter) {
+        if (newFilter == null) {
+            stopSearch();
+            // book.showPage( promptPage );
             return;
-        }        
+        }
         stopSearch();
-        
-        viewer.setInput( null );
-        filter = newFilter;        
-        searchMonitor=Platform.getJobManager().createProgressGroup();
-        searchMonitor.setTaskName( getPartName());           
-        looking.setPriority( Job.BUILD );
-        looking.setProgressGroup( searchMonitor, IProgressMonitor.UNKNOWN );
-        cancel.setEnabled( true );
-        looking.schedule(); // do it                
+
+        viewer.setInput(null);
+        filter = newFilter;
+        searchMonitor = Job.getJobManager().createProgressGroup();
+        searchMonitor.setTaskName(getPartName());
+        looking.setPriority(Job.BUILD);
+        looking.setProgressGroup(searchMonitor, IProgressMonitor.UNKNOWN);
+        cancel.setEnabled(true);
+        looking.schedule(); // do it
     }
-  
-    protected void searchImplementation( Object filter, IProgressMonitor monitor, ResultSet results ) {
+
+    protected void searchImplementation(Object filter, IProgressMonitor monitor,
+            ResultSet results) {
         // No default action.
-     }
-    
-    /*
-     * (non-Javadoc)
-     * 
-     * @see org.eclipse.ui.part.ISetSelectionTarget#selectReveal(org.eclipse.jface.viewers.ISelection)
-     */
-    public void selectReveal( ISelection selection ) {
-        //viewer.setSelection(selection);
+    }
+
+    @Override
+    public void selectReveal(ISelection selection) {
+        // viewer.setSelection(selection);
     }
 
     @Override
     public void setFocus() {
-        if( viewer != null && viewer.getControl().isVisible() ) {
+        if (viewer != null && viewer.getControl().isVisible()) {
             viewer.getControl().setFocus();
         }
     }
-    
+
     /**
-     * Toggles the orientationof the layout
+     * Toggles the orientation of the layout
      */
     static class ToggleOrientationAction extends Action {
-        private SearchPart view;    
-        private Orientation orientation;        
+        private SearchPart view;
+
+        private Orientation orientation;
+
         public ToggleOrientationAction(SearchPart searchPart, Orientation orientation) {
-            super("", AS_RADIO_BUTTON); //$NON-NLS-1$            
-            Messages.initAction( this, "orientation_"+orientation.toString().toLowerCase() );             //$NON-NLS-1$
+            super("", AS_RADIO_BUTTON); //$NON-NLS-1$
+            Messages.initAction(this, "orientation_" + orientation.toString().toLowerCase()); //$NON-NLS-1$
             view = searchPart;
             this.orientation = orientation;
-            //PlatformUI.getWorkbench().getHelpSystem().setHelp(this, lookup context id? );                    
-        }        
+            // PlatformUI.getWorkbench().getHelpSystem().setHelp(this, lookup context id? );
+        }
+
         public Orientation getOrientation() {
             return orientation;
-        }           
+        }
+
         /*
          * @see Action#actionPerformed
-         */     
+         */
+        @Override
         public void run() {
             if (isChecked()) {
-                view.orientation = orientation; 
+                view.orientation = orientation;
                 view.computeOrientation();
             }
         }
-        
+
     }
+
     /**
      * Set of results collected for display in a SearchPart (such as the info view)
      */
-    public static class ResultSet{
-        SearchPart owner; 
-        List<Object> results=new CopyOnWriteArrayList<Object>();
-        private int changes=0;
-        
-        private ResultSet(SearchPart owner){
-            this.owner=owner;
+    public static class ResultSet {
+        SearchPart owner;
+
+        List<Object> results = new CopyOnWriteArrayList<>();
+
+        private int changes = 0;
+
+        private ResultSet(SearchPart owner) {
+            this.owner = owner;
         }
+
         public boolean firstNotification() {
-            return changes==1;
+            return changes == 1;
         }
-        private void notifyChange(Collection< ? extends Object> changed){
+
+        private void notifyChange(Collection<? extends Object> changed) {
             changes++;
             owner.notifyChange(this, changed);
         }
-        public void add( int arg0, Object arg1 ) {
+
+        public void add(int arg0, Object arg1) {
             results.add(arg0, arg1);
             notifyChange(Collections.singleton(arg1));
         }
-        public boolean add( Object arg0 ) {
+
+        public boolean add(Object arg0) {
             boolean add = results.add(arg0);
             notifyChange(Collections.singleton(arg0));
             return add;
         }
-        public boolean addAll( Collection< ? extends Object> arg0 ) {
+
+        public boolean addAll(Collection<? extends Object> arg0) {
             boolean addAll = results.addAll(arg0);
             notifyChange(arg0);
             return addAll;
         }
-        public boolean addAll( int arg0, Collection< ? extends Object> arg1 ) {
+
+        public boolean addAll(int arg0, Collection<? extends Object> arg1) {
             boolean addAll = results.addAll(arg0, arg1);
             notifyChange(arg1);
             return addAll;
         }
-        public boolean contains( Object arg0 ) {
+
+        public boolean contains(Object arg0) {
             return results.contains(arg0);
         }
-        public boolean containsAll( Collection< ? > arg0 ) {
+
+        public boolean containsAll(Collection<?> arg0) {
             return results.containsAll(arg0);
         }
-        public Object get( int arg0 ) {
+
+        public Object get(int arg0) {
             return results.get(arg0);
         }
-        public int indexOf( Object arg0 ) {
+
+        public int indexOf(Object arg0) {
             return results.indexOf(arg0);
         }
-        
+
     }
 
 }

--- a/plugins/org.locationtech.udig.ui/src/org/locationtech/udig/ui/operations/AbstractPropertyValue.java
+++ b/plugins/org.locationtech.udig.ui/src/org/locationtech/udig/ui/operations/AbstractPropertyValue.java
@@ -1,4 +1,5 @@
-/* uDig - User Friendly Desktop Internet GIS client
+/**
+ * uDig - User Friendly Desktop Internet GIS client
  * http://udig.refractions.net
  * (C) 2004, Refractions Research Inc.
  *
@@ -12,38 +13,36 @@ package org.locationtech.udig.ui.operations;
 import java.util.Set;
 import java.util.concurrent.CopyOnWriteArraySet;
 
-import org.eclipse.core.runtime.IStatus;
-import org.eclipse.core.runtime.Status;
-
 import org.locationtech.udig.internal.ui.UiPlugin;
 
 /**
- * Abstract class that can be used as a superclass for PropertyValue implementations. 
- * 
+ * Abstract class that can be used as a superclass for PropertyValue implementations.
+ *
  * @author Jesse
  * @since 1.1.0
  */
 public abstract class AbstractPropertyValue<T> implements PropertyValue<T> {
-    protected Set<IOpFilterListener> listeners=new CopyOnWriteArraySet<IOpFilterListener>();
-    
-    public void addListener( IOpFilterListener listener ) {
+    protected Set<IOpFilterListener> listeners = new CopyOnWriteArraySet<>();
+
+    @Override
+    public void addListener(IOpFilterListener listener) {
         listeners.add(listener);
     }
 
-
-    public void removeListener( IOpFilterListener listener ) {
+    @Override
+    public void removeListener(IOpFilterListener listener) {
         listeners.add(listener);
     }
-    
+
     /**
      * Notifies listener that the value of the filter has changed.
      */
     public void notifyListeners(Object changed) {
-        for( IOpFilterListener listener : listeners ) {
+        for (IOpFilterListener listener : listeners) {
             try {
                 listener.notifyChange(changed);
             } catch (Exception e) {
-                UiPlugin.trace(UiPlugin.ID, listener.getClass(), e.getMessage(), e );
+                UiPlugin.trace(UiPlugin.ID, listener.getClass(), e.getMessage(), e);
             }
         }
     }

--- a/plugins/org.locationtech.udig.ui/src/org/locationtech/udig/ui/operations/EnablementUtil.java
+++ b/plugins/org.locationtech.udig.ui/src/org/locationtech/udig/ui/operations/EnablementUtil.java
@@ -1,4 +1,5 @@
-/* uDig - User Friendly Desktop Internet GIS client
+/**
+ * uDig - User Friendly Desktop Internet GIS client
  * http://udig.refractions.net
  * (C) 2004, Refractions Research Inc.
  *
@@ -9,83 +10,86 @@
  */
 package org.locationtech.udig.ui.operations;
 
-import org.locationtech.udig.internal.ui.UiPlugin;
-
 import org.eclipse.core.runtime.IConfigurationElement;
+import org.locationtech.udig.internal.ui.UiPlugin;
 
 /**
  * Utility class for parsing enablement children
+ *
  * @author Jesse
  * @since 1.1.0
  */
 public class EnablementUtil {
 
-    public static OpFilter parseEnablement( String extensionID, IConfigurationElement[] enablement ) {
-        
-        if( !validateChildren(extensionID, enablement) || enablement[0]==null ){
-            if( enablement.length>0 && enablement[0]==null )
+    public static OpFilter parseEnablement(String extensionID, IConfigurationElement[] enablement) {
+
+        if (!validateChildren(extensionID, enablement) || enablement[0] == null) {
+            if (enablement.length > 0 && enablement[0] == null)
                 UiPlugin.log("EnablementUtil: null enablement", null); //$NON-NLS-1$
             return OpFilter.TRUE;
         }
-        
+
         IConfigurationElement[] children = enablement[0].getChildren();
-        if ( !validateChildren( extensionID, children) ){
-            UiPlugin.log("EnablementUtil: Expected child of "+extensionID+" but didn't find one...", null); //$NON-NLS-1$ //$NON-NLS-2$
+        if (!validateChildren(extensionID, children)) {
+            UiPlugin.log(
+                    "EnablementUtil: Expected child of " + extensionID + " but didn't find one...", //$NON-NLS-1$ //$NON-NLS-2$
+                    null);
             return OpFilter.TRUE;
         }
-        OpFilterParser parser = new OpFilterParser(new FilterParser[]{
-                new AdaptsToParserImpl(), new PropertyParser()
-        });
+        OpFilterParser parser = new OpFilterParser(
+                new FilterParser[] { new AdaptsToParserImpl(), new PropertyParser() });
         return parser.parseFilter(children[0]);
 
     }
 
-    private static boolean  validateChildren( String extensionID, IConfigurationElement[] children ) {
-        
-        if( children.length<1){
+    private static boolean validateChildren(String extensionID, IConfigurationElement[] children) {
+
+        if (children.length < 1) {
             return false;
         }
-        if( children.length > 1){
-            UiPlugin.log("EnablementUtil: Error, more than one enablement element "+extensionID, null); //$NON-NLS-1$
+        if (children.length > 1) {
+            UiPlugin.log("EnablementUtil: Error, more than one enablement element " + extensionID, //$NON-NLS-1$
+                    null);
             return false;
         }
         return true;
     }
 
-    
-
-    public static EnablesForData parseEnablesFor( String enablesFor, IConfigurationElement configElem ) {
-        if( enablesFor==null ) {
-            enablesFor="1"; //$NON-NLS-1$
+    public static EnablesForData parseEnablesFor(String enablesFor,
+            IConfigurationElement configElem) {
+        if (enablesFor == null) {
+            enablesFor = "1"; //$NON-NLS-1$
         }
-        
-        enablesFor=enablesFor.trim();
-        EnablesForData data=new EnablesForData();
-        if( enablesFor.equals("+") ){ //$NON-NLS-1$
-            data.minHits=1;
-            data.exactMatch=false;
-        } else if( enablesFor.equals("multiple") ){ //$NON-NLS-1$
-            data.minHits=2;
-            data.exactMatch=false;
-        } else if( enablesFor.equals("2+") ){ //$NON-NLS-1$
-            data.minHits=2;
-            data.exactMatch=false;
+
+        enablesFor = enablesFor.trim();
+        EnablesForData data = new EnablesForData();
+        if (enablesFor.equals("+")) { //$NON-NLS-1$
+            data.minHits = 1;
+            data.exactMatch = false;
+        } else if (enablesFor.equals("multiple")) { //$NON-NLS-1$
+            data.minHits = 2;
+            data.exactMatch = false;
+        } else if (enablesFor.equals("2+")) { //$NON-NLS-1$
+            data.minHits = 2;
+            data.exactMatch = false;
         } else {
-            try{
-                data.minHits=Integer.parseInt(enablesFor);
-                data.exactMatch=true;
-            }catch (Exception e) {
-                UiPlugin.log("Error parsing extension: "+configElem.getNamespace()+"/"+configElem.getName(), e);  //$NON-NLS-1$//$NON-NLS-2$
-                data.minHits=0;
-                data.exactMatch=false;
+            try {
+                data.minHits = Integer.parseInt(enablesFor);
+                data.exactMatch = true;
+            } catch (Exception e) {
+                UiPlugin.log("Error parsing extension: " + configElem.getNamespaceIdentifier() + "/" //$NON-NLS-1$//$NON-NLS-2$
+                        + configElem.getName(), e);
+                data.minHits = 0;
+                data.exactMatch = false;
             }
         }
         return data;
     }
-    
-    public static class EnablesForData{
-        int minHits=0;
-        boolean exactMatch=false;
+
+    public static class EnablesForData {
+        int minHits = 0;
+
+        boolean exactMatch = false;
     }
 
 }


### PR DESCRIPTION
This includes deprecations of type:

- `getNamespace()` to `getNamespaceIdentifier()`
- `Platform.run()` to `SafeRunner.run()`
- `Platform.getJobManager()` to `Job.getJobManager()`
- `ILayer.getProperties()` to `ILayer.getBlackboard()`

Additionally I removed unused imports and NLS warnings.