### PR TITLE
Possibility to overwrite preferences using .options file

### DIFF
--- a/docs/user/en/tasks/Running uDig.rst
+++ b/docs/user/en/tasks/Running uDig.rst
@@ -82,6 +82,36 @@ You can change the location of your workspace using a command line option:
 
     udig -data <workspace location>
 
+Preferences
+-----------
+
+The uDig application has lots of :doc:`../reference/Preferences` with a sensible default. In case the application should have
+a different setup, its possible to pre-configure application using an ``.options`` file placed in installation folder to overwrite
+defaults.
+
+This requires to start application with arguments (see ``.ini`` file in root installation directory of uDig)
+
+::
+
+    -pluginCustomization
+    .options
+
+.. note::
+   Its required to add it **before** ``-vmargs`` otherwise preferences values are not applied correctly.
+
+where the content of the ``.options`` file looks like this, one line per preferences option:
+
+::
+
+    <plugin-id>/<preferences constant>=<value
+
+Related articles:
+
+-  https://www.eclipse.org/articles/preferences/preferences.htm
+-  https://gnu-mcu-eclipse.github.io/developer/eclipse/runtime-preferences/
+
+
+
 Configuration
 -------------
 

--- a/features/org.locationtech.udig-product/org.locationtech.udig-product.product
+++ b/features/org.locationtech.udig-product/org.locationtech.udig-product.product
@@ -14,8 +14,13 @@
    </configIni>
 
    <launcherArgs>
-      <vmArgs>-Xmx386M -Dosgi.parentClassloader=ext -Dorg.eclipse.emf.ecore.plugin.EcorePlugin.doNotLoadResourcesPlugin=true</vmArgs>
-      <vmArgsMac>-XstartOnFirstThread -Dorg.eclipse.swt.internal.carbon.smallFonts -Djava.awt.headless=true</vmArgsMac>
+      <programArgs>-pluginCustomization
+.options
+      </programArgs>
+      <vmArgs>-Xmx386M -Dosgi.parentClassloader=ext -Dorg.eclipse.emf.ecore.plugin.EcorePlugin.doNotLoadResourcesPlugin=true
+      </vmArgs>
+      <vmArgsMac>-XstartOnFirstThread -Dorg.eclipse.swt.internal.carbon.smallFonts -Djava.awt.headless=true
+      </vmArgsMac>
    </launcherArgs>
 
    <windowImages i16="./icons/icon16.gif" i32="./icons/icon32.gif" i48="./icons/icon48.gif" i64="./icons/icon64.gif" i128="./icons/icon128.gif"/>
@@ -77,9 +82,9 @@ Content and such source code may be obtained at http://github.com/udig .
       <plugin id="org.eclipse.equinox.ds" autoStart="true" startLevel="2" />
       <plugin id="org.eclipse.equinox.p2.reconciler.dropins" autoStart="true" startLevel="5" />
       <plugin id="org.eclipse.equinox.simpleconfigurator" autoStart="true" startLevel="1" />
+      <property name="osgi.instance.area.default" value="$LOCALAPPDATA$/uDig/workspace" os="win32" />
       <property name="osgi.configuration.area.default" value="$LOCALAPPDATA$/uDig/configuration" os="win32" />
       <property name="org.eclipse.update.reconcile" value="false" />
-      <property name="osgi.instance.area.default" value="$LOCALAPPDATA$/uDig/workspace" os="win32" />
    </configurations>
 
 </product>


### PR DESCRIPTION
This feature allows to overwrite preferences by filling .options as show below:

`plugin-id/preference-key=<new value>`

for example:

```org.locationtech.udig.project/HIDE_RENDER_JOB=true```

allows you to hide Render-Jobs shown in Progress-View (default is false).


Change-Id: Ib17c009e8ba0335af0bd9832dfa440c88a37954e
Signed-off-by: Frank Gasdorf <fgdrf@users.sourceforge.net>