### PR TITLE
Replace deprecated method with newer method instead

### DIFF
--- a/plugins/org.locationtech.udig.feature.editor/src/org/locationtech/udig/feature/editor/field/ListAttributeField.java
+++ b/plugins/org.locationtech.udig.feature.editor/src/org/locationtech/udig/feature/editor/field/ListAttributeField.java
@@ -173,7 +173,7 @@ public abstract class ListAttributeField extends AttributeField {
     private int convertHorizontalDLUsToPixels(Button control, int buttonWidth) {
         GC gc = new GC(control);
         gc.setFont(control.getFont());
-        int averageWidth = (int) Math.round(gc.getFontMetrics().getAverageCharacterWidth());
+        double averageWidth = gc.getFontMetrics().getAverageCharacterWidth();
         gc.dispose();
 
         double horizontalDialogUnitSize = averageWidth * 0.25;

--- a/plugins/org.locationtech.udig.feature.editor/src/org/locationtech/udig/feature/editor/field/ListAttributeField.java
+++ b/plugins/org.locationtech.udig.feature.editor/src/org/locationtech/udig/feature/editor/field/ListAttributeField.java
@@ -1,7 +1,7 @@
-/*
- *    uDig - User Friendly Desktop Internet GIS client
- *    http://udig.refractions.net
- *    (C) 2012, Refractions Research Inc.
+/**
+ * uDig - User Friendly Desktop Internet GIS client
+ * http://udig.refractions.net
+ * (C) 2012, Refractions Research Inc.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -41,20 +41,20 @@ import org.opengis.feature.type.AttributeDescriptor;
  * <li>createList</li>
  * <li>getNewInputObject</li>
  * </p>
+ *
  * @author Jody
  * @since 1.2.0
  * @see ListEditor
  */
 public abstract class ListAttributeField extends AttributeField {
     /**
-     * The list widget; <code>null</code> if none
-     * (before creation or after disposal).
+     * The list widget; <code>null</code> if none (before creation or after disposal).
      */
     private List list;
 
     /**
-     * The button box containing the Add, Remove, Up, and Down buttons;
-     * <code>null</code> if none (before creation or after disposal).
+     * The button box containing the Add, Remove, Up, and Down buttons; <code>null</code> if none
+     * (before creation or after disposal).
      */
     private Composite buttonBox;
 
@@ -84,14 +84,14 @@ public abstract class ListAttributeField extends AttributeField {
     private SelectionListener selectionListener;
 
     /**
-     * Creates a new list field editor 
+     * Creates a new list field editor
      */
     protected ListAttributeField() {
     }
 
     /**
      * Creates a list field editor.
-     * 
+     *
      * @param name the name of the preference this field editor works on
      * @param labelText the label text of the field editor
      * @param parent the parent of the field editor's control
@@ -119,9 +119,7 @@ public abstract class ListAttributeField extends AttributeField {
         }
     }
 
-    /* (non-Javadoc)
-     * Method declared on FieldEditor.
-     */
+    @Override
     public void adjustForNumColumns(int numColumns) {
         Control control = getLabelControl();
         ((GridData) control.getLayoutData()).horizontalSpan = numColumns;
@@ -141,8 +139,8 @@ public abstract class ListAttributeField extends AttributeField {
     }
 
     /**
-     * Combines the given list of items into a single string.
-     * This method is the converse of <code>parseString</code>. 
+     * Combines the given list of items into a single string. This method is the converse of
+     * <code>parseString</code>.
      * <p>
      * Subclasses must implement this method.
      * </p>
@@ -155,7 +153,7 @@ public abstract class ListAttributeField extends AttributeField {
 
     /**
      * Helper method to create a push button.
-     * 
+     *
      * @param parent the parent control
      * @param key the resource name used to supply the button's label text
      * @return Button
@@ -165,19 +163,17 @@ public abstract class ListAttributeField extends AttributeField {
         button.setText(JFaceResources.getString(key));
         button.setFont(parent.getFont());
         GridData data = new GridData(GridData.FILL_HORIZONTAL);
-        int widthHint = convertHorizontalDLUsToPixels(button,
-                IDialogConstants.BUTTON_WIDTH);
-        data.widthHint = Math.max(widthHint, button.computeSize(SWT.DEFAULT,
-                SWT.DEFAULT, true).x);
+        int widthHint = convertHorizontalDLUsToPixels(button, IDialogConstants.BUTTON_WIDTH);
+        data.widthHint = Math.max(widthHint, button.computeSize(SWT.DEFAULT, SWT.DEFAULT, true).x);
         button.setLayoutData(data);
         button.addSelectionListener(getSelectionListener());
         return button;
     }
 
-    private int convertHorizontalDLUsToPixels( Button control, int buttonWidth ) {
+    private int convertHorizontalDLUsToPixels(Button control, int buttonWidth) {
         GC gc = new GC(control);
         gc.setFont(control.getFont());
-        int averageWidth = gc.getFontMetrics().getAverageCharWidth();
+        int averageWidth = (int) Math.round(gc.getFontMetrics().getAverageCharacterWidth());
         gc.dispose();
 
         double horizontalDialogUnitSize = averageWidth * 0.25;
@@ -190,6 +186,7 @@ public abstract class ListAttributeField extends AttributeField {
      */
     public void createSelectionListener() {
         selectionListener = new SelectionAdapter() {
+            @Override
             public void widgetSelected(SelectionEvent event) {
                 Widget widget = event.widget;
                 if (widget == addButton) {
@@ -207,9 +204,7 @@ public abstract class ListAttributeField extends AttributeField {
         };
     }
 
-    /* (non-Javadoc)
-     * Method declared on FieldEditor.
-     */
+    @Override
     protected void doFillIntoGrid(Composite parent, int numColumns) {
         Control control = getLabelControl(parent);
         GridData gd = new GridData();
@@ -229,13 +224,11 @@ public abstract class ListAttributeField extends AttributeField {
         buttonBox.setLayoutData(gd);
     }
 
-    /* (non-Javadoc)
-     * Method declared on FieldEditor.
-     */
+    @Override
     public void doLoad() {
         if (list != null) {
-            Object value = getFeature().getAttribute( getAttributeName() );            
-            String text = Converters.convert(value, String.class );
+            Object value = getFeature().getAttribute(getAttributeName());
+            String text = Converters.convert(value, String.class);
             String[] array = parseString(text);
             for (int i = 0; i < array.length; i++) {
                 list.add(array[i]);
@@ -243,16 +236,14 @@ public abstract class ListAttributeField extends AttributeField {
         }
     }
 
-    /* (non-Javadoc)
-     * Method declared on FieldEditor.
-     */
+    @Override
     protected void doLoadDefault() {
         if (list != null) {
             list.removeAll();
             SimpleFeatureType schema = getFeature().getFeatureType();
-            AttributeDescriptor descriptor = schema.getDescriptor( getAttributeName());            
+            AttributeDescriptor descriptor = schema.getDescriptor(getAttributeName());
             Object value = descriptor.getDefaultValue();
-            String text = Converters.convert(value, String.class );
+            String text = Converters.convert(value, String.class);
             String[] array = parseString(text);
             for (int i = 0; i < array.length; i++) {
                 list.add(array[i]);
@@ -260,13 +251,11 @@ public abstract class ListAttributeField extends AttributeField {
         }
     }
 
-    /* (non-Javadoc)
-     * Method declared on FieldEditor.
-     */
+    @Override
     protected void doStore() {
         String s = createList(list.getItems());
-        if (s != null) {                  
-            getFeature().setAttribute( getAttributeName(), s);
+        if (s != null) {
+            getFeature().setAttribute(getAttributeName(), s);
         }
     }
 
@@ -278,8 +267,7 @@ public abstract class ListAttributeField extends AttributeField {
     }
 
     /**
-     * Returns this field editor's button box containing the Add, Remove,
-     * Up, and Down button.
+     * Returns this field editor's button box containing the Add, Remove, Up, and Down button.
      *
      * @param parent the parent control
      * @return the button box
@@ -292,6 +280,7 @@ public abstract class ListAttributeField extends AttributeField {
             buttonBox.setLayout(layout);
             createButtons(buttonBox);
             buttonBox.addDisposeListener(new DisposeListener() {
+                @Override
                 public void widgetDisposed(DisposeEvent event) {
                     addButton = null;
                     removeButton = null;
@@ -317,11 +306,11 @@ public abstract class ListAttributeField extends AttributeField {
      */
     public List getListControl(Composite parent) {
         if (list == null) {
-            list = new List(parent, SWT.BORDER | SWT.SINGLE | SWT.V_SCROLL
-                    | SWT.H_SCROLL);
+            list = new List(parent, SWT.BORDER | SWT.SINGLE | SWT.V_SCROLL | SWT.H_SCROLL);
             list.setFont(parent.getFont());
             list.addSelectionListener(getSelectionListener());
             list.addDisposeListener(new DisposeListener() {
+                @Override
                 public void widgetDisposed(DisposeEvent event) {
                     list = null;
                 }
@@ -331,10 +320,12 @@ public abstract class ListAttributeField extends AttributeField {
         }
         return list;
     }
-    public List getControl(){
+
+    @Override
+    public List getControl() {
         return list;
     }
-    
+
     /**
      * Creates and returns a new item for the list.
      * <p>
@@ -345,16 +336,13 @@ public abstract class ListAttributeField extends AttributeField {
      */
     protected abstract String getNewInputObject();
 
-    /* (non-Javadoc)
-     * Method declared on FieldEditor.
-     */
+    @Override
     public int getNumberOfControls() {
         return 3;
     }
 
     /**
-     * Returns this field editor's selection listener.
-     * The listener is created if nessessary.
+     * Returns this field editor's selection listener. The listener is created if nessessary.
      *
      * @return the selection listener
      */
@@ -368,8 +356,7 @@ public abstract class ListAttributeField extends AttributeField {
     /**
      * Returns this field editor's shell.
      * <p>
-     * This method is internal to the framework; subclassers should not call
-     * this method.
+     * This method is internal to the framework; subclassers should not call this method.
      * </p>
      *
      * @return the shell
@@ -382,8 +369,8 @@ public abstract class ListAttributeField extends AttributeField {
     }
 
     /**
-     * Splits the given string into a list of strings.
-     * This method is the converse of <code>createList</code>. 
+     * Splits the given string into a list of strings. This method is the converse of
+     * <code>createList</code>.
      * <p>
      * Subclasses must implement this method.
      * </p>
@@ -408,17 +395,16 @@ public abstract class ListAttributeField extends AttributeField {
 
     /**
      * Invoked when the selection in the list has changed.
-     * 
+     *
      * <p>
-     * The default implementation of this method utilizes the selection index
-     * and the size of the list to toggle the enablement of the up, down and
-     * remove buttons.
+     * The default implementation of this method utilizes the selection index and the size of the
+     * list to toggle the enablement of the up, down and remove buttons.
      * </p>
-     * 
+     *
      * <p>
      * Sublcasses may override.
      * </p>
-     * 
+     *
      * @since 3.5
      */
     protected void selectionChanged() {
@@ -431,9 +417,7 @@ public abstract class ListAttributeField extends AttributeField {
         downButton.setEnabled(size > 1 && index >= 0 && index < size - 1);
     }
 
-    /* (non-Javadoc)
-     * Method declared on FieldEditor.
-     */
+    @Override
     public void setFocus() {
         if (list != null) {
             list.setFocus();
@@ -443,8 +427,8 @@ public abstract class ListAttributeField extends AttributeField {
     /**
      * Moves the currently selected item up or down.
      *
-     * @param up <code>true</code> if the item should move up,
-     *  and <code>false</code> if it should move down
+     * @param up <code>true</code> if the item should move up, and <code>false</code> if it should
+     *        move down
      */
     private void swap(boolean up) {
         setPresentsDefaultValue(false);
@@ -471,9 +455,10 @@ public abstract class ListAttributeField extends AttributeField {
     /*
      * @see FieldEditor.setEnabled(boolean,Composite).
      */
+    @Override
     public void setEnabled(boolean enabled) {
         super.setEnabled(enabled);
-        if( list != null && list.isDisposed() ){
+        if (list != null && list.isDisposed()) {
             list.setEnabled(enabled);
             addButton.setEnabled(enabled);
             removeButton.setEnabled(enabled);
@@ -481,10 +466,11 @@ public abstract class ListAttributeField extends AttributeField {
             downButton.setEnabled(enabled);
         }
     }
-    
+
+    @Override
     public void setVisible(boolean visble) {
         super.setVisible(visble);
-        if( list != null && list.isDisposed() ){
+        if (list != null && list.isDisposed()) {
             list.setVisible(visble);
             addButton.setVisible(visble);
             removeButton.setVisible(visble);
@@ -492,50 +478,50 @@ public abstract class ListAttributeField extends AttributeField {
             downButton.setVisible(visble);
         }
     }
-    
+
     /**
-     * Return the Add button.  
-     * 
+     * Return the Add button.
+     *
      * @return the button
      * @since 3.5
      */
     protected Button getAddButton() {
         return addButton;
     }
-    
+
     /**
-     * Return the Remove button.  
-     * 
+     * Return the Remove button.
+     *
      * @return the button
      * @since 3.5
      */
     protected Button getRemoveButton() {
         return removeButton;
     }
-    
+
     /**
-     * Return the Up button.  
-     * 
+     * Return the Up button.
+     *
      * @return the button
      * @since 3.5
      */
     protected Button getUpButton() {
         return upButton;
     }
-    
+
     /**
-     * Return the Down button.  
-     * 
+     * Return the Down button.
+     *
      * @return the button
      * @since 3.5
      */
     protected Button getDownButton() {
         return downButton;
     }
-    
+
     /**
      * Return the List.
-     * 
+     *
      * @return the list
      * @since 3.5
      */

--- a/plugins/org.locationtech.udig.printing.ui/src/org/locationtech/udig/printing/ui/internal/editor/figures/BoxFigure.java
+++ b/plugins/org.locationtech.udig.printing.ui/src/org/locationtech/udig/printing/ui/internal/editor/figures/BoxFigure.java
@@ -1,7 +1,7 @@
-/*
- *    uDig - User Friendly Desktop Internet GIS client
- *    http://udig.refractions.net
- *    (C) 2004, Refractions Research Inc.
+/**
+ * uDig - User Friendly Desktop Internet GIS client
+ * http://udig.refractions.net
+ * (C) 2004, Refractions Research Inc.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -14,11 +14,6 @@ package org.locationtech.udig.printing.ui.internal.editor.figures;
 import java.awt.Graphics2D;
 import java.awt.image.BufferedImage;
 import java.awt.image.RenderedImage;
-
-import org.locationtech.udig.printing.model.Box;
-import org.locationtech.udig.printing.model.PropertyListener;
-import org.locationtech.udig.ui.PlatformGIS;
-import org.locationtech.udig.ui.graphics.AWTSWTImageUtils;
 
 import org.eclipse.core.runtime.IProgressMonitor;
 import org.eclipse.core.runtime.IStatus;
@@ -37,10 +32,13 @@ import org.eclipse.swt.graphics.Color;
 import org.eclipse.swt.graphics.Image;
 import org.eclipse.swt.widgets.Display;
 import org.eclipse.ui.PlatformUI;
+import org.locationtech.udig.printing.model.Box;
+import org.locationtech.udig.ui.PlatformGIS;
+import org.locationtech.udig.ui.graphics.AWTSWTImageUtils;
 
 /**
  * Draws LabelBoxes
- * 
+ *
  * @author Richard Gould
  * @since 0.3
  */
@@ -48,6 +46,7 @@ public class BoxFigure extends Figure {
     private Box box;
 
     private RectangleFigure rectangleFigure;
+
     private Label label;
 
     public BoxFigure() {
@@ -66,84 +65,91 @@ public class BoxFigure extends Figure {
         return this.label.getTextBounds();
     }
 
-    public void setName( String name ) {
+    public void setName(String name) {
         this.label.setText(name);
         this.repaint();
     }
 
-    public void setBox( Box newBox ) {
+    public void setBox(Box newBox) {
         this.box = newBox;
 
         this.repaint();
     }
-    
-    public void setBounds( Rectangle rect ) {
+
+    @Override
+    public void setBounds(Rectangle rect) {
         super.setBounds(rect);
         this.rectangleFigure.setBounds(rect);
         this.label.setBounds(rect);
     }
 
-    protected void paintFigure( Graphics graphics ) {
+    @Override
+    protected void paintFigure(Graphics graphics) {
         super.paintFigure(graphics);
     }
 
     PreviewJob drawJob = new PreviewJob();
 
-    boolean rendering=false;
-    private IJobChangeListener listener = new JobChangeAdapter(){
+    boolean rendering = false;
+
+    private IJobChangeListener listener = new JobChangeAdapter() {
 
         @Override
-        public void scheduled( IJobChangeEvent event ) {
-            rendering=true;
+        public void scheduled(IJobChangeEvent event) {
+            rendering = true;
         }
-        
-        public void done( IJobChangeEvent event ) {
-            rendering=false;
-            if( PlatformUI.getWorkbench().isClosing())
+
+        @Override
+        public void done(IJobChangeEvent event) {
+            rendering = false;
+            if (PlatformUI.getWorkbench().isClosing())
                 return;
-            
-            Display.getDefault().asyncExec(new Runnable(){
+
+            Display.getDefault().asyncExec(new Runnable() {
+                @Override
                 public void run() {
                     repaint();
                 }
             });
         }
     };
-    
 
-    protected void paintClientArea( Graphics graphics ) {
-        if( box.getSize().width<1 || box.getSize().height<1)
+    @Override
+    protected void paintClientArea(Graphics graphics) {
+        if (box.getSize().width < 1 || box.getSize().height < 1)
             return;
-        
+
         drawJob.addJobChangeListener(listener);
         graphics.translate(this.getLocation().x, this.getLocation().y);
-        
-        if(box.getBoxPrinter() == null)
-        	return;
 
-        if ((!box.getBoxPrinter().isNewPreviewNeeded() && drawJob.getCacheImage()!=null)
-                || (drawJob.getDraws()>5 && drawJob.getCacheImage()!=null) ) {
+        if (box.getBoxPrinter() == null)
+            return;
+
+        if ((!box.getBoxPrinter().isNewPreviewNeeded() && drawJob.getCacheImage() != null)
+                || (drawJob.getDraws() > 5 && drawJob.getCacheImage() != null)) {
             drawJob.setDraws(0);
             // on the Draw2D graphics context
-            graphics.drawImage(drawJob.getCacheImage(),0,0);
+            graphics.drawImage(drawJob.getCacheImage(), 0, 0);
         } else {
             // gets the Graphics2D context
-            if( !rendering ){
+            if (!rendering) {
                 drawJob.clearCache();
                 drawJob.setDisplay(Display.getCurrent());
                 drawJob.setBox(box);
                 drawJob.schedule();
             }
-            String message = "Rendering Preview";
+            String message = "Rendering Preview"; //$NON-NLS-1$
             Color color = graphics.getBackgroundColor();
             graphics.setBackgroundColor(Display.getCurrent().getSystemColor(SWT.COLOR_GRAY));
-            graphics.fillRectangle(0,0,box.getSize().width-1, box.getSize().height-1);
+            graphics.fillRectangle(0, 0, box.getSize().width - 1, box.getSize().height - 1);
             graphics.setBackgroundColor(color);
             graphics.setForegroundColor(Display.getCurrent().getSystemColor(SWT.COLOR_BLACK));
-            graphics.drawRectangle(0,0,box.getSize().width-1, box.getSize().height-1);
+            graphics.drawRectangle(0, 0, box.getSize().width - 1, box.getSize().height - 1);
             int fontHeight = graphics.getFontMetrics().getHeight();
-            int fontWidth = graphics.getFontMetrics().getAverageCharWidth()*message.length();
-            graphics.drawText(message, box.getSize().width/2-fontWidth, box.getSize().height/2-fontHeight);
+            int fontWidth = (int) Math.round(graphics.getFontMetrics().getAverageCharacterWidth())
+                    * message.length();
+            graphics.drawText(message, box.getSize().width / 2 - fontWidth,
+                    box.getSize().height / 2 - fontHeight);
         }
 
     }
@@ -151,25 +157,28 @@ public class BoxFigure extends Figure {
     private static class PreviewJob extends Job {
 
         private Box box;
-        private Display display;
-        private Image cacheImage;
-        private int draws=0;
 
-        public synchronized void setBox( Box box ) {
+        private Display display;
+
+        private Image cacheImage;
+
+        private int draws = 0;
+
+        public synchronized void setBox(Box box) {
             this.box = box;
         }
 
         public void clearCache() {
-            if( cacheImage!=null )
+            if (cacheImage != null)
                 cacheImage.dispose();
-            cacheImage=null;
+            cacheImage = null;
         }
 
         PreviewJob() {
-            super("Preview Job");
+            super("Preview Job"); //$NON-NLS-1$
         }
 
-        public synchronized void setDisplay( Display display2 ) {
+        public synchronized void setDisplay(Display display2) {
             this.display = display2;
         }
 
@@ -177,38 +186,39 @@ public class BoxFigure extends Figure {
             return cacheImage;
         }
 
-        
-        
-        protected IStatus run( IProgressMonitor monitor ) {
+        @Override
+        protected IStatus run(IProgressMonitor monitor) {
             int width = box.getSize().width;
             int height = box.getSize().height;
             BufferedImage image = new BufferedImage(width, height, BufferedImage.TYPE_INT_ARGB);
-            
+
             // does the Java 2D painting
             Graphics2D createGraphics = image.createGraphics();
             box.getBoxPrinter().createPreview(createGraphics, monitor);
 
             ImageRunnable runnable = new ImageRunnable();
             runnable.image = image;
-            
-            PlatformGIS.syncInDisplayThread (runnable);
-            
+
+            PlatformGIS.syncInDisplayThread(runnable);
+
             synchronized (this) {
                 this.cacheImage = runnable.swtImage;
                 draws++;
             }
             return Status.OK_STATUS;
         }
-        
+
         private class ImageRunnable implements Runnable {
 
-        	Image swtImage;
-			private RenderedImage image;
-			
-			public void run() {
-				swtImage = AWTSWTImageUtils.createSWTImage(image, true);
-			}
-        	
+            Image swtImage;
+
+            private RenderedImage image;
+
+            @Override
+            public void run() {
+                swtImage = AWTSWTImageUtils.createSWTImage(image, true);
+            }
+
         }
 
         /**
@@ -221,10 +231,10 @@ public class BoxFigure extends Figure {
         /**
          * @param draws The draws to set.
          */
-        public synchronized void setDraws( int draws ) {
+        public synchronized void setDraws(int draws) {
             this.draws = draws;
         }
 
     }
-    
+
 }


### PR DESCRIPTION
This PR will solve the deprecated use of `getAverageCharWidth()`.

Note that I needed to use `Math.round()` because the newer method is returning a `double` instead of an int.

Double to int conversion done like this:
```
(int) Math.round(gc.getFontMetrics().getAverageCharacterWidth())
```