### PR TITLE
[HK] fixed initialization of OraclePlugin

### DIFF
--- a/plugins/org.locationtech.udig.catalog.oracle/src/org/locationtech/udig/catalog/internal/oracle/OraclePlugin.java
+++ b/plugins/org.locationtech.udig.catalog.oracle/src/org/locationtech/udig/catalog/internal/oracle/OraclePlugin.java
@@ -33,7 +33,7 @@ public class OraclePlugin extends AbstractUIPlugin {
     /**
      * The constructor.
      */
-    private OraclePlugin() {
+    public OraclePlugin() {
         super();
         plugin = this;
     }


### PR DESCRIPTION
for stacktrace:
```
Caused by: org.osgi.framework.BundleException: Error loading bundle activator.
	at org.eclipse.osgi.internal.framework.BundleContextImpl.start(BundleContextImpl.java:760)
	at org.eclipse.osgi.internal.framework.EquinoxBundle.startWorker0(EquinoxBundle.java:1005)
	at org.eclipse.osgi.internal.framework.EquinoxBundle$EquinoxModule.startWorker(EquinoxBundle.java:357)
	at org.eclipse.osgi.container.Module.doStart(Module.java:589)
	at org.eclipse.osgi.container.Module.start(Module.java:457)
	at org.eclipse.osgi.framework.util.SecureAction.start(SecureAction.java:471)
	at org.eclipse.osgi.internal.hooks.EclipseLazyStarter.postFindLocalClass(EclipseLazyStarter.java:117)
	... 57 more
Caused by: java.lang.NoSuchMethodException: org.locationtech.udig.catalog.internal.oracle.OraclePlugin.<init>()
	at java.lang.Class.getConstructor0(Class.java:3082)
	at java.lang.Class.getConstructor(Class.java:1825)
	at org.eclipse.osgi.internal.framework.BundleContextImpl.loadBundleActivator(BundleContextImpl.java:799)
	at org.eclipse.osgi.internal.framework.BundleContextImpl.start(BundleContextImpl.java:752)
```

Change-Id: Ia3fbe63331dcb35ca12ff17e132eb609317cdca3
Signed-off-by: Frank Gasdorf <fgdrf@users.sourceforge.net>