### PR TITLE
Remove several deprecated functions

### DIFF
--- a/plugins/org.locationtech.udig.project.tests/src/org/locationtech/udig/project/interceptor/ShowViewInterceptorTest.java
+++ b/plugins/org.locationtech.udig.project.tests/src/org/locationtech/udig/project/interceptor/ShowViewInterceptorTest.java
@@ -43,7 +43,7 @@ import org.opengis.filter.Id;
 
 /**
  * Tests {@link ShowViewInterceptor}
- * 
+ *
  * @author Jesse
  * @since 1.1.0
  */
@@ -64,7 +64,7 @@ public class ShowViewInterceptorTest {
                 CatalogTests.createGeoResource("type2", 3, true)); //$NON-NLS-1$
         map.getLayersInternal().add(layer2);
         featureSource = layer.getResource(SimpleFeatureSource.class,new NullProgressMonitor());
-        f = (SimpleFeature) featureSource.getFeatures().features().next();
+        f = featureSource.getFeatures().features().next();
         FilterFactory filterFactory = CommonFactoryFinder
                 .getFilterFactory(GeoTools.getDefaultHints());
         filter = filterFactory.id(FeatureUtils.stringToId(filterFactory, f
@@ -132,7 +132,7 @@ public class ShowViewInterceptorTest {
         FeatureCollection<SimpleFeatureType, SimpleFeature>  features = assertFilter(layer, 1);
         assertEquals(f, features.features().next());
         assertFilter(layer2, 3);
-        
+
         layer.getStyleBlackboard().clear();
 
         assertFilter(layer, 5);

--- a/plugins/org.locationtech.udig.project.tests/src/org/locationtech/udig/project/internal/LayerInterceptorsTest.java
+++ b/plugins/org.locationtech.udig.project.tests/src/org/locationtech/udig/project/internal/LayerInterceptorsTest.java
@@ -1,7 +1,7 @@
-/*
- *    uDig - User Friendly Desktop Internet GIS client
- *    http://udig.refractions.net
- *    (C) 2012, Refractions Research Inc.
+/**
+ * uDig - User Friendly Desktop Internet GIS client
+ * http://udig.refractions.net
+ * (C) 2012, Refractions Research Inc.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -12,18 +12,18 @@ package org.locationtech.udig.project.internal;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
-import org.locationtech.udig.project.tests.support.MapTests;
 
 import org.junit.Before;
 import org.junit.Test;
+import org.locationtech.udig.project.tests.support.MapTests;
 
 public class LayerInterceptorsTest {
 
     @Before
     public void setUp() throws Exception {
-        TestLayerAddedInterceptor.layerAdded=null;
-        TestLayerRemovedInterceptor.layerRemoved=null;
-        TestLayerCreatedInterceptor.layerCreated=null;
+        TestLayerAddedInterceptor.layerAdded = null;
+        TestLayerRemovedInterceptor.layerRemoved = null;
+        TestLayerCreatedInterceptor.layerCreated = null;
     }
 
     @Test
@@ -31,30 +31,30 @@ public class LayerInterceptorsTest {
         assertNull(TestLayerAddedInterceptor.layerAdded);
         assertNull(TestLayerRemovedInterceptor.layerRemoved);
         assertNull(TestLayerCreatedInterceptor.layerCreated);
-        
-        
-        Map map=MapTests.createDefaultMap("name", 1, true, null); //$NON-NLS-1$
+
+        Map map = MapTests.createDefaultMap("name", 1, true, null); //$NON-NLS-1$
 
         // Layer is wrapped by a TestLayer so the creation interceptor is run on the wrapped object
         // but id should still be the same.
-        assertEquals(map.getMapLayers().get(0).getID(), TestLayerCreatedInterceptor.layerCreated.getID());
+        assertEquals(map.getMapLayers().get(0).getID(),
+                TestLayerCreatedInterceptor.layerCreated.getID());
         assertEquals(map.getMapLayers().get(0), TestLayerAddedInterceptor.layerAdded);
         assertNull(TestLayerRemovedInterceptor.layerRemoved);
-        
-        TestLayerAddedInterceptor.layerAdded=null;
-        TestLayerCreatedInterceptor.layerCreated=null;
-        
+
+        TestLayerAddedInterceptor.layerAdded = null;
+        TestLayerCreatedInterceptor.layerCreated = null;
+
         Layer createLayer = ProjectFactory.eINSTANCE.createLayer();
         map.getLayersInternal().add(createLayer);
-        
+
         assertEquals(createLayer, TestLayerAddedInterceptor.layerAdded);
         assertNull(TestLayerCreatedInterceptor.layerCreated);
         assertNull(TestLayerRemovedInterceptor.layerRemoved);
-        
-        TestLayerAddedInterceptor.layerAdded=null;
-        
+
+        TestLayerAddedInterceptor.layerAdded = null;
+
         map.getLayersInternal().remove(createLayer);
-        
+
         assertEquals(createLayer, TestLayerRemovedInterceptor.layerRemoved);
         assertNull(TestLayerAddedInterceptor.layerAdded);
         assertNull(TestLayerCreatedInterceptor.layerCreated);

--- a/plugins/org.locationtech.udig.project.tests/src/org/locationtech/udig/project/internal/MapInterceptorsTest.java
+++ b/plugins/org.locationtech.udig.project.tests/src/org/locationtech/udig/project/internal/MapInterceptorsTest.java
@@ -1,7 +1,7 @@
-/*
- *    uDig - User Friendly Desktop Internet GIS client
- *    http://udig.refractions.net
- *    (C) 2012, Refractions Research Inc.
+/**
+ * uDig - User Friendly Desktop Internet GIS client
+ * http://udig.refractions.net
+ * (C) 2012, Refractions Research Inc.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -12,44 +12,42 @@ package org.locationtech.udig.project.internal;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
-import org.locationtech.udig.project.tests.support.AbstractProjectTestCase;
-import org.locationtech.udig.project.tests.support.MapTests;
 
 import org.junit.Before;
 import org.junit.Test;
+import org.locationtech.udig.project.tests.support.AbstractProjectTestCase;
+import org.locationtech.udig.project.tests.support.MapTests;
 
 public class MapInterceptorsTest extends AbstractProjectTestCase {
 
     @Before
     public void setUp() throws Exception {
-        TestMapCreationInterceptor.mapCreated=null;
-        TestMapOpeningInterceptor.mapOpening=null;
+        TestMapCreationInterceptor.mapCreated = null;
+        TestMapOpeningInterceptor.mapOpening = null;
     }
-    
+
     @Test
     public void testMapInterceptors() throws Exception {
         assertNull(TestMapCreationInterceptor.mapCreated);
         assertNull(TestMapOpeningInterceptor.mapOpening);
-        
-        Map map=MapTests.createDefaultMap("name", 1, true, null); //$NON-NLS-1$
-        
+
+        Map map = MapTests.createDefaultMap("name", 1, true, null); //$NON-NLS-1$
+
         assertEquals(map, TestMapCreationInterceptor.mapCreated);
         assertNull(TestMapOpeningInterceptor.mapOpening);
-        
-        TestMapCreationInterceptor.mapCreated=null;
-        
+
+        TestMapCreationInterceptor.mapCreated = null;
+
         Layer createLayer = ProjectFactory.eINSTANCE.createLayer();
         map.getLayersInternal().add(createLayer);
-        
+
         assertNull(TestMapCreationInterceptor.mapCreated);
         assertNull(TestMapOpeningInterceptor.mapOpening);
-        
-        
+
         map.getLayersInternal().remove(createLayer);
-        
+
         assertNull(TestMapCreationInterceptor.mapCreated);
         assertNull(TestMapOpeningInterceptor.mapOpening);
-        
 
         assertNull(TestMapCreationInterceptor.mapCreated);
         assertNull(TestMapOpeningInterceptor.mapOpening);

--- a/plugins/org.locationtech.udig.project.tests/src/org/locationtech/udig/project/tests/support/MapTests.java
+++ b/plugins/org.locationtech.udig.project.tests/src/org/locationtech/udig/project/tests/support/MapTests.java
@@ -20,6 +20,7 @@ import java.util.List;
 
 import org.eclipse.core.runtime.NullProgressMonitor;
 import org.geotools.data.FeatureStore;
+import org.geotools.referencing.crs.DefaultGeographicCRS;
 import org.geotools.styling.Style;
 import org.locationtech.jts.geom.Envelope;
 import org.locationtech.udig.catalog.CatalogPlugin;
@@ -55,9 +56,11 @@ public class MapTests {
      * RenderContexts.
      * <p>
      * The viewport model will contain all the features in the resource and will be the same CRS.
+     * </p>
      * <p>
      * map.getRenderExecutor().getRenderContext.getImage() contains the rendered image. (After a
      * refresh is called).
+     * </p>
      *
      * @param resource
      * @param displaySize
@@ -70,7 +73,7 @@ public class MapTests {
     }
 
     /**
-     * Will create a rendermanager
+     * Will create a RenderManager
      *
      * @param resource
      * @param displaySize
@@ -88,6 +91,8 @@ public class MapTests {
         final Map map = ProjectFactory.eINSTANCE.createMap(
                 ProjectPlugin.getPlugin().getProjectRegistry().getDefaultProject(), "testMap", //$NON-NLS-1$
                 new ArrayList<Layer>());
+
+        map.getViewportModelInternal().setCRS(DefaultGeographicCRS.WGS84);
 
         Layer tmp = map.getLayerFactory().createLayer(resource);
         Layer layer = new TestLayer();
@@ -115,7 +120,6 @@ public class MapTests {
                 @Override
                 public void refresh(Envelope bounds) {
                     // do nothing
-
                 }
 
                 @Override
@@ -136,8 +140,6 @@ public class MapTests {
             RenderManager rm = map.getRenderManagerInternal();
             rm.setMapDisplay(new TestMapDisplay(displaySize));
             rm.getRendererCreator().getLayers().add(layer);
-
-            map.getViewportModelInternal().setCRS(layer.getCRS());
 
             final Runnable job = new Runnable() {
                 @Override

--- a/plugins/org.locationtech.udig.project.ui/src/org/locationtech/udig/project/ui/internal/commands/SetLayerCRSCommand.java
+++ b/plugins/org.locationtech.udig.project.ui/src/org/locationtech/udig/project/ui/internal/commands/SetLayerCRSCommand.java
@@ -1,4 +1,5 @@
-/* uDig - User Friendly Desktop Internet GIS client
+/**
+ * uDig - User Friendly Desktop Internet GIS client
  * http://udig.refractions.net
  * (C) 2004, Refractions Research Inc.
  *
@@ -23,51 +24,57 @@ import org.opengis.referencing.crs.CoordinateReferenceSystem;
 
 /**
  * Sets the CRS of the layer
+ *
  * @author Jesse
  * @since 1.1.0
  */
 public class SetLayerCRSCommand extends AbstractCommand implements UndoableMapCommand {
-    public static final String NAME=Messages.SetLayerCRSCommand_name; 
+    public static final String NAME = Messages.SetLayerCRSCommand_name;
 
     private StaticProvider<ILayer> provider;
+
     private Layer layer;
-    private CoordinateReferenceSystem crs,old;
 
-    private ReferencedEnvelope oldBounds=null;
+    private CoordinateReferenceSystem crs, old;
 
-    public SetLayerCRSCommand(ILayer layer, CoordinateReferenceSystem crs){
-        this.provider=new StaticProvider<ILayer>(layer);
-        this.crs=crs;
+    private ReferencedEnvelope oldBounds = null;
+
+    public SetLayerCRSCommand(ILayer layer, CoordinateReferenceSystem crs) {
+        this.provider = new StaticProvider<>(layer);
+        this.crs = crs;
     }
-    
+
+    @Override
     public String getName() {
         return NAME;
     }
 
-    public void run( IProgressMonitor monitor ) throws Exception {
+    @Override
+    public void run(IProgressMonitor monitor) throws Exception {
         monitor.beginTask(NAME, 1);
-        if( layer==null )
-            layer=(Layer) provider.get();
-        old=layer.getCRS(monitor);
+        if (layer == null)
+            layer = (Layer) provider.get();
+        old = layer.getCRS();
         monitor.setTaskName(NAME);
         layer.setCRS(crs);
         ViewportModel viewportModel = layer.getMapInternal().getViewportModelInternal();
-            ReferencedEnvelope bounds = (ReferencedEnvelope) layer.getMapInternal().getViewportModel().getBounds();
-            if( layer.getMapInternal().getMapLayers().size()==1 
-                    && !bounds.intersects( (Envelope) layer.getBounds(monitor, viewportModel.getCRS()))){
-                oldBounds=bounds;
-                
-                viewportModel.zoomToExtent();
-            }
+        ReferencedEnvelope bounds = layer.getMapInternal().getViewportModel().getBounds();
+        if (layer.getMapInternal().getMapLayers().size() == 1 && !bounds
+                .intersects((Envelope) layer.getBounds(monitor, viewportModel.getCRS()))) {
+            oldBounds = bounds;
+
+            viewportModel.zoomToExtent();
+        }
         monitor.done();
     }
 
-    public void rollback( IProgressMonitor monitor ) throws Exception {        
-        String name=Messages.SetLayerCRSCommand_undoTask; 
+    @Override
+    public void rollback(IProgressMonitor monitor) throws Exception {
+        String name = Messages.SetLayerCRSCommand_undoTask;
         monitor.beginTask(name, 1);
-        Layer layer=(Layer) provider.get();
+        Layer layer = (Layer) provider.get();
         layer.setCRS(old);
-        if( oldBounds!=null ){
+        if (oldBounds != null) {
             ViewportModel viewportModel = layer.getMapInternal().getViewportModelInternal();
             viewportModel.setBounds(oldBounds);
         }

--- a/plugins/org.locationtech.udig.project.ui/src/org/locationtech/udig/project/ui/internal/property/pages/LayerInteractionPropertyPage.java
+++ b/plugins/org.locationtech.udig.project.ui/src/org/locationtech/udig/project/ui/internal/property/pages/LayerInteractionPropertyPage.java
@@ -1,4 +1,5 @@
-/* uDig - User Friendly Desktop Internet GIS client
+/**
+ * uDig - User Friendly Desktop Internet GIS client
  * http://udig.refractions.net
  * (C) 2011, Refractions Research Inc.
  *
@@ -30,29 +31,33 @@ import org.opengis.feature.type.GeometryDescriptor;
 
 /**
  * Preference page for controlling Layer interaction with user.
- * 
+ *
  * @author pfeiffp
  */
 public class LayerInteractionPropertyPage extends PropertyPage implements IWorkbenchPropertyPage {
 
     private Button visibleButton;
+
     private Button layerButton;
+
     private Button informationButton;
+
     private Button selectButton;
+
     private Button editButton;
+
     private Button backgroundButton;
+
     private Button aoiButton;
+
     private Layer layer;
+
     private boolean isPolygon = false;
+
     private boolean isRaster = false;
-    
-    /*
-     * (non-Javadoc)
-     * @see
-     * org.eclipse.jface.preference.PreferencePage#createContents(org.eclipse.swt.widgets.Composite)
-     */
+
     @Override
-    protected Control createContents( Composite parent ) {
+    protected Control createContents(Composite parent) {
         layer = (Layer) getElement();
 
         SimpleFeatureType schema = layer.getSchema();
@@ -61,9 +66,9 @@ public class LayerInteractionPropertyPage extends PropertyPage implements IWorkb
         if (schema != null) {
             GeometryDescriptor geomDescriptor = schema.getGeometryDescriptor();
             if (geomDescriptor != null) {
-                Class< ? extends Geometry> binding = (Class< ? extends Geometry>) geomDescriptor
+                Class<? extends Geometry> binding = (Class<? extends Geometry>) geomDescriptor
                         .getType().getBinding();
-                switch( Geometries.getForBinding(binding) ) {
+                switch (Geometries.getForBinding(binding)) {
                 case MULTIPOLYGON:
                 case POLYGON:
                     isPolygon = true;
@@ -101,12 +106,15 @@ public class LayerInteractionPropertyPage extends PropertyPage implements IWorkb
         layerButton.setText(Messages.LayerInteraction_Layer);
         layerButton.setLocation(20, 20);
         layerButton.pack();
-        layerButton.addSelectionListener(new SelectionListener(){
-            public void widgetSelected( SelectionEvent event ) {
+        layerButton.addSelectionListener(new SelectionListener() {
+            @Override
+            public void widgetSelected(SelectionEvent event) {
                 setBackgroundLayer(!layerButton.getSelection());
                 setApplyButton();
             }
-            public void widgetDefaultSelected( SelectionEvent event ) {
+
+            @Override
+            public void widgetDefaultSelected(SelectionEvent event) {
             }
         });
 
@@ -132,12 +140,15 @@ public class LayerInteractionPropertyPage extends PropertyPage implements IWorkb
         backgroundButton.setText(Messages.LayerInteraction_Background);
         backgroundButton.setLocation(20, 100);
         backgroundButton.pack();
-        backgroundButton.addSelectionListener(new SelectionListener(){
-            public void widgetSelected( SelectionEvent event ) {
+        backgroundButton.addSelectionListener(new SelectionListener() {
+            @Override
+            public void widgetSelected(SelectionEvent event) {
                 setBackgroundLayer(backgroundButton.getSelection());
                 setApplyButton();
             }
-            public void widgetDefaultSelected( SelectionEvent event ) {
+
+            @Override
+            public void widgetDefaultSelected(SelectionEvent event) {
             }
         });
 
@@ -150,26 +161,29 @@ public class LayerInteractionPropertyPage extends PropertyPage implements IWorkb
         loadLayer();
         return interactionPage;
     }
-    
-    /*
+
+    /**
      * Returns a new default selection listener to add to buttons
      */
     private SelectionListener defaultSelectionListener() {
-        return new SelectionListener(){
-            public void widgetSelected( SelectionEvent event ) {
+        return new SelectionListener() {
+            @Override
+            public void widgetSelected(SelectionEvent event) {
                 setApplyButton();
             }
-            public void widgetDefaultSelected( SelectionEvent event ) {
+
+            @Override
+            public void widgetDefaultSelected(SelectionEvent event) {
             }
         };
     }
-    
+
     @Override
     public boolean performOk() {
         saveLayer();
         return super.performOk();
     }
-    
+
     @Override
     protected void performApply() {
         saveLayer();
@@ -181,111 +195,109 @@ public class LayerInteractionPropertyPage extends PropertyPage implements IWorkb
         loadLayer();
         super.performDefaults();
     }
-    
+
     /** Update the apply and revert buttons if anything has been modified ... */
-    protected void setApplyButton(){
-        boolean changed = (
-                visibleButton.getSelection() != layer.isVisible()
-                || backgroundButton.getSelection() != layer.getInteraction( Interaction.BACKGROUND )
-                || informationButton.getSelection() != layer.getInteraction( Interaction.INFO )
-                || selectButton.getSelection() != layer.isSelectable()
-                || editButton.getSelection() != layer.getInteraction( Interaction.EDIT )
-                || aoiButton.getSelection() != layer.getInteraction( Interaction.AOI ) 
-        );
-        
+    protected void setApplyButton() {
+        boolean changed = (visibleButton.getSelection() != layer.isVisible()
+                || backgroundButton.getSelection() != layer.getInteraction(Interaction.BACKGROUND)
+                || informationButton.getSelection() != layer.getInteraction(Interaction.INFO)
+                || selectButton.getSelection() != layer.getInteraction(Interaction.SELECT)
+                || editButton.getSelection() != layer.getInteraction(Interaction.EDIT)
+                || aoiButton.getSelection() != layer.getInteraction(Interaction.AOI));
+
         this.getApplyButton().setEnabled(changed);
         this.getDefaultsButton().setEnabled(changed);
     }
-    
-    /*
+
+    /**
      * Saves any changes in interaction values for this layer
      */
     private void saveLayer() {
-        if( visibleButton.getSelection() != layer.isVisible() ){
+        if (visibleButton.getSelection() != layer.isVisible()) {
             layer.setVisible(visibleButton.getSelection());
         }
-        if( backgroundButton.getSelection() != layer.getInteraction( Interaction.BACKGROUND )){
+        if (backgroundButton.getSelection() != layer.getInteraction(Interaction.BACKGROUND)) {
             layer.setInteraction(Interaction.BACKGROUND, backgroundButton.getSelection());
         }
-        if( informationButton.getSelection() != layer.getInteraction( Interaction.INFO )){
+        if (informationButton.getSelection() != layer.getInteraction(Interaction.INFO)) {
             layer.setInteraction(Interaction.INFO, informationButton.getSelection());
         }
-        if( selectButton.getSelection() != layer.isSelectable() ){
-            layer.setSelectable(selectButton.getSelection());
+        if (selectButton.getSelection() != layer.getInteraction(Interaction.SELECT)) {
+            layer.setInteraction(Interaction.SELECT, selectButton.getSelection());
         }
-        if( editButton.getSelection() != layer.getInteraction( Interaction.EDIT )){
+        if (editButton.getSelection() != layer.getInteraction(Interaction.EDIT)) {
             layer.setInteraction(Interaction.EDIT, editButton.getSelection());
         }
-        if( aoiButton.getSelection() != layer.getInteraction( Interaction.AOI )){
+        if (aoiButton.getSelection() != layer.getInteraction(Interaction.AOI)) {
             layer.setInteraction(Interaction.AOI, aoiButton.getSelection());
         }
     }
-    
-    /* Grabs the layer and fills in the current page. */
+
+    /**
+     * Grabs the layer and fills in the current page.
+     */
     private void loadLayer() {
-        
+
         // set values and enable / disable buttons
         visibleButton.setSelection(layer.isVisible());
-        
+
         // set background layer
         boolean isBackgroundLayer = layer.getInteraction(Interaction.BACKGROUND);
-		backgroundButton.setSelection(isBackgroundLayer);
+        backgroundButton.setSelection(isBackgroundLayer);
         layerButton.setSelection(!isBackgroundLayer);
         setBackgroundLayer(isBackgroundLayer);
     }
-    
-    /*
-     * enables button and sets the selection to the value supplied
+
+    /**
+     * Enables button and sets the selection to the value supplied
      */
     private void enableButton(Button button, boolean selection) {
         button.setEnabled(true);
         button.setSelection(selection);
     }
-    
-    /*
-     * disables the button and sets selection to false
+
+    /**
+     * Disables the button and sets selection to false
      */
     private void disableButton(Button button) {
         button.setEnabled(false);
         button.setSelection(false);
     }
-    
-    /*
+
+    /**
      * Sets background layer options based on layer properties
      */
     private void setBackgroundLayer(boolean selection) {
         if (selection) {
             // enable background layer options if applicable
             setPolygonLayer();
-            
+
             // disable non background layer options
             disableButton(informationButton);
             disableButton(selectButton);
             disableButton(editButton);
-        }
-        else {
+        } else {
             // check if raster layer
             setRasterLayer();
-            
+
             // disable background layer options
             disableButton(aoiButton);
         }
     }
 
-    /*
+    /**
      * Sets polygon layer options based on layer properties
      */
     private void setPolygonLayer() {
         aoiButton.setEnabled(isPolygon);
         if (isPolygon) {
             aoiButton.setSelection(layer.getInteraction(Interaction.AOI));
-        }
-        else {
+        } else {
             aoiButton.setSelection(false);
         }
     }
-    
-    /*
+
+    /**
      * Sets raster layer options based on layer properties
      */
     private void setRasterLayer() {
@@ -295,13 +307,12 @@ public class LayerInteractionPropertyPage extends PropertyPage implements IWorkb
             // disable non raster options
             disableButton(selectButton);
             disableButton(editButton);
-        }
-        else {
+        } else {
             enableButton(informationButton, layer.getInteraction(Interaction.INFO));
-            enableButton(selectButton, layer.isSelectable());
+            enableButton(selectButton, layer.getInteraction(Interaction.SELECT));
             enableButton(editButton, layer.getInteraction(Interaction.EDIT));
         }
-        
+
     }
 
 }

--- a/plugins/org.locationtech.udig.project/src/org/locationtech/udig/project/ILayer.java
+++ b/plugins/org.locationtech.udig.project/src/org/locationtech/udig/project/ILayer.java
@@ -337,18 +337,6 @@ public interface ILayer extends ILegendItem, Comparable<ILayer> {
     /**
      * Gets the CRS for the layer. NOTE: THIS METHOD MAY BLOCK!!!
      *
-     * @param monitor may be null.
-     * @return the CoordinateReferenceSystem of the layer or if the CRS cannot be determined. the
-     *         current map's CRS will be returned, or if this fails the CRS will be WGS84.
-     *
-     * @deprecated use getCRS()
-     */
-    @Deprecated
-    CoordinateReferenceSystem getCRS(IProgressMonitor monitor);
-
-    /**
-     * Gets the CRS for the layer. NOTE: THIS METHOD MAY BLOCK!!!
-     *
      * @return the CoordinateReferenceSystem of the layer or if the CRS cannot be determined. the
      *         current map's CRS will be returned, or if this fails the CRS will be WGS84.
      */

--- a/plugins/org.locationtech.udig.project/src/org/locationtech/udig/project/internal/Layer.java
+++ b/plugins/org.locationtech.udig.project/src/org/locationtech/udig/project/internal/Layer.java
@@ -1,4 +1,5 @@
-/* uDig - User Friendly Desktop Internet GIS client
+/**
+ * uDig - User Friendly Desktop Internet GIS client
  * http://udig.refractions.net
  * (C) 2004-2012, Refractions Research Inc.
  *
@@ -16,7 +17,6 @@ import java.util.Map;
 import java.util.Set;
 
 import org.eclipse.core.runtime.IAdaptable;
-import org.eclipse.core.runtime.IProgressMonitor;
 import org.eclipse.emf.ecore.EObject;
 import org.eclipse.jface.resource.ImageDescriptor;
 import org.geotools.data.FeatureEvent;
@@ -66,8 +66,8 @@ public interface Layer
     /**
      * Filter indicating the selected features.
      * <p>
-     * In order for this value to be useful the layer should be selectable, often a single fid
-     * filter during user edit opperations.
+     * In order for this value to be useful the layer should be selectable, often a single FID
+     * filter during user edit operations.
      * </p>
      * <p>
      * Note: Filter.EXCLUDE indicates no selected Features. (All features are filtered out)
@@ -232,39 +232,6 @@ public interface Layer
     public void setInteraction(Interaction interaction, boolean isApplicable);
 
     /**
-     * Indicates this layer is capable of selectable.
-     * <p>
-     * A Selectable Layer can be used with the Utilities.getQuery opperation. The selection tool
-     * category will maintain a separate user interface concept of applicability. The selection tool
-     * will not be capabile of considering a non selectable layer applicable.
-     * </p>
-     * IMPORTANT FUTURE CHANGE NOTE: future design: Instead of isSelectable and isInfoable a single
-     * boolean isApplicable( String toolkitID ) will be used to determine whether the layer is
-     * applicable to the current tool cateogry. If the layer is not capable of Each tool category
-     * extension will declare a color, which will be an underlay for the layer decorator, and an
-     * optional validator class, to determine whether the capability for the layer can be set.
-     * Indicates this layer is selectable.
-     *
-     * @return <code>true</code> if layer is selectable, <code>false</code> otherwise.
-     * @deprecated use getInteraction(Interaction.SELECT)
-     */
-    @Deprecated
-    public boolean isSelectable();
-
-    /**
-     * Sets the value of the '{@link org.locationtech.udig.project.internal.Layer#isSelectable
-     * <em>Selectable</em>}' attribute. <!-- begin-user-doc --> Used by the user to control which
-     * layers are selectable, may be ignored for GeoResources that do not support editing. <!--
-     * end-user-doc -->
-     *
-     * @param value the new value of the '<em>Selectable</em>' attribute.
-     * @see #isSelectable()
-     * @deprecated use setInteraction(Interaction.SELECT, value)
-     */
-    @Deprecated
-    void setSelectable(boolean value);
-
-    /**
      * Gets the name from the associated metadata.
      *
      * @return the name from the associated metadata
@@ -295,7 +262,7 @@ public interface Layer
      * Sets the value of the '{@link org.locationtech.udig.project.internal.Layer#getCatalogRef
      * <em>Catalog Ref</em>}' attribute. <!-- begin-user-doc --> <!-- end-user-doc -->
      *
-     * @param value the new value of the '<em>Catalog Ref</em>' attribute.
+     * @param value the new value of the '<em>CatalogRef</em>' attribute.
      * @see #getCatalogRef()
      * @generated
      */
@@ -351,9 +318,9 @@ public interface Layer
 
     /**
      * Sets the value of the '{@link org.locationtech.udig.project.internal.Layer#getGeoResource
-     * <em>Geo Resource</em>}' attribute. <!-- begin-user-doc --> <!-- end-user-doc -->
+     * <em>GeoResource</em>}' attribute. <!-- begin-user-doc --> <!-- end-user-doc -->
      *
-     * @param value the new value of the '<em>Geo Resource</em>' attribute.
+     * @param value the new value of the '<em>GeoResource</em>' attribute.
      * @see #getGeoResource()
      * @generated
      */
@@ -372,7 +339,7 @@ public interface Layer
     /**
      * ImageDescriptor for this Layer.
      * <p>
-     * Note we need to do the decorator exention on Layer to reflect status.
+     * Note we need to do the decorator extention on Layer to reflect status.
      *
      * @return Custom glyph - or null if none available.
      * @uml.property name="glyph"
@@ -411,17 +378,6 @@ public interface Layer
     public Query getQuery(boolean selection);
 
     /**
-     * Gets the CRS for the layer. NOTE: THIS METHOD MAY BLOCK!!!
-     *
-     * @param monitor may be null.
-     * @return the CoordinateReferenceSystem of the layer or if the CRS cannot be determined. the
-     *         current map's CRS will be returned, or if this fails the CRS will be WGS84.
-     * @model
-     */
-    @Override
-    CoordinateReferenceSystem getCRS(IProgressMonitor monitor);
-
-    /**
      * A convenience method for getCRS(null). Logs any exceptions with the Plugin log.
      * <p>
      * This method also allows the CRS to be viewed as an attribute by EMF so ui components and
@@ -447,7 +403,7 @@ public interface Layer
     /**
      * Temporary layer properties, used for lightweight collaboration.
      * <p>
-     * Note these values are not persisted, this can act as a blackboard for plugin collabaration.
+     * Note these values are not persisted, this can act as a blackboard for plugin collaboration.
      * These properties are not saved and are reset when a map is opened.
      * </p>
      * If you need long term collaboration we can set up a persistent blackboard in the same manner

--- a/plugins/org.locationtech.udig.project/src/org/locationtech/udig/project/internal/LayerDecorator.java
+++ b/plugins/org.locationtech.udig.project/src/org/locationtech/udig/project/internal/LayerDecorator.java
@@ -93,10 +93,6 @@ public class LayerDecorator implements Layer, InternalEObject {
         this.interalObject = (InternalEObject) layer;
     }
 
-    /*
-     * @see
-     * org.locationtech.udig.project.Layer#addListener(org.locationtech.udig.project.LayerListener)
-     */
     @Override
     public synchronized void addListener(final ILayerListener listener) {
         if (listeners == null) {
@@ -106,10 +102,6 @@ public class LayerDecorator implements Layer, InternalEObject {
         listeners.add(listener);
     }
 
-    /*
-     * @see org.locationtech.udig.project.Layer#removeListener(org.locationtech.udig.project.
-     * LayerListener)
-     */
     @Override
     public synchronized void removeListener(final ILayerListener listener) {
         listeners.remove(listener);
@@ -121,7 +113,7 @@ public class LayerDecorator implements Layer, InternalEObject {
 
     protected synchronized void fireLayerChange(LayerEvent event) {
         if (listeners.size() == 0) {
-            return; // nobody is listenting
+            return; // nobody is listening
         }
         for (ILayerListener listener : listeners) {
             try {
@@ -132,631 +124,353 @@ public class LayerDecorator implements Layer, InternalEObject {
         }
     }
 
-    /*
-     * @see org.locationtech.udig.project.Layer#properties()
-     */
     @Override
     public IBlackboard getProperties() {
         return layer.getProperties();
     }
 
-    /*
-     * @see org.locationtech.udig.project.Layer#getContextModel()
-     */
     @Override
     public ContextModel getContextModel() {
         return layer.getContextModel();
     }
 
-    /*
-     * @see org.locationtech.udig.project.Layer#setContextModel(org.locationtech.udig.project.
-     * ContextModel)
-     */
     @Override
     public void setContextModel(ContextModel value) {
         layer.setContextModel(value);
     }
 
-    /*
-     * @see org.locationtech.udig.project.Layer#getFilter()
-     */
     @Override
     public Filter getFilter() {
         return layer.getFilter();
     }
 
-    /*
-     * @see org.locationtech.udig.project.Layer#setFilter(org.opengis.filter.Filter)
-     */
     @Override
     public void setFilter(Filter value) {
         layer.setFilter(value);
     }
 
-    /*
-     * @see org.locationtech.udig.project.Layer#getStyleBlackboard()
-     */
     @Override
     public StyleBlackboard getStyleBlackboard() {
         return layer.getStyleBlackboard();
     }
 
-    /*
-     * @see org.locationtech.udig.project.Layer#setStyleBlackboard(org.locationtech.udig.project.
-     * StyleBlackboard)
-     */
     @Override
     public void setStyleBlackboard(StyleBlackboard value) {
         layer.setStyleBlackboard(value);
     }
 
-    /*
-     * @see org.locationtech.udig.project.Layer#getZorder()
-     */
     @Override
     public int getZorder() {
         return layer.getZorder();
     }
 
-    /*
-     * @see org.locationtech.udig.project.Layer#setZorder(int)
-     */
     @Override
     public void setZorder(int value) {
         layer.setZorder(value);
     }
 
-    /*
-     * @see org.locationtech.udig.project.Layer#getStatus()
-     */
     @Override
     public int getStatus() {
         return layer.getStatus();
     }
 
-    /*
-     * @see org.locationtech.udig.project.Layer#setStatus(int)
-     */
     @Override
     public void setStatus(int value) {
         layer.setStatus(value);
     }
 
-    /*
-     * @see org.locationtech.udig.project.Layer#isApplicable(java.lang.String)
-     */
     @Override
     public boolean getInteraction(Interaction interaction) {
         return layer.getInteraction(interaction);
     }
 
-    /*
-     * @see org.locationtech.udig.project.Layer#setApplicable(java.lang.String, boolean)
-     */
     @Override
     public void setInteraction(Interaction interaction, boolean isApplicable) {
         layer.setInteraction(interaction, isApplicable);
     }
 
-    /*
-     * @see org.locationtech.udig.project.Layer#isSelectable()
-     */
-    @Override
-    public boolean isSelectable() {
-        return layer.isSelectable();
-    }
-
-    /*
-     * @see org.locationtech.udig.project.Layer#setSelectable(boolean)
-     */
-    @Override
-    public void setSelectable(boolean value) {
-        layer.setSelectable(value);
-    }
-
-    /*
-     * @see org.locationtech.udig.project.Layer#getName()
-     */
     @Override
     public String getName() {
         return layer.getName();
     }
 
-    /*
-     * @see org.locationtech.udig.project.Layer#setName(java.lang.String)
-     */
     @Override
     public void setName(String value) {
         layer.setName(value);
     }
 
-    /*
-     * @see org.locationtech.udig.project.Layer#getCatalogRef()
-     */
     @Override
     public CatalogRef getCatalogRef() {
         return layer.getCatalogRef();
     }
 
-    /*
-     * @see
-     * org.locationtech.udig.project.Layer#setCatalogRef(org.locationtech.udig.project.LayerRef)
-     */
     @Override
     public void setCatalogRef(CatalogRef value) {
         layer.setCatalogRef(value);
     }
 
-    /*
-     * @see org.locationtech.udig.project.Layer#getID()
-     */
     @Override
     public URL getID() {
         return layer.getID();
     }
 
-    /*
-     * @see org.locationtech.udig.project.Layer#setID(java.net.URL)
-     */
     @Override
     public void setID(URL value) {
         layer.setID(value);
     }
 
-    /*
-     * @see org.locationtech.udig.project.Layer#isVisible()
-     */
     @Override
     public boolean isVisible() {
         return layer.isVisible();
     }
 
-    /*
-     * @see org.locationtech.udig.project.Layer#setVisible(boolean)
-     */
     @Override
     public void setVisible(boolean value) {
         layer.setVisible(value);
     }
 
-    /*
-     * @see org.locationtech.udig.project.Layer#getGeoResources()
-     */
     @Override
     public List<IGeoResource> getGeoResources() {
         return layer.getGeoResources();
     }
 
-    /*
-     * @see org.locationtech.udig.project.Layer#getGlyph()
-     */
     @Override
     public ImageDescriptor getIcon() {
         return layer.getIcon();
     }
 
-    /*
-     * @see org.locationtech.udig.project.Layer#setGlyph(org.eclipse.jface.resource.ImageDescriptor)
-     */
     @Override
     public void setIcon(ImageDescriptor value) {
         layer.setIcon(value);
     }
 
-    /*
-     * @see org.locationtech.udig.project.Layer#getQuery(boolean)
-     */
     @Override
     public Query getQuery(boolean selection) {
         return layer.getQuery(selection);
     }
 
-    /*
-     * @see org.locationtech.udig.project.Layer#getSchema()
-     */
     @Override
     public SimpleFeatureType getSchema() {
         return layer.getSchema();
     }
 
-    /*
-     * @see org.locationtech.udig.project.Layer#getCRS(org.eclipse.core.runtime.IProgressMonitor)
-     */
-    @Override
-    public CoordinateReferenceSystem getCRS(IProgressMonitor monitor) {
-        return layer.getCRS();
-    }
-
-    /*
-     * @see org.locationtech.udig.project.Layer#getCRS()
-     */
     @Override
     public CoordinateReferenceSystem getCRS() {
         return layer.getCRS();
     }
 
-    /*
-     * @see org.locationtech.udig.project.Layer#setCRS(org.opengis.referencing.crs.
-     * CoordinateReferenceSystem)
-     */
     @Override
     public void setCRS(CoordinateReferenceSystem value) {
         layer.setCRS(value);
     }
 
-    /*
-     * @see org.locationtech.udig.project.Layer#refresh(org.locationtech.jts.geom.Envelope)
-     */
     @Override
     public void refresh(Envelope bounds) {
         layer.refresh(bounds);
     }
 
-    /*
-     * @see org.locationtech.udig.project.Layer#getMathTransform()
-     */
     @Override
     public MathTransform layerToMapTransform() throws IOException {
         return layer.layerToMapTransform();
     }
 
-    /*
-     * @see org.locationtech.udig.project.Layer#getBounds(org.eclipse.core.runtime.IProgressMonitor,
-     * org.opengis.referencing.crs.CoordinateReferenceSystem)
-     */
     @Override
     public ReferencedEnvelope getBounds(IProgressMonitor monitor, CoordinateReferenceSystem crs) {
         return layer.getBounds(monitor, crs);
     }
 
-    /*
-     * @see org.locationtech.udig.project.Layer#createBBoxFilter(org.locationtech.jts.geom.Envelope)
-     */
     @Override
     public Filter createBBoxFilter(Envelope boundingBox, IProgressMonitor monitor) {
         return layer.createBBoxFilter(boundingBox, monitor);
     }
 
-    /*
-     * @see org.eclipse.emf.ecore.EObject#eClass()
-     */
     @Override
     public EClass eClass() {
         return layer.eClass();
     }
 
-    /*
-     * @see org.eclipse.emf.ecore.EObject#eResource()
-     */
     @Override
     public Resource eResource() {
         return layer.eResource();
     }
 
-    /*
-     * @see org.eclipse.emf.ecore.EObject#eContainer()
-     */
     @Override
     public EObject eContainer() {
         return layer.eContainer();
     }
 
-    /*
-     * @see org.eclipse.emf.ecore.EObject#eContainingFeature()
-     */
     @Override
     public EStructuralFeature eContainingFeature() {
         return layer.eContainingFeature();
     }
 
-    /*
-     * @see org.eclipse.emf.ecore.EObject#eContainmentFeature()
-     */
     @Override
     public EReference eContainmentFeature() {
         return layer.eContainmentFeature();
     }
 
-    /*
-     * @see org.eclipse.emf.ecore.EObject#eContents()
-     */
     @Override
     public EList eContents() {
         return layer.eContents();
     }
 
-    /*
-     * @see org.eclipse.emf.ecore.EObject#eAllContents()
-     */
     @Override
     public TreeIterator eAllContents() {
         return layer.eAllContents();
     }
 
-    /*
-     * @see org.eclipse.emf.ecore.EObject#eIsProxy()
-     */
     @Override
     public boolean eIsProxy() {
         return layer.eIsProxy();
     }
 
-    /*
-     * @see org.eclipse.emf.ecore.EObject#eCrossReferences()
-     */
     @Override
     public EList eCrossReferences() {
         return layer.eCrossReferences();
     }
 
-    /*
-     * @see org.eclipse.emf.ecore.EObject#eGet(org.eclipse.emf.ecore.EStructuralFeature)
-     */
     @Override
     public Object eGet(EStructuralFeature feature) {
         return layer.eGet(feature);
     }
 
-    /*
-     * @see org.eclipse.emf.ecore.EObject#eGet(org.eclipse.emf.ecore.EStructuralFeature, boolean)
-     */
     @Override
     public Object eGet(EStructuralFeature feature, boolean resolve) {
         return layer.eGet(feature, resolve);
     }
 
-    /*
-     * @see org.eclipse.emf.ecore.EObject#eSet(org.eclipse.emf.ecore.EStructuralFeature,
-     * java.lang.Object)
-     */
     @Override
     public void eSet(EStructuralFeature feature, Object newValue) {
         layer.eSet(feature, newValue);
     }
 
-    /*
-     * @see org.eclipse.emf.ecore.EObject#eIsSet(org.eclipse.emf.ecore.EStructuralFeature)
-     */
     @Override
     public boolean eIsSet(EStructuralFeature feature) {
         return layer.eIsSet(feature);
     }
 
-    /*
-     * @see org.eclipse.emf.ecore.EObject#eUnset(org.eclipse.emf.ecore.EStructuralFeature)
-     */
     @Override
     public void eUnset(EStructuralFeature feature) {
         layer.eUnset(feature);
     }
 
-    /*
-     * @see org.eclipse.emf.common.notify.Notifier#eAdapters()
-     */
     @Override
     public EList eAdapters() {
         return layer.eAdapters();
     }
 
-    /*
-     * @see org.eclipse.emf.common.notify.Notifier#eDeliver()
-     */
     @Override
     public boolean eDeliver() {
         return layer.eDeliver();
     }
 
-    /*
-     * @see org.eclipse.emf.common.notify.Notifier#eSetDeliver(boolean)
-     */
     @Override
     public void eSetDeliver(boolean deliver) {
         layer.eSetDeliver(deliver);
     }
 
-    /*
-     * @see
-     * org.eclipse.emf.common.notify.Notifier#eNotify(org.eclipse.emf.common.notify.Notification)
-     */
     @Override
     public void eNotify(Notification notification) {
         layer.eNotify(notification);
     }
 
-    /*
-     * @see java.lang.Comparable#compareTo(java.lang.Object)
-     */
     @Override
     public int compareTo(ILayer other) {
         return layer.compareTo(other);
     }
 
-    /**
-     * @see org.locationtech.udig.project.internal.Layer#getMap()
-     */
     @Override
     public Map getMapInternal() {
         return layer.getMapInternal();
     }
 
-    /**
-     * @see org.eclipse.emf.ecore.InternalEObject#eNotificationRequired()
-     */
     @Override
     public boolean eNotificationRequired() {
         return interalObject.eNotificationRequired();
     }
 
-    /**
-     * @see org.eclipse.emf.ecore.InternalEObject#eURIFragmentSegment(org.eclipse.emf.ecore.EStructuralFeature,
-     *      org.eclipse.emf.ecore.EObject)
-     */
     @Override
     public String eURIFragmentSegment(EStructuralFeature eFeature, EObject eObject) {
         return interalObject.eURIFragmentSegment(eFeature, eObject);
     }
 
-    /**
-     * @see org.eclipse.emf.ecore.InternalEObject#eObjectForURIFragmentSegment(java.lang.String)
-     */
     @Override
     public EObject eObjectForURIFragmentSegment(String uriFragmentSegment) {
         return interalObject.eObjectForURIFragmentSegment(uriFragmentSegment);
     }
 
-    /**
-     * @see org.eclipse.emf.ecore.InternalEObject#eSetClass(org.eclipse.emf.ecore.EClass)
-     */
     @Override
     public void eSetClass(EClass eClass) {
         interalObject.eSetClass(eClass);
     }
 
-    /**
-     * @see org.eclipse.emf.ecore.InternalEObject#eSetting(org.eclipse.emf.ecore.EStructuralFeature)
-     */
     @Override
     public Setting eSetting(EStructuralFeature feature) {
         return interalObject.eSetting(feature);
     }
 
-    /**
-     * @see org.eclipse.emf.ecore.InternalEObject#eBaseStructuralFeatureID(int, java.lang.Class)
-     */
-    // public int eBaseStructuralFeatureID( int derivedFeatureID, Class baseClass ) {
-    // return interalObject.eBaseStructuralFeatureID(derivedFeatureID, baseClass);
-    // }
-
-    /**
-     * @see org.eclipse.emf.ecore.InternalEObject#eContainerFeatureID()
-     */
     @Override
     public int eContainerFeatureID() {
         return interalObject.eContainerFeatureID();
     }
 
-    /**
-     * @see org.eclipse.emf.ecore.InternalEObject#eDerivedStructuralFeatureID(int, java.lang.Class)
-     */
-    // public int eDerivedStructuralFeatureID( int baseFeatureID, Class baseClass ) {
-    // return interalObject.eDerivedStructuralFeatureID(baseFeatureID, baseClass);
-    // }
-
-    /**
-     * @see org.eclipse.emf.ecore.InternalEObject#eSetResource(org.eclipse.emf.ecore.resource.Resource.Internal,
-     *      org.eclipse.emf.common.notify.NotificationChain)
-     */
     @Override
     public NotificationChain eSetResource(Internal resource, NotificationChain notifications) {
         return interalObject.eSetResource(resource, notifications);
     }
 
-    /**
-     * @see org.eclipse.emf.ecore.InternalEObject#eInverseAdd(org.eclipse.emf.ecore.InternalEObject,
-     *      int, java.lang.Class, org.eclipse.emf.common.notify.NotificationChain)
-     */
-    // public NotificationChain eInverseAdd( InternalEObject otherEnd, int featureID, Class
-    // baseClass,
-    // NotificationChain notifications ) {
-    // return interalObject.eInverseAdd(otherEnd, featureID, baseClass, notifications);
-    // }
-
-    /**
-     * @see org.eclipse.emf.ecore.InternalEObject#eInverseRemove(org.eclipse.emf.ecore.InternalEObject,
-     *      int, java.lang.Class, org.eclipse.emf.common.notify.NotificationChain)
-     */
-    // public NotificationChain eInverseRemove( InternalEObject otherEnd, int featureID,
-    // Class baseClass, NotificationChain notifications ) {
-    // return interalObject.eInverseRemove(otherEnd, featureID, baseClass, notifications);
-    // }
-
-    /**
-     * @see org.eclipse.emf.ecore.InternalEObject#eBasicSetContainer(org.eclipse.emf.ecore.InternalEObject,
-     *      int, org.eclipse.emf.common.notify.NotificationChain)
-     */
     @Override
     public NotificationChain eBasicSetContainer(InternalEObject newContainer,
             int newContainerFeatureID, NotificationChain notifications) {
         return interalObject.eBasicSetContainer(newContainer, newContainerFeatureID, notifications);
     }
 
-    /**
-     * @see org.eclipse.emf.ecore.InternalEObject#eBasicRemoveFromContainer(org.eclipse.emf.common.notify.NotificationChain)
-     */
     @Override
     public NotificationChain eBasicRemoveFromContainer(NotificationChain notifications) {
         return interalObject.eBasicRemoveFromContainer(notifications);
     }
 
-    /**
-     * @see org.eclipse.emf.ecore.InternalEObject#eProxyURI()
-     */
     @Override
     public URI eProxyURI() {
         return interalObject.eProxyURI();
     }
 
-    /**
-     * @see org.eclipse.emf.ecore.InternalEObject#eSetProxyURI(org.eclipse.emf.common.util.URI)
-     */
     @Override
     public void eSetProxyURI(URI uri) {
         interalObject.eSetProxyURI(uri);
     }
 
-    /**
-     * @see org.eclipse.emf.ecore.InternalEObject#eResolveProxy(org.eclipse.emf.ecore.InternalEObject)
-     */
     @Override
     public EObject eResolveProxy(InternalEObject proxy) {
         return interalObject.eResolveProxy(proxy);
     }
 
-    /**
-     * @see org.eclipse.emf.ecore.InternalEObject#eInternalResource()
-     */
     @Override
     public Internal eInternalResource() {
         return interalObject.eInternalResource();
     }
 
-    /**
-     * @see org.eclipse.emf.ecore.InternalEObject#eStore()
-     */
     @Override
     public EStore eStore() {
         return interalObject.eStore();
     }
 
-    /**
-     * @see org.eclipse.emf.ecore.InternalEObject#eSetStore(org.eclipse.emf.ecore.InternalEObject.EStore)
-     */
     @Override
     public void eSetStore(EStore store) {
         interalObject.eSetStore(store);
     }
 
-    /**
-     * @see org.locationtech.udig.project.ILayer#getGeoResource()
-     */
     @Override
     public IGeoResource getGeoResource() {
         return layer.getGeoResource();
     }
 
-    /**
-     * @see org.locationtech.udig.project.internal.Layer#setGeoResource(org.locationtech.udig.catalog.IGeoResource)
-     * @deprecated
-     */
     @Deprecated
     @Override
     public void setGeoResource(IGeoResource value) {
         layer.setGeoResource(value);
     }
 
-    /**
-     * @see org.locationtech.udig.project.ILayer#getGeoResource(java.lang.Class)
-     */
     @Override
     public <E> E getResource(Class<E> resourceType, IProgressMonitor monitor) throws IOException {
         return layer.getResource(resourceType, monitor);
@@ -771,90 +485,56 @@ public class LayerDecorator implements Layer, InternalEObject {
         return layer;
     }
 
-    /**
-     * @see org.locationtech.udig.project.ILayer#getMap()
-     */
     @Override
     public IMap getMap() {
         return layer.getMap();
     }
 
-    /**
-     * @see org.eclipse.core.runtime.IAdaptable#getAdapter(java.lang.Class)
-     */
     @Override
     public Object getAdapter(Class adapter) {
         return layer.getAdapter(adapter);
     }
 
-    /**
-     * @see org.locationtech.udig.core.IBlockingAdaptable#getAdapter(java.lang.Class,
-     *      org.eclipse.core.runtime.IProgressMonitor)
-     */
     @Override
     public <T> T getAdapter(Class<T> adapter, IProgressMonitor monitor) throws IOException {
         return layer.getAdapter(adapter, monitor);
     }
 
-    /**
-     * @see org.locationtech.udig.core.IBlockingAdaptable#canAdaptTo(java.lang.Class)
-     */
     @Override
     public <T> boolean canAdaptTo(Class<T> adapter) {
         return layer.canAdaptTo(adapter);
     }
 
-    /**
-     * @see org.locationtech.udig.project.internal.Layer#getColourScheme()
-     */
     @Override
     public ColourScheme getColourScheme() {
         return layer.getColourScheme();
     }
 
-    /**
-     * @see org.locationtech.udig.project.internal.Layer#setColourScheme(org.locationtech.udig.ui.palette.ColourScheme)
-     */
     @Override
     public void setColourScheme(ColourScheme value) {
         layer.setColourScheme(value);
     }
 
-    /**
-     * @see org.locationtech.udig.project.internal.Layer#getDefaultColor()
-     */
     @Override
     public Color getDefaultColor() {
         return layer.getDefaultColor();
     }
 
-    /**
-     * @see org.locationtech.udig.project.internal.Layer#setDefaultColor(java.awt.Color)
-     */
     @Override
     public void setDefaultColor(Color value) {
         layer.setDefaultColor(value);
     }
 
-    /**
-     * @see org.locationtech.udig.project.ILayer#mapToLayerTransform()
-     */
     @Override
     public MathTransform mapToLayerTransform() throws IOException {
         return layer.mapToLayerTransform();
     }
 
-    /**
-     * @see org.locationtech.udig.project.internal.Layer#setStatusMessage(java.lang.String)
-     */
     @Override
     public void setStatusMessage(String message) {
         layer.setStatusMessage(message);
     }
 
-    /**
-     * @see org.locationtech.udig.project.ILayer#getStatusMessage()
-     */
     @Override
     public String getStatusMessage() {
         return layer.getStatusMessage();

--- a/plugins/org.locationtech.udig.project/src/org/locationtech/udig/project/internal/commands/edit/CreateFeatureCommand.java
+++ b/plugins/org.locationtech.udig.project/src/org/locationtech/udig/project/internal/commands/edit/CreateFeatureCommand.java
@@ -1,4 +1,5 @@
-/* uDig - User Friendly Desktop Internet GIS client
+/**
+ * uDig - User Friendly Desktop Internet GIS client
  * http://udig.refractions.net
  * (C) 2004-2012, Refractions Research Inc.
  *
@@ -13,20 +14,6 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Random;
 
-import org.locationtech.udig.core.internal.ExtensionPointList;
-import org.locationtech.udig.core.internal.FeatureUtils;
-import org.locationtech.udig.core.internal.GeometryBuilder;
-import org.locationtech.udig.project.AdaptableFeature;
-import org.locationtech.udig.project.ILayer;
-import org.locationtech.udig.project.command.MapCommand;
-import org.locationtech.udig.project.command.UndoableMapCommand;
-import org.locationtech.udig.project.interceptor.FeatureInterceptor;
-import org.locationtech.udig.project.interceptor.MapInterceptor;
-import org.locationtech.udig.project.internal.Layer;
-import org.locationtech.udig.project.internal.Map;
-import org.locationtech.udig.project.internal.Messages;
-import org.locationtech.udig.project.internal.ProjectPlugin;
-
 import org.eclipse.core.runtime.IConfigurationElement;
 import org.eclipse.core.runtime.IProgressMonitor;
 import org.eclipse.jface.dialogs.MessageDialog;
@@ -34,9 +21,23 @@ import org.eclipse.swt.widgets.Display;
 import org.geotools.data.FeatureStore;
 import org.geotools.data.Transaction;
 import org.geotools.factory.CommonFactoryFinder;
-import org.geotools.util.factory.GeoTools;
 import org.geotools.feature.simple.SimpleFeatureBuilder;
 import org.geotools.referencing.CRS;
+import org.geotools.util.factory.GeoTools;
+import org.locationtech.jts.geom.Coordinate;
+import org.locationtech.jts.geom.Geometry;
+import org.locationtech.udig.core.internal.ExtensionPointList;
+import org.locationtech.udig.core.internal.FeatureUtils;
+import org.locationtech.udig.core.internal.GeometryBuilder;
+import org.locationtech.udig.project.AdaptableFeature;
+import org.locationtech.udig.project.ILayer;
+import org.locationtech.udig.project.Interaction;
+import org.locationtech.udig.project.command.MapCommand;
+import org.locationtech.udig.project.command.UndoableMapCommand;
+import org.locationtech.udig.project.interceptor.FeatureInterceptor;
+import org.locationtech.udig.project.internal.Layer;
+import org.locationtech.udig.project.internal.Messages;
+import org.locationtech.udig.project.internal.ProjectPlugin;
 import org.opengis.feature.Feature;
 import org.opengis.feature.simple.SimpleFeature;
 import org.opengis.feature.simple.SimpleFeatureType;
@@ -45,12 +46,9 @@ import org.opengis.filter.FilterFactory;
 import org.opengis.referencing.operation.MathTransform;
 import org.opengis.util.CodeList;
 
-import org.locationtech.jts.geom.Coordinate;
-import org.locationtech.jts.geom.Geometry;
-
 /**
  * Creates a new feature in the current edit layer.
- * 
+ *
  * @author jones
  * @since 0.3
  * @version 1.2
@@ -63,10 +61,10 @@ public class CreateFeatureCommand extends AbstractEditCommand implements Undoabl
 
     /**
      * Construct <code>CreateFeatureCommand</code>.
-     * 
+     *
      * @param coordinates Coordinates in Map coordinates.
      */
-    public CreateFeatureCommand( Coordinate[] coordinates ) {
+    public CreateFeatureCommand(Coordinate[] coordinates) {
         int i = 0;
         if (coordinates != null) {
             i = coordinates.length;
@@ -78,11 +76,9 @@ public class CreateFeatureCommand extends AbstractEditCommand implements Undoabl
         this.coordinates = c;
     }
 
-    /**
-     * @see org.locationtech.udig.project.command.MapCommand#run()
-     */
+    @Override
     @SuppressWarnings("unchecked")
-    public void run( IProgressMonitor monitor ) throws Exception {
+    public void run(IProgressMonitor monitor) throws Exception {
         ILayer editLayer = getMap().getEditManager().getEditLayer();
         if (editLayer == null) {
             editLayer = findEditLayer();
@@ -94,24 +90,16 @@ public class CreateFeatureCommand extends AbstractEditCommand implements Undoabl
             return;
         }
 
-        FeatureStore<SimpleFeatureType, SimpleFeature> store = editLayer.getResource(
-                FeatureStore.class, null);
+        FeatureStore<SimpleFeatureType, SimpleFeature> store = editLayer
+                .getResource(FeatureStore.class, null);
         transform();
         if (store.getTransaction() == Transaction.AUTO_COMMIT) {
             throw new Exception("Error transaction has not been started"); //$NON-NLS-1$
         }
         final SimpleFeatureType type = store.getSchema();
 
-        // Object[] attrs = new Object[type.getAttributeCount()];
-        // for( int i = 0; i < attrs.length; i++ ) {
-        // attrs[i] = toDefaultValue(type.getDescriptor(i));
-        // }
-        //        
-        // final SimpleFeature newFeature = SimpleFeatureBuilder.build(type, attrs, "newFeature"
-        // + new Random().nextInt());
-
-        String proposedFid = "newFeature"+"newFeature" + new Random().nextInt();
-        final SimpleFeature newFeature = SimpleFeatureBuilder.template(type, proposedFid );
+        String proposedFid = "newFeature" + "newFeature" + new Random().nextInt(); //$NON-NLS-1$ //$NON-NLS-2$
+        final SimpleFeature newFeature = SimpleFeatureBuilder.template(type, proposedFid);
 
         Class geomType = type.getGeometryDescriptor().getType().getBinding();
         Geometry geom = GeometryBuilder.create().safeCreateGeometry(geomType, coordinates);
@@ -119,21 +107,22 @@ public class CreateFeatureCommand extends AbstractEditCommand implements Undoabl
         fid = newFeature.getID();
 
         SimpleFeature feature = new AdaptableFeature(newFeature, editLayer);
-        
+
         runFeatureCreationInterceptors(feature);
 
         map.getEditManagerInternal().addFeature(newFeature, (Layer) editLayer);
     }
+
     /**
      * Retrieves a default value for the provided descriptor.
      * <p>
      * The descriptor getDefaultValue() is used if available; if not a default value is created base
      * on the descriptor binding. The default values mirror those used by Java; empty string,
      * boolean false, 0 integer, 0.0 double, etc... >p>
-     * 
+     *
      * @param type attribute descriptor
      */
-    private Object toDefaultValue( AttributeDescriptor type ) {
+    private Object toDefaultValue(AttributeDescriptor type) {
         if (type.getDefaultValue() != null) {
             return type.getDefaultValue();
         }
@@ -167,9 +156,10 @@ public class CreateFeatureCommand extends AbstractEditCommand implements Undoabl
         if (map.getEditManagerInternal().getEditLayerInternal() != null) {
             return map.getEditManagerInternal().getEditLayerInternal();
         }
-        for( Iterator<Layer> iter = map.getLayersInternal().iterator(); iter.hasNext(); ) {
+        for (Iterator<Layer> iter = map.getLayersInternal().iterator(); iter.hasNext();) {
             layer = iter.next();
-            if (layer.hasResource(FeatureStore.class) && layer.isSelectable() && layer.isVisible()) {
+            if (layer.hasResource(FeatureStore.class) && layer.getInteraction(Interaction.SELECT)
+                    && layer.isVisible()) {
                 break;
             }
         }
@@ -178,61 +168,59 @@ public class CreateFeatureCommand extends AbstractEditCommand implements Undoabl
 
     /**
      * Transforms coordinates into the layer CRS if required
-     * 
+     *
      * @throws Exception
      */
     private void transform() throws Exception {
         ILayer editLayer = getMap().getEditManager().getEditLayer();
-        if (map.getViewportModel().getCRS().equals(editLayer.getCRS(null))) {
+        if (map.getViewportModel().getCRS().equals(editLayer.getCRS())) {
             return;
         }
-        MathTransform mt = CRS.findMathTransform(map.getViewportModel().getCRS(), editLayer
-                .getCRS(), true);
+        MathTransform mt = CRS.findMathTransform(map.getViewportModel().getCRS(),
+                editLayer.getCRS(), true);
         if (mt == null || mt.isIdentity()) {
             return;
         }
         double[] coords = new double[coordinates.length * 2];
-        for( int i = 0; i < coordinates.length; i++ ) {
+        for (int i = 0; i < coordinates.length; i++) {
             coords[i * 2] = coordinates[i].x;
             coords[i * 2 + 1] = coordinates[i].y;
         }
         mt.transform(coords, 0, coords, 0, coordinates.length);
-        for( int i = 0; i < coordinates.length; i++ ) {
+        for (int i = 0; i < coordinates.length; i++) {
             coordinates[i].x = coords[i * 2];
             coordinates[i].y = coords[i * 2 + 1];
         }
     }
 
+    @Override
     public MapCommand copy() {
         return new CreateFeatureCommand(coordinates);
     }
 
-    /**
-     * @see org.locationtech.udig.project.command.MapCommand#getName()
-     */
+    @Override
     public String getName() {
         return Messages.CreateFeatureCommand_createFeature;
     }
 
-    /**
-     * @see org.locationtech.udig.project.command.UndoableCommand#rollback()
-     */
-    public void rollback( IProgressMonitor monitor ) throws Exception {
+    @Override
+    public void rollback(IProgressMonitor monitor) throws Exception {
         ILayer editLayer = getMap().getEditManager().getEditLayer();
-        FilterFactory filterFactory = CommonFactoryFinder.getFilterFactory(GeoTools
-                .getDefaultHints());
-        editLayer.getResource(FeatureStore.class, null).removeFeatures(
-                filterFactory.id(FeatureUtils.stringToId(filterFactory, fid)));
+        FilterFactory filterFactory = CommonFactoryFinder
+                .getFilterFactory(GeoTools.getDefaultHints());
+        editLayer.getResource(FeatureStore.class, null)
+                .removeFeatures(filterFactory.id(FeatureUtils.stringToId(filterFactory, fid)));
     }
-    public static void runFeatureCreationInterceptors( Feature feature ) {
+
+    public static void runFeatureCreationInterceptors(Feature feature) {
         List<IConfigurationElement> interceptors = ExtensionPointList
                 .getExtensionPointList(FeatureInterceptor.EXTENSION_ID);
-        for( IConfigurationElement element : interceptors ) {
-            String id = element.getAttribute("id");
+        for (IConfigurationElement element : interceptors) {
+            String id = element.getAttribute("id"); //$NON-NLS-1$
             if (FeatureInterceptor.CREATED_ID.equals(element.getName())) {
                 try {
                     FeatureInterceptor interceptor = (FeatureInterceptor) element
-                            .createExecutableExtension("class");
+                            .createExecutableExtension("class"); //$NON-NLS-1$
                     interceptor.run(feature);
                 } catch (Exception e) {
                     ProjectPlugin.log("FeatureInterceptor " + id + ":" + e, e);

--- a/plugins/org.locationtech.udig.project/src/org/locationtech/udig/project/internal/impl/LayerImpl.java
+++ b/plugins/org.locationtech.udig.project/src/org/locationtech/udig/project/internal/impl/LayerImpl.java
@@ -168,9 +168,9 @@ public class LayerImpl extends EObjectImpl implements Layer {
     protected static final int ZORDER_EDEFAULT = 0;
 
     /**
-     * The cached value of the '{@link #getZorder() <em>Zorder</em>}' attribute.
-     * <!-- begin-user-doc
+     * The cached value of the '{@link #getZorder() <em>Zorder</em>}' attribute. <!-- begin-user-doc
      * --> <!-- end-user-doc -->
+     *
      * @see #getZorder()
      * @generated
      * @ordered
@@ -242,7 +242,6 @@ public class LayerImpl extends EObjectImpl implements Layer {
             }
         }
 
-        @SuppressWarnings("unchecked")
         private void registerWithContainers(Notification msg) {
             // register itself with container objects
             switch (msg.getEventType()) {
@@ -343,7 +342,7 @@ public class LayerImpl extends EObjectImpl implements Layer {
     CopyOnWriteArraySet<ILayerListener> listeners = new CopyOnWriteArraySet<>();
 
     /**
-     * Ensures that a warning about georesources not found is only logged once
+     * Ensures that a warning about GeoResources not found is only logged once
      */
     private volatile boolean warned = false;
 
@@ -358,7 +357,7 @@ public class LayerImpl extends EObjectImpl implements Layer {
     private final Lock geoResourceCacheLock = new UDIGDisplaySafeLock();
 
     /**
-     * indicates whether or not the CRS is a known CRS (the georesources return null when asked for
+     * indicates whether or not the CRS is a known CRS (the GeoResources return null when asked for
      * a CRS). If null then it has not been computed yet. if false and crsLoader !=null then it is
      * being computed.
      */
@@ -366,7 +365,7 @@ public class LayerImpl extends EObjectImpl implements Layer {
 
     /**
      * Used in {@link #isUnknownCRS()} to lazily compute the CRS. If null and unknownCRS is null
-     * then the crs has not been computed. if not null then the computatin is taking place.
+     * then the CRS has not been computed. if not null then the computation is taking place.
      */
     private volatile ISafeRunnable crsLoader;
 
@@ -389,19 +388,11 @@ public class LayerImpl extends EObjectImpl implements Layer {
         CatalogPlugin.removeListener(this);
     }
 
-    /*
-     * @see
-     * org.locationtech.udig.project.Layer#addListener(org.locationtech.udig.project.LayerListener)
-     */
     @Override
     public void addListener(final ILayerListener listener) {
         listeners.add(listener);
     }
 
-    /*
-     * @see
-     * org.locationtech.udig.project.Layer#removeListener(org.locationtech.udig.project.LayerListener)
-     */
     @Override
     public void removeListener(final ILayerListener listener) {
         listeners.remove(listener);
@@ -428,6 +419,7 @@ public class LayerImpl extends EObjectImpl implements Layer {
 
     /**
      * <!-- begin-user-doc --> <!-- end-user-doc -->
+     *
      * @generated
      */
     @Override
@@ -437,6 +429,7 @@ public class LayerImpl extends EObjectImpl implements Layer {
 
     /**
      * <!-- begin-user-doc --> <!-- end-user-doc -->
+     *
      * @generated
      */
     @Override
@@ -448,6 +441,7 @@ public class LayerImpl extends EObjectImpl implements Layer {
 
     /**
      * <!-- begin-user-doc --> <!-- end-user-doc -->
+     *
      * @generated
      */
     public NotificationChain basicSetContextModel(ContextModel newContextModel,
@@ -459,6 +453,7 @@ public class LayerImpl extends EObjectImpl implements Layer {
 
     /**
      * <!-- begin-user-doc --> <!-- end-user-doc -->
+     *
      * @generated
      */
     @Override
@@ -501,7 +496,6 @@ public class LayerImpl extends EObjectImpl implements Layer {
      * @generated NOT
      */
     @Override
-    @SuppressWarnings("unchecked")
     public void setZorder(int newZorder) {
         if (getContextModel() == null || getMapInternal().getLayersInternal() == null) {
             return;
@@ -518,6 +512,7 @@ public class LayerImpl extends EObjectImpl implements Layer {
 
     /**
      * <!-- begin-user-doc --> <!-- end-user-doc -->
+     *
      * @generated
      */
     @Override
@@ -527,6 +522,7 @@ public class LayerImpl extends EObjectImpl implements Layer {
 
     /**
      * <!-- begin-user-doc --> <!-- end-user-doc -->
+     *
      * @generated
      */
     @Override
@@ -540,6 +536,7 @@ public class LayerImpl extends EObjectImpl implements Layer {
 
     /**
      * <!-- begin-user-doc --> <!-- end-user-doc -->
+     *
      * @generated
      */
     @Override
@@ -549,6 +546,7 @@ public class LayerImpl extends EObjectImpl implements Layer {
 
     /**
      * <!-- begin-user-doc --> <!-- end-user-doc -->
+     *
      * @generated
      */
     @Override
@@ -603,6 +601,7 @@ public class LayerImpl extends EObjectImpl implements Layer {
 
     /**
      * <!-- begin-user-doc --> <!-- end-user-doc -->
+     *
      * @generated
      */
     @Override
@@ -612,6 +611,7 @@ public class LayerImpl extends EObjectImpl implements Layer {
 
     /**
      * <!-- begin-user-doc --> <!-- end-user-doc -->
+     *
      * @generated
      */
     @Override
@@ -636,8 +636,11 @@ public class LayerImpl extends EObjectImpl implements Layer {
      * <b>New implementation of the method:
      * <p>
      * getGeoResource() is a blocking method but it must not block UI thread. With this purpose the
-     * new imlementation is done to avoid UI thread blocking because of synchronization. </b> <!--
-     * end-user-doc -->
+     * new implementation is done to avoid UI thread blocking because of synchronization.
+     * </p>
+     * </b>
+     *
+     * <!-- end-user-doc -->
      *
      * @uml.property name="geoResources"
      * @generated NOT
@@ -739,7 +742,8 @@ public class LayerImpl extends EObjectImpl implements Layer {
 
     private boolean assertNotInDisplayAccess() {
         if (Display.getCurrent() != null) {
-            //            ProjectPlugin.log("getGeoResources was called in display Thread", new Exception("JUST A WARNING NOT CRITICAL")); //$NON-NLS-1$ //$NON-NLS-2$
+            // ProjectPlugin.log("getGeoResources was called in display Thread", new Exception("JUST
+            // A WARNING NOT CRITICAL")); //$NON-NLS-1$ //$NON-NLS-2$
         }
         return true;
     }
@@ -825,6 +829,7 @@ public class LayerImpl extends EObjectImpl implements Layer {
 
     /**
      * <!-- begin-user-doc --> <!-- end-user-doc -->
+     *
      * @generated
      */
     public void setCatalogRefGen(CatalogRef newCatalogRef) {
@@ -837,6 +842,7 @@ public class LayerImpl extends EObjectImpl implements Layer {
 
     /**
      * <!-- begin-user-doc --> <!-- end-user-doc -->
+     *
      * @generated
      */
     @Override
@@ -846,6 +852,7 @@ public class LayerImpl extends EObjectImpl implements Layer {
 
     /**
      * <!-- begin-user-doc --> <!-- end-user-doc -->
+     *
      * @generated
      */
     public NotificationChain basicSetStyleBlackboard(StyleBlackboard newStyleBlackboard,
@@ -892,6 +899,7 @@ public class LayerImpl extends EObjectImpl implements Layer {
 
     /**
      * <!-- begin-user-doc --> <!-- end-user-doc -->
+     *
      * @generated
      */
     @Override
@@ -901,6 +909,7 @@ public class LayerImpl extends EObjectImpl implements Layer {
 
     /**
      * <!-- begin-user-doc --> <!-- end-user-doc -->
+     *
      * @generated
      */
     @Override
@@ -1009,6 +1018,7 @@ public class LayerImpl extends EObjectImpl implements Layer {
 
     /**
      * <!-- begin-user-doc --> <!-- end-user-doc -->
+     *
      * @generated
      */
     @Override
@@ -1018,6 +1028,7 @@ public class LayerImpl extends EObjectImpl implements Layer {
 
     /**
      * please use getIcon
+     *
      * @deprecated
      * @generated NOT
      */
@@ -1027,8 +1038,8 @@ public class LayerImpl extends EObjectImpl implements Layer {
     }
 
     /**
-     * <!-- begin-user-doc -->
-     * <!-- end-user-doc -->
+     * <!-- begin-user-doc --> <!-- end-user-doc -->
+     *
      * @generated
      */
     @Override
@@ -1042,30 +1053,13 @@ public class LayerImpl extends EObjectImpl implements Layer {
 
     /**
      * please use setIcon
+     *
      * @deprecated
      * @generated NOT
      */
     @Deprecated
     public void setGlyph(ImageDescriptor icon) {
         setIcon(icon);
-    }
-
-    /**
-     * @deprecated use getInteraction(Interaction.SELECT)
-     */
-    @Deprecated
-    @Override
-    public boolean isSelectable() {
-        return getInteraction(Interaction.SELECT);
-    }
-
-    /**
-     * @deprecated use setInteraction(Interaction.SELECT, value)
-     */
-    @Deprecated
-    @Override
-    public void setSelectable(boolean newSelectable) {
-        setInteraction(Interaction.SELECT, newSelectable);
     }
 
     /**
@@ -1112,9 +1106,9 @@ public class LayerImpl extends EObjectImpl implements Layer {
     private volatile int status;
 
     /**
-     * The default value of the '{@link #getName() <em>Name</em>}' attribute.
-     * <!-- begin-user-doc
+     * The default value of the '{@link #getName() <em>Name</em>}' attribute. <!-- begin-user-doc
      * --> <!-- end-user-doc -->
+     *
      * @see #getName()
      * @generated
      * @ordered
@@ -1152,9 +1146,9 @@ public class LayerImpl extends EObjectImpl implements Layer {
     protected volatile CatalogRef catalogRef = new CatalogRef(this);
 
     /**
-     * The default value of the '{@link #getID() <em>ID</em>}' attribute.
-     * <!-- begin-user-doc -->
+     * The default value of the '{@link #getID() <em>ID</em>}' attribute. <!-- begin-user-doc -->
      * <!-- end-user-doc -->
+     *
      * @see #getID()
      * @generated
      * @ordered
@@ -1222,9 +1216,9 @@ public class LayerImpl extends EObjectImpl implements Layer {
     protected volatile EList<IGeoResource> geoResources = null;
 
     /**
-     * The default value of the '{@link #getCRS() <em>CRS</em>}' attribute.
-     * <!-- begin-user-doc -->
+     * The default value of the '{@link #getCRS() <em>CRS</em>}' attribute. <!-- begin-user-doc -->
      * <!-- end-user-doc -->
+     *
      * @see #getCRS()
      * @generated
      * @ordered
@@ -1352,9 +1346,9 @@ public class LayerImpl extends EObjectImpl implements Layer {
     protected EMap<Interaction, Boolean> interactionMap;
 
     /**
-     * The default value of the '{@link #isShown() <em>Shown</em>}' attribute.
-     * <!-- begin-user-doc -->
-     * <!-- end-user-doc -->
+     * The default value of the '{@link #isShown() <em>Shown</em>}' attribute. <!-- begin-user-doc
+     * --> <!-- end-user-doc -->
+     *
      * @see #isShown()
      * @generated
      * @ordered
@@ -1362,9 +1356,9 @@ public class LayerImpl extends EObjectImpl implements Layer {
     protected static final boolean SHOWN_EDEFAULT = false;
 
     /**
-     * The cached value of the '{@link #isShown() <em>Shown</em>}' attribute.
-     * <!-- begin-user-doc -->
-     * <!-- end-user-doc -->
+     * The cached value of the '{@link #isShown() <em>Shown</em>}' attribute. <!-- begin-user-doc
+     * --> <!-- end-user-doc -->
+     *
      * @see #isShown()
      * @generated
      * @ordered
@@ -1372,9 +1366,9 @@ public class LayerImpl extends EObjectImpl implements Layer {
     protected boolean shown = SHOWN_EDEFAULT;
 
     /**
-     * The default value of the '{@link #getIcon() <em>Icon</em>}' attribute.
-     * <!-- begin-user-doc -->
-     * <!-- end-user-doc -->
+     * The default value of the '{@link #getIcon() <em>Icon</em>}' attribute. <!-- begin-user-doc
+     * --> <!-- end-user-doc -->
+     *
      * @see #getIcon()
      * @generated
      * @ordered
@@ -1382,9 +1376,9 @@ public class LayerImpl extends EObjectImpl implements Layer {
     protected static final ImageDescriptor ICON_EDEFAULT = null;
 
     /**
-     * The cached value of the '{@link #getIcon() <em>Icon</em>}' attribute.
-     * <!-- begin-user-doc -->
+     * The cached value of the '{@link #getIcon() <em>Icon</em>}' attribute. <!-- begin-user-doc -->
      * <!-- end-user-doc -->
+     *
      * @see #getIcon()
      * @generated
      * @ordered
@@ -1393,9 +1387,6 @@ public class LayerImpl extends EObjectImpl implements Layer {
 
     private volatile String statusMessage = Messages.LayerImpl_status;
 
-    /**
-     * @see org.locationtech.udig.project.internal.Layer#getSchema()
-     */
     @Override
     public SimpleFeatureType getSchema() {
         FeatureSource<SimpleFeatureType, SimpleFeature> data;
@@ -1407,41 +1398,14 @@ public class LayerImpl extends EObjectImpl implements Layer {
         } catch (IOException e) {
             ProjectPlugin.log(null, e);
         }
-        // XXX: rgould how do I process a getWMS().createDescribeLayerRequest()?
-
-        // URL wfsURL = null;
-        //
-        // try {
-        // DescribeLayerRequest request = null;
-        // request = getWMS().createDescribeLayerRequest();
-        // request.setLayers(getName());
-        // DescribeLayerResponse response = (DescribeLayerResponse)
-        // getWMS().issueRequest(request);
-        // wfsURL = response.getLayerDescs()[0].getWfs();
-        // } catch (SAXException e1) {
-        // // TODO Catch e1
-        // } catch (UnsupportedOperationException e) {
-        // // TODO Catch e
-        // } catch (IOException e) {
-        // // TODO Catch e
-        // }
-
-        // WFS URL now possibly has a URL
-
         return null;
     }
 
-    /**
-     * @see java.lang.Comparable#compareTo(java.lang.Object)
-     */
     @Override
     public int compareTo(ILayer arg0) {
         return doComparison(this, arg0);
     }
 
-    /**
-     * @see org.locationtech.udig.project.internal.Layer#getInteraction(java.lang.String)
-     */
     @Override
     public boolean getInteraction(Interaction interaction) {
         // special cases handled as fields
@@ -1475,9 +1439,6 @@ public class LayerImpl extends EObjectImpl implements Layer {
         return false;
     }
 
-    /**
-     * @see org.locationtech.udig.project.internal.Layer#setInteraction(java.lang.String, boolean)
-     */
     @Override
     public void setInteraction(Interaction interaction, boolean applicable) {
         if (Interaction.VISIBLE.equals(interaction)) {
@@ -1494,7 +1455,10 @@ public class LayerImpl extends EObjectImpl implements Layer {
      */
     @Override
     public CoordinateReferenceSystem getCRS() {
-        return getCRS(null);
+        if (cRS == null) {
+            return UNKNOWN_CRS;
+        }
+        return cRS;
     }
 
     /**
@@ -1519,6 +1483,7 @@ public class LayerImpl extends EObjectImpl implements Layer {
 
     /**
      * <!-- begin-user-doc --> <!-- end-user-doc -->
+     *
      * @generated
      */
     public void setCRSGen(CoordinateReferenceSystem newCRS) {
@@ -1544,6 +1509,7 @@ public class LayerImpl extends EObjectImpl implements Layer {
 
     /**
      * <!-- begin-user-doc --> <!-- end-user-doc -->
+     *
      * @generated
      */
     @Override
@@ -1553,6 +1519,7 @@ public class LayerImpl extends EObjectImpl implements Layer {
 
     /**
      * <!-- begin-user-doc --> <!-- end-user-doc -->
+     *
      * @generated
      */
     @Override
@@ -1566,6 +1533,7 @@ public class LayerImpl extends EObjectImpl implements Layer {
 
     /**
      * <!-- begin-user-doc --> <!-- end-user-doc -->
+     *
      * @generated
      */
     @Override
@@ -1575,6 +1543,7 @@ public class LayerImpl extends EObjectImpl implements Layer {
 
     /**
      * <!-- begin-user-doc --> <!-- end-user-doc -->
+     *
      * @generated
      */
     @Override
@@ -1686,6 +1655,7 @@ public class LayerImpl extends EObjectImpl implements Layer {
 
     /**
      * <!-- begin-user-doc --> <!-- end-user-doc -->
+     *
      * @generated
      */
     @Override
@@ -1700,6 +1670,7 @@ public class LayerImpl extends EObjectImpl implements Layer {
 
     /**
      * <!-- begin-user-doc --> <!-- end-user-doc -->
+     *
      * @generated
      */
     @Override
@@ -1714,8 +1685,8 @@ public class LayerImpl extends EObjectImpl implements Layer {
     }
 
     /**
-     * <!-- begin-user-doc -->
-     * <!-- end-user-doc -->
+     * <!-- begin-user-doc --> <!-- end-user-doc -->
+     *
      * @generated
      */
     @Override
@@ -1724,8 +1695,8 @@ public class LayerImpl extends EObjectImpl implements Layer {
     }
 
     /**
-     * <!-- begin-user-doc -->
-     * <!-- end-user-doc -->
+     * <!-- begin-user-doc --> <!-- end-user-doc -->
+     *
      * @generated
      */
     @Override
@@ -1737,9 +1708,6 @@ public class LayerImpl extends EObjectImpl implements Layer {
                     oldShown, shown));
     }
 
-    /**
-     * @see org.eclipse.core.runtime.IAdaptable#getAdapter(java.lang.Class)
-     */
     @Override
     @SuppressWarnings("unchecked")
     public Object getAdapter(final Class adapter) {
@@ -1786,7 +1754,7 @@ public class LayerImpl extends EObjectImpl implements Layer {
             }
         }
 
-        /*
+        /**
          * Adapt to an IWorkbenchAdapter. Other aspects of Eclipse can read the properties we
          * provide access to. (example: Property page dialogs can read the label and display that in
          * their title.)
@@ -1805,16 +1773,9 @@ public class LayerImpl extends EObjectImpl implements Layer {
         return Platform.getAdapterManager().getAdapter(this, adapter);
     }
 
-    @Override
-    public CoordinateReferenceSystem getCRS(IProgressMonitor monitor) {
-
-        if (cRS != null)
-            return cRS;
-        return getCRSInternal(monitor);
-    }
-
     /**
      * <!-- begin-user-doc --> <!-- end-user-doc -->
+     *
      * @generated
      */
     @Override
@@ -1831,6 +1792,7 @@ public class LayerImpl extends EObjectImpl implements Layer {
 
     /**
      * <!-- begin-user-doc --> <!-- end-user-doc -->
+     *
      * @generated
      */
     @Override
@@ -1850,6 +1812,7 @@ public class LayerImpl extends EObjectImpl implements Layer {
 
     /**
      * <!-- begin-user-doc --> <!-- end-user-doc -->
+     *
      * @generated
      */
     @Override
@@ -1864,6 +1827,7 @@ public class LayerImpl extends EObjectImpl implements Layer {
 
     /**
      * <!-- begin-user-doc --> <!-- end-user-doc -->
+     *
      * @generated
      */
     @Override
@@ -1920,6 +1884,7 @@ public class LayerImpl extends EObjectImpl implements Layer {
 
     /**
      * <!-- begin-user-doc --> <!-- end-user-doc -->
+     *
      * @generated
      */
     @SuppressWarnings("unchecked")
@@ -1991,6 +1956,7 @@ public class LayerImpl extends EObjectImpl implements Layer {
 
     /**
      * <!-- begin-user-doc --> <!-- end-user-doc -->
+     *
      * @generated
      */
     @Override
@@ -2059,6 +2025,7 @@ public class LayerImpl extends EObjectImpl implements Layer {
 
     /**
      * <!-- begin-user-doc --> <!-- end-user-doc -->
+     *
      * @generated
      */
     @Override
@@ -2112,34 +2079,6 @@ public class LayerImpl extends EObjectImpl implements Layer {
             return ICON_EDEFAULT == null ? icon != null : !ICON_EDEFAULT.equals(icon);
         }
         return super.eIsSet(featureID);
-    }
-
-    /**
-     * queries the georesources for a CRS
-     *
-     * @param monitor
-     * @return
-     */
-    private CoordinateReferenceSystem getCRSInternal(IProgressMonitor monitor) {
-        try {
-            CoordinateReferenceSystem crs = getGeoResource().getInfo(monitor).getCRS();
-            if (crs != null)
-                return crs;
-        } catch (Exception e) {
-            ProjectPlugin.log(null, e);
-        }
-
-        List<IGeoResource> list = getGeoResources();
-        for (IGeoResource resource : list) {
-            try {
-                if (resource.getInfo(monitor).getCRS() != null)
-                    return resource.getInfo(monitor).getCRS();
-            } catch (Exception e) {
-                ProjectPlugin.log(null, e);
-            }
-        }
-
-        return UNKNOWN_CRS;
     }
 
     @Override
@@ -2228,7 +2167,7 @@ public class LayerImpl extends EObjectImpl implements Layer {
     private ReferencedEnvelope obtainBoundsFromResources(IProgressMonitor monitor) {
         ReferencedEnvelope result = null;
         for (IGeoResource resource : getGeoResources()) {
-            //IGeoResourceInfo info = resource.getInfo(monitor);
+            // IGeoResourceInfo info = resource.getInfo(monitor);
             IGeoResourceInfo info = getInfo(resource, monitor);
             Envelope tmp = null;
             if (info != null)
@@ -2275,7 +2214,7 @@ public class LayerImpl extends EObjectImpl implements Layer {
     /**
      * Creates A geometry filter for the given layer.
      *
-     * @param boundingBox in the same crs as the viewport model.
+     * @param boundingBox in the same CRS as the viewport model.
      * @return a Geometry filter in the correct CRS or null if an exception occurs.
      */
     @Override
@@ -2304,9 +2243,6 @@ public class LayerImpl extends EObjectImpl implements Layer {
         return bboxFilter;
     }
 
-    /**
-     * @see org.locationtech.udig.project.internal.Layer#getMap()
-     */
     @Override
     public org.locationtech.udig.project.internal.Map getMapInternal() {
         ContextModel context = getContextModel();
@@ -2315,18 +2251,11 @@ public class LayerImpl extends EObjectImpl implements Layer {
         return context.getMap();
     }
 
-    /**
-     * @see org.locationtech.udig.project.ILayer#getMap()
-     */
     @Override
     public IMap getMap() {
         return getMapInternal();
     }
 
-    /**
-     * @see org.locationtech.udig.core.IBlockingAdaptable#getAdapter(java.lang.Class,
-     *      org.eclipse.core.runtime.IProgressMonitor)
-     */
     @Override
     public <T> T getAdapter(final Class<T> adapter, IProgressMonitor monitor) throws IOException {
         if (hasResource(adapter)) {
@@ -2336,14 +2265,11 @@ public class LayerImpl extends EObjectImpl implements Layer {
             return list.get(0);
         }
         if (adapter.isAssignableFrom(CoordinateReferenceSystem.class)) {
-            return adapter.cast(getCRS(monitor));
+            return adapter.cast(getCRS());
         }
         return null;
     }
 
-    /**
-     * @see org.locationtech.udig.core.IBlockingAdaptable#canAdaptTo(java.lang.Class)
-     */
     @Override
     public <T> boolean canAdaptTo(Class<T> adapter) {
         return hasResource(adapter) || adapter.isAssignableFrom(CoordinateReferenceSystem.class);

--- a/plugins/org.locationtech.udig.project/src/org/locationtech/udig/project/internal/impl/MapImpl.java
+++ b/plugins/org.locationtech.udig.project/src/org/locationtech/udig/project/internal/impl/MapImpl.java
@@ -1,4 +1,5 @@
-/* uDig - User Friendly Desktop Internet GIS client
+/**
+ * uDig - User Friendly Desktop Internet GIS client
  * http://udig.refractions.net
  * (C) 2004-2012, Refractions Research Inc.
  *
@@ -59,6 +60,7 @@ import org.locationtech.udig.project.ILegendItem;
 import org.locationtech.udig.project.IMapCompositionListener;
 import org.locationtech.udig.project.IMapListener;
 import org.locationtech.udig.project.IProject;
+import org.locationtech.udig.project.Interaction;
 import org.locationtech.udig.project.command.Command;
 import org.locationtech.udig.project.command.CommandListener;
 import org.locationtech.udig.project.command.CommandManager;
@@ -112,6 +114,7 @@ import org.opengis.referencing.operation.TransformException;
  * Project element used by MapEditorInput.
  * <p>
  * For more information please see *org.locationtech.udig.project.internal.ui.mapEditorInput*.
+ * </p>
  *
  * @author Jesse
  * @since 1.0.0
@@ -122,9 +125,9 @@ public class MapImpl extends EObjectImpl implements Map {
     private static final String ERROR_EXECUTING_COMMAND = "Error executing command: ";
 
     /**
-     * The default value of the '{@link #getName() <em>Name</em>}' attribute.
-     * <!-- begin-user-doc
+     * The default value of the '{@link #getName() <em>Name</em>}' attribute. <!-- begin-user-doc
      * --> <!-- end-user-doc -->
+     *
      * @see #getName()
      * @generated NOT
      * @ordered
@@ -132,9 +135,9 @@ public class MapImpl extends EObjectImpl implements Map {
     protected static final String NAME_EDEFAULT = "";
 
     /**
-     * The cached value of the '{@link #getName() <em>Name</em>}' attribute.
-     * <!-- begin-user-doc
-     * --> <!-- end-user-doc -->
+     * The cached value of the '{@link #getName() <em>Name</em>}' attribute. <!-- begin-user-doc -->
+     * <!-- end-user-doc -->
+     *
      * @see #getName()
      * @generated NOT
      * @ordered
@@ -144,6 +147,7 @@ public class MapImpl extends EObjectImpl implements Map {
     /**
      * The cached value of the '{@link #getProjectInternal() <em>Project Internal</em>}' reference.
      * <!-- begin-user-doc --> <!-- end-user-doc -->
+     *
      * @see #getProjectInternal()
      * @generated not
      * @ordered
@@ -151,8 +155,9 @@ public class MapImpl extends EObjectImpl implements Map {
     protected volatile Project projectInternal = null;
 
     /**
-     * The cached value of the '{@link #getContextModel() <em>Context Model</em>}' containment reference.
-     * <!-- begin-user-doc --> <!-- end-user-doc -->
+     * The cached value of the '{@link #getContextModel() <em>Context Model</em>}' containment
+     * reference. <!-- begin-user-doc --> <!-- end-user-doc -->
+     *
      * @see #getContextModel()
      * @generated not
      * @ordered
@@ -180,8 +185,9 @@ public class MapImpl extends EObjectImpl implements Map {
     protected volatile String abstract_ = ABSTRACT_EDEFAULT;
 
     /**
-     * The default value of the '{@link #getNavCommandStack() <em>Nav Command Stack</em>}' attribute.
-     * <!-- begin-user-doc --> <!-- end-user-doc -->
+     * The default value of the '{@link #getNavCommandStack() <em>Nav Command Stack</em>}'
+     * attribute. <!-- begin-user-doc --> <!-- end-user-doc -->
+     *
      * @see #getNavCommandStack()
      * @generated
      * @ordered
@@ -189,8 +195,9 @@ public class MapImpl extends EObjectImpl implements Map {
     protected static final NavCommandStack NAV_COMMAND_STACK_EDEFAULT = null;
 
     /**
-     * The default value of the '{@link #getCommandStack() <em>Command Stack</em>}' attribute.
-     * <!-- begin-user-doc --> <!-- end-user-doc -->
+     * The default value of the '{@link #getCommandStack() <em>Command Stack</em>}' attribute. <!--
+     * begin-user-doc --> <!-- end-user-doc -->
+     *
      * @see #getCommandStack()
      * @generated
      * @ordered
@@ -198,8 +205,9 @@ public class MapImpl extends EObjectImpl implements Map {
     protected static final CommandStack COMMAND_STACK_EDEFAULT = null;
 
     /**
-     * The cached value of the '{@link #getLayerFactory() <em>Layer Factory</em>}' containment reference.
-     * <!-- begin-user-doc --> <!-- end-user-doc -->
+     * The cached value of the '{@link #getLayerFactory() <em>Layer Factory</em>}' containment
+     * reference. <!-- begin-user-doc --> <!-- end-user-doc -->
+     *
      * @see #getLayerFactory()
      * @generated not
      * @ordered
@@ -207,8 +215,9 @@ public class MapImpl extends EObjectImpl implements Map {
     protected volatile LayerFactory layerFactory = null;
 
     /**
-     * The cached value of the '{@link #getViewportModelInternal() <em>Viewport Model Internal</em>}' containment reference.
-     * <!-- begin-user-doc --> <!-- end-user-doc -->
+     * The cached value of the '{@link #getViewportModelInternal() <em>Viewport Model
+     * Internal</em>}' containment reference. <!-- begin-user-doc --> <!-- end-user-doc -->
+     *
      * @see #getViewportModelInternal()
      * @generated not
      * @ordered
@@ -216,8 +225,8 @@ public class MapImpl extends EObjectImpl implements Map {
     protected volatile ViewportModel viewportModelInternal = null;
 
     /**
-     * The default value of the '{@link #getColorPalette() <em>Color Palette</em>}' attribute.
-     * <!-- begin-user-doc --> <!-- end-user-doc -->
+     * The default value of the '{@link #getColorPalette() <em>Color Palette</em>}' attribute. <!--
+     * begin-user-doc --> <!-- end-user-doc -->
      *
      * @see #getColorPalette()
      * @generated NOT
@@ -236,8 +245,9 @@ public class MapImpl extends EObjectImpl implements Map {
     protected volatile BrewerPalette colorPalette = null;
 
     /**
-     * The cached value of the '{@link #getEditManagerInternal() <em>Edit Manager Internal</em>}' containment reference.
-     * <!-- begin-user-doc --> <!-- end-user-doc -->
+     * The cached value of the '{@link #getEditManagerInternal() <em>Edit Manager Internal</em>}'
+     * containment reference. <!-- begin-user-doc --> <!-- end-user-doc -->
+     *
      * @see #getEditManagerInternal()
      * @generated not
      * @ordered
@@ -245,8 +255,9 @@ public class MapImpl extends EObjectImpl implements Map {
     protected volatile EditManager editManagerInternal = null;
 
     /**
-     * The cached value of the '{@link #getRenderManagerInternal() <em>Render Manager Internal</em>}' reference.
-     * <!-- begin-user-doc --> <!-- end-user-doc -->
+     * The cached value of the '{@link #getRenderManagerInternal() <em>Render Manager
+     * Internal</em>}' reference. <!-- begin-user-doc --> <!-- end-user-doc -->
+     *
      * @see #getRenderManagerInternal()
      * @generated not
      * @ordered
@@ -254,8 +265,8 @@ public class MapImpl extends EObjectImpl implements Map {
     protected volatile RenderManager renderManagerInternal = null;
 
     /**
-     * The default value of the '{@link #getColourScheme() <em>Colour Scheme</em>}' attribute.
-     * <!-- begin-user-doc --> <!-- end-user-doc -->
+     * The default value of the '{@link #getColourScheme() <em>Colour Scheme</em>}' attribute. <!--
+     * begin-user-doc --> <!-- end-user-doc -->
      *
      * @see #getColourScheme()
      * @generated NOT
@@ -276,8 +287,9 @@ public class MapImpl extends EObjectImpl implements Map {
     protected volatile ColourScheme colourScheme = null;
 
     /**
-     * The cached value of the '{@link #getBlackBoardInternal() <em>Black Board Internal</em>}' containment reference.
-     * <!-- begin-user-doc --> <!-- end-user-doc -->
+     * The cached value of the '{@link #getBlackBoardInternal() <em>Black Board Internal</em>}'
+     * containment reference. <!-- begin-user-doc --> <!-- end-user-doc -->
+     *
      * @see #getBlackBoardInternal()
      * @generated not
      * @ordered
@@ -286,8 +298,8 @@ public class MapImpl extends EObjectImpl implements Map {
 
     /**
      * The cached value of the '{@link #getLegend() <em>Legend</em>}' containment reference list.
-     * <!-- begin-user-doc -->
-     * <!-- end-user-doc -->
+     * <!-- begin-user-doc --> <!-- end-user-doc -->
+     *
      * @see #getLegend()
      * @generated
      * @ordered
@@ -319,6 +331,7 @@ public class MapImpl extends EObjectImpl implements Map {
 
     /**
      * <!-- begin-user-doc --> <!-- end-user-doc -->
+     *
      * @generated
      */
     @Override
@@ -350,6 +363,7 @@ public class MapImpl extends EObjectImpl implements Map {
 
     /**
      * <!-- begin-user-doc --> <!-- end-user-doc -->
+     *
      * @generated
      */
     public Project getProjectInternalGen() {
@@ -368,6 +382,7 @@ public class MapImpl extends EObjectImpl implements Map {
 
     /**
      * <!-- begin-user-doc --> <!-- end-user-doc -->
+     *
      * @generated
      */
     public Project basicGetProjectInternal() {
@@ -376,6 +391,7 @@ public class MapImpl extends EObjectImpl implements Map {
 
     /**
      * <!-- begin-user-doc --> <!-- end-user-doc -->
+     *
      * @generated
      */
     public NotificationChain basicSetProjectInternal(Project newProjectInternal,
@@ -395,6 +411,7 @@ public class MapImpl extends EObjectImpl implements Map {
 
     /**
      * <!-- begin-user-doc --> <!-- end-user-doc -->
+     *
      * @generated NOT
      */
     @Override
@@ -440,6 +457,7 @@ public class MapImpl extends EObjectImpl implements Map {
 
     /**
      * <!-- begin-user-doc --> <!-- end-user-doc -->
+     *
      * @generated
      */
     @SuppressWarnings("deprecation")
@@ -511,6 +529,7 @@ public class MapImpl extends EObjectImpl implements Map {
 
     /**
      * <!-- begin-user-doc --> <!-- end-user-doc -->
+     *
      * @generated
      */
     public NotificationChain basicSetViewportModelInternal(ViewportModel newViewportModelInternal,
@@ -545,6 +564,7 @@ public class MapImpl extends EObjectImpl implements Map {
 
     /**
      * <!-- begin-user-doc --> <!-- end-user-doc -->
+     *
      * @generated
      */
     public void setViewportModelInternalGen(ViewportModel newViewportModelInternal) {
@@ -567,6 +587,7 @@ public class MapImpl extends EObjectImpl implements Map {
 
     /**
      * <!-- begin-user-doc --> <!-- end-user-doc -->
+     *
      * @generated NOT
      */
     @Override
@@ -575,7 +596,7 @@ public class MapImpl extends EObjectImpl implements Map {
             String defaultPalette = ProjectPlugin.getPlugin().getPreferenceStore()
                     .getString(PreferenceConstants.P_DEFAULT_PALETTE);
             if (defaultPalette == null || !PlatformGIS.getColorBrewer().hasPalette(defaultPalette))
-                defaultPalette = "Dark2"; //failsafe default //$NON-NLS-1$
+                defaultPalette = "Dark2"; // failsafe default //$NON-NLS-1$
             colorPalette = PlatformGIS.getColorBrewer().getPalette(defaultPalette);
         }
         return colorPalette;
@@ -583,6 +604,7 @@ public class MapImpl extends EObjectImpl implements Map {
 
     /**
      * <!-- begin-user-doc --> <!-- end-user-doc -->
+     *
      * @generated
      */
     @Override
@@ -596,6 +618,7 @@ public class MapImpl extends EObjectImpl implements Map {
 
     /**
      * <!-- begin-user-doc --> <!-- end-user-doc -->
+     *
      * @generated
      */
     @Override
@@ -605,6 +628,7 @@ public class MapImpl extends EObjectImpl implements Map {
 
     /**
      * <!-- begin-user-doc --> <!-- end-user-doc -->
+     *
      * @generated
      */
     @Override
@@ -618,6 +642,7 @@ public class MapImpl extends EObjectImpl implements Map {
 
     /**
      * <!-- begin-user-doc --> <!-- end-user-doc -->
+     *
      * @generated
      */
     @Override
@@ -627,6 +652,7 @@ public class MapImpl extends EObjectImpl implements Map {
 
     /**
      * <!-- begin-user-doc --> <!-- end-user-doc -->
+     *
      * @generated
      */
     @Override
@@ -686,7 +712,8 @@ public class MapImpl extends EObjectImpl implements Map {
     }
 
     /**
-     * Takes an Extent, usually from a {@link CoordinateReferenceSystem}, and converts it to a ReferencedEnvelope
+     * Takes an Extent, usually from a {@link CoordinateReferenceSystem}, and converts it to a
+     * ReferencedEnvelope
      *
      * @param extent the extent to convert.
      * @param crs the desired CRS of the ReferencedEnvelope.
@@ -806,6 +833,7 @@ public class MapImpl extends EObjectImpl implements Map {
 
     /**
      * <!-- begin-user-doc --> <!-- end-user-doc -->
+     *
      * @generated
      */
     public NotificationChain basicSetLayerFactory(LayerFactory newLayerFactory,
@@ -825,6 +853,7 @@ public class MapImpl extends EObjectImpl implements Map {
 
     /**
      * <!-- begin-user-doc --> <!-- end-user-doc -->
+     *
      * @generated
      */
     @Override
@@ -1020,8 +1049,8 @@ public class MapImpl extends EObjectImpl implements Map {
     }
 
     /**
-     * <!-- begin-user-doc -->
-     * <!-- end-user-doc -->
+     * <!-- begin-user-doc --> <!-- end-user-doc -->
+     *
      * @generated
      */
     @Override
@@ -1065,8 +1094,8 @@ public class MapImpl extends EObjectImpl implements Map {
     }
 
     /**
-     * <!-- begin-user-doc -->
-     * <!-- end-user-doc -->
+     * <!-- begin-user-doc --> <!-- end-user-doc -->
+     *
      * @generated
      */
     @Override
@@ -1094,8 +1123,8 @@ public class MapImpl extends EObjectImpl implements Map {
     }
 
     /**
-     * <!-- begin-user-doc -->
-     * <!-- end-user-doc -->
+     * <!-- begin-user-doc --> <!-- end-user-doc -->
+     *
      * @generated
      */
     @Override
@@ -1138,8 +1167,8 @@ public class MapImpl extends EObjectImpl implements Map {
     }
 
     /**
-     * <!-- begin-user-doc -->
-     * <!-- end-user-doc -->
+     * <!-- begin-user-doc --> <!-- end-user-doc -->
+     *
      * @generated
      */
     @SuppressWarnings("unchecked")
@@ -1188,8 +1217,8 @@ public class MapImpl extends EObjectImpl implements Map {
     }
 
     /**
-     * <!-- begin-user-doc -->
-     * <!-- end-user-doc -->
+     * <!-- begin-user-doc --> <!-- end-user-doc -->
+     *
      * @generated
      */
     @Override
@@ -1236,8 +1265,8 @@ public class MapImpl extends EObjectImpl implements Map {
     }
 
     /**
-     * <!-- begin-user-doc -->
-     * <!-- end-user-doc -->
+     * <!-- begin-user-doc --> <!-- end-user-doc -->
+     *
      * @generated
      */
     @Override
@@ -1296,6 +1325,7 @@ public class MapImpl extends EObjectImpl implements Map {
 
     /**
      * <!-- begin-user-doc --> <!-- end-user-doc -->
+     *
      * @generated
      */
     public NotificationChain basicSetEditManagerInternal(EditManager newEditManagerInternal,
@@ -1316,6 +1346,7 @@ public class MapImpl extends EObjectImpl implements Map {
 
     /**
      * <!-- begin-user-doc --> <!-- end-user-doc -->
+     *
      * @generated
      */
     @Override
@@ -1339,6 +1370,7 @@ public class MapImpl extends EObjectImpl implements Map {
 
     /**
      * <!-- begin-user-doc --> <!-- end-user-doc -->
+     *
      * @generated
      */
     @Override
@@ -1358,6 +1390,7 @@ public class MapImpl extends EObjectImpl implements Map {
 
     /**
      * <!-- begin-user-doc --> <!-- end-user-doc -->
+     *
      * @generated
      */
     public RenderManager basicGetRenderManagerInternal() {
@@ -1366,6 +1399,7 @@ public class MapImpl extends EObjectImpl implements Map {
 
     /**
      * <!-- begin-user-doc --> <!-- end-user-doc -->
+     *
      * @generated
      */
     public NotificationChain basicSetRenderManagerInternal(RenderManager newRenderManagerInternal,
@@ -1386,6 +1420,7 @@ public class MapImpl extends EObjectImpl implements Map {
 
     /**
      * <!-- begin-user-doc --> <!-- end-user-doc -->
+     *
      * @generated
      */
     public void setRenderManagerInternalGen(RenderManager newRenderManagerInternal) {
@@ -1451,6 +1486,7 @@ public class MapImpl extends EObjectImpl implements Map {
 
     /**
      * <!-- begin-user-doc --> <!-- end-user-doc -->
+     *
      * @generated NOT
      */
     @Override
@@ -1463,6 +1499,7 @@ public class MapImpl extends EObjectImpl implements Map {
 
     /**
      * <!-- begin-user-doc --> <!-- end-user-doc -->
+     *
      * @generated
      */
     @Override
@@ -1486,6 +1523,7 @@ public class MapImpl extends EObjectImpl implements Map {
 
     /**
      * <!-- begin-user-doc --> <!-- end-user-doc -->
+     *
      * @generated
      */
     @Override
@@ -1495,6 +1533,7 @@ public class MapImpl extends EObjectImpl implements Map {
 
     /**
      * <!-- begin-user-doc --> <!-- end-user-doc -->
+     *
      * @generated
      */
     public NotificationChain basicSetBlackBoardInternal(Blackboard newBlackBoardInternal,
@@ -1515,6 +1554,7 @@ public class MapImpl extends EObjectImpl implements Map {
 
     /**
      * <!-- begin-user-doc --> <!-- end-user-doc -->
+     *
      * @generated
      */
     @Override
@@ -1539,8 +1579,8 @@ public class MapImpl extends EObjectImpl implements Map {
     }
 
     /**
-     * <!-- begin-user-doc -->
-     * <!-- end-user-doc -->
+     * <!-- begin-user-doc --> <!-- end-user-doc -->
+     *
      * @generated
      */
     @Override
@@ -1554,6 +1594,7 @@ public class MapImpl extends EObjectImpl implements Map {
 
     /**
      * <!-- begin-user-doc --> <!-- end-user-doc -->
+     *
      * @generated
      */
     @Override
@@ -1587,9 +1628,9 @@ public class MapImpl extends EObjectImpl implements Map {
         }
 
         /*
-         * Adapt to an IWorkbenchAdapter. Other aspects of Eclipse can read the
-         * properties we provide access to. (example: Property page dialogs
-         * can read the label and display that in their title.)
+         * Adapt to an IWorkbenchAdapter. Other aspects of Eclipse can read the properties we
+         * provide access to. (example: Property page dialogs can read the label and display that in
+         * their title.)
          */
         if (adapter.isAssignableFrom(IWorkbenchAdapter.class)) {
             return new WorkbenchAdapter() {
@@ -1820,7 +1861,7 @@ public class MapImpl extends EObjectImpl implements Map {
      * Constructs a filter for the provided layer, based on the GeometryFilter.
      */
     private Filter target(Layer layer, Filter filter) {
-        if (!layer.isSelectable()) {
+        if (!layer.getInteraction(Interaction.SELECT)) {
             return Filter.INCLUDE;
         }
         try {

--- a/plugins/org.locationtech.udig.project/src/org/locationtech/udig/project/internal/render/impl/ViewportModelImpl.java
+++ b/plugins/org.locationtech.udig.project/src/org/locationtech/udig/project/internal/render/impl/ViewportModelImpl.java
@@ -65,9 +65,9 @@ import org.opengis.referencing.operation.TransformException;
  */
 public class ViewportModelImpl extends EObjectImpl implements ViewportModel {
     /**
-     * The default value of the '{@link #getCRS() <em>CRS</em>}' attribute.
-     * <!-- begin-user-doc -->
+     * The default value of the '{@link #getCRS() <em>CRS</em>}' attribute. <!-- begin-user-doc -->
      * <!-- end-user-doc -->
+     *
      * @see #getCRS()
      * @generated
      * @ordered
@@ -93,9 +93,9 @@ public class ViewportModelImpl extends EObjectImpl implements ViewportModel {
     protected boolean cRSESet = false;
 
     /**
-     * The default value of the '{@link #getBounds() <em>Bounds</em>}' attribute.
-     * <!-- begin-user-doc -->
-     * <!-- end-user-doc -->
+     * The default value of the '{@link #getBounds() <em>Bounds</em>}' attribute. <!--
+     * begin-user-doc --> <!-- end-user-doc -->
+     *
      * @see #getBounds()
      * @generated
      * @ordered
@@ -104,8 +104,8 @@ public class ViewportModelImpl extends EObjectImpl implements ViewportModel {
             .createFromString(RenderPackage.eINSTANCE.getReferencedEnvelope(), ""); //$NON-NLS-1$
 
     /**
-     * The cached value of the '{@link #getBounds() <em>Bounds</em>}' attribute. <!--
-     * begin-user-doc --> <!-- end-user-doc -->
+     * The cached value of the '{@link #getBounds() <em>Bounds</em>}' attribute. <!-- begin-user-doc
+     * --> <!-- end-user-doc -->
      *
      * @see #getBounds()
      * @generated NOT
@@ -134,8 +134,8 @@ public class ViewportModelImpl extends EObjectImpl implements ViewportModel {
     protected static final double HEIGHT_EDEFAULT = 0.0;
 
     /**
-     * The default value of the '{@link #getWidth() <em>Width</em>}' attribute. <!--
-     * begin-user-doc --> <!-- end-user-doc -->
+     * The default value of the '{@link #getWidth() <em>Width</em>}' attribute. <!-- begin-user-doc
+     * --> <!-- end-user-doc -->
      *
      * @see #getWidth()
      * @generated
@@ -164,8 +164,9 @@ public class ViewportModelImpl extends EObjectImpl implements ViewportModel {
     protected static final Coordinate PIXEL_SIZE_EDEFAULT = null;
 
     /**
-     * The cached value of the '{@link #getRenderManagerInternal() <em>Render Manager Internal</em>}' reference.
-     * <!-- begin-user-doc --> <!-- end-user-doc -->
+     * The cached value of the '{@link #getRenderManagerInternal() <em>Render Manager
+     * Internal</em>}' reference. <!-- begin-user-doc --> <!-- end-user-doc -->
+     *
      * @see #getRenderManagerInternal()
      * @generated
      * @ordered
@@ -173,9 +174,9 @@ public class ViewportModelImpl extends EObjectImpl implements ViewportModel {
     protected RenderManager renderManagerInternal;
 
     /**
-     * The cached value of the '{@link #getPreferredScaleDenominators() <em>Preferred Scale Denominators</em>}' attribute.
-     * <!-- begin-user-doc -->
-     * <!-- end-user-doc -->
+     * The cached value of the '{@link #getPreferredScaleDenominators() <em>Preferred Scale
+     * Denominators</em>}' attribute. <!-- begin-user-doc --> <!-- end-user-doc -->
+     *
      * @see #getPreferredScaleDenominators()
      * @generated
      * @ordered
@@ -194,6 +195,7 @@ public class ViewportModelImpl extends EObjectImpl implements ViewportModel {
 
     /**
      * <!-- begin-user-doc --> <!-- end-user-doc -->
+     *
      * @generated
      */
     @Override
@@ -203,6 +205,7 @@ public class ViewportModelImpl extends EObjectImpl implements ViewportModel {
 
     /**
      * <!-- begin-user-doc --> <!-- end-user-doc -->
+     *
      * @generated
      */
     @Override
@@ -212,7 +215,6 @@ public class ViewportModelImpl extends EObjectImpl implements ViewportModel {
 
     @Override
     public void setCRS(CoordinateReferenceSystem newCRS) {
-        double scale = getScaleDenominator();
         if (newCRS == null)
             throw new IllegalArgumentException("A CRS cannot be null"); //$NON-NLS-1$
         if (newCRS.equals(cRS))
@@ -236,6 +238,7 @@ public class ViewportModelImpl extends EObjectImpl implements ViewportModel {
                     DirectPosition newCenter = transform.transform(position,
                             new DirectPosition2D());
                     setCenter(new Coordinate(newCenter.getOrdinate(0), newCenter.getOrdinate(1)));
+                    double scale = getScaleDenominator();
                     setScale(scale);
                 }
             } catch (FactoryException e) {
@@ -286,6 +289,7 @@ public class ViewportModelImpl extends EObjectImpl implements ViewportModel {
 
     /**
      * <!-- begin-user-doc --> <!-- end-user-doc -->
+     *
      * @generated
      */
     @Override
@@ -343,7 +347,8 @@ public class ViewportModelImpl extends EObjectImpl implements ViewportModel {
                     mapDisplay.getDPI(), referenced);
             if (forceContainBBoxZoom && !finalBounds.contains(newBounds)) {
                 Iterator<Double> tail = getPreferredScaleDenominators().tailSet(scale).iterator();
-                // the tail will include scale because scale is one of the elements in the set.  So drop that
+                // the tail will include scale because scale is one of the elements in the set. So
+                // drop that
                 tail.next();
                 Double nextLargest = tail.next();
                 if (nextLargest != null) {
@@ -471,6 +476,7 @@ public class ViewportModelImpl extends EObjectImpl implements ViewportModel {
 
     /**
      * <!-- begin-user-doc --> <!-- end-user-doc -->
+     *
      * @generated
      */
     @Override
@@ -481,8 +487,8 @@ public class ViewportModelImpl extends EObjectImpl implements ViewportModel {
     }
 
     /**
-     * <!-- begin-user-doc -->
-     * <!-- end-user-doc -->
+     * <!-- begin-user-doc --> <!-- end-user-doc -->
+     *
      * @generated
      */
     public NotificationChain basicSetMapInternal(Map newMapInternal, NotificationChain msgs) {
@@ -493,6 +499,7 @@ public class ViewportModelImpl extends EObjectImpl implements ViewportModel {
 
     /**
      * <!-- begin-user-doc --> <!-- end-user-doc -->
+     *
      * @generated
      */
     public void setMapInternalGen(Map newMapInternal) {
@@ -553,6 +560,7 @@ public class ViewportModelImpl extends EObjectImpl implements ViewportModel {
 
     /**
      * <!-- begin-user-doc --> <!-- end-user-doc -->
+     *
      * @generated
      */
     @Override
@@ -562,6 +570,7 @@ public class ViewportModelImpl extends EObjectImpl implements ViewportModel {
 
     /**
      * <!-- begin-user-doc --> <!-- end-user-doc -->
+     *
      * @generated
      */
     public NotificationChain basicSetRenderManagerInternal(RenderManager newRenderManagerInternal,
@@ -582,6 +591,7 @@ public class ViewportModelImpl extends EObjectImpl implements ViewportModel {
 
     /**
      * <!-- begin-user-doc --> <!-- end-user-doc -->
+     *
      * @generated
      */
     @Override
@@ -645,7 +655,7 @@ public class ViewportModelImpl extends EObjectImpl implements ViewportModel {
     @Override
     public AffineTransform worldToScreenTransform() {
         if (!validState())
-            return new AffineTransform(); //Identity (screen-space is arbitrary here.)
+            return new AffineTransform(); // Identity (screen-space is arbitrary here.)
         // set up the affine transform and calculate scale values
         return worldToScreenTransform(getBounds(),
                 getRenderManagerInternal().getMapDisplay().getDisplaySize());
@@ -801,6 +811,7 @@ public class ViewportModelImpl extends EObjectImpl implements ViewportModel {
 
     /**
      * <!-- begin-user-doc --> <!-- end-user-doc -->
+     *
      * @generated
      */
     @Override
@@ -867,7 +878,7 @@ public class ViewportModelImpl extends EObjectImpl implements ViewportModel {
             eNotify(new ENotificationImpl(this, Notification.SET,
                     RenderPackage.VIEWPORT_MODEL__BOUNDS, oldBounds, bounds));
 
-            //notifyListeners(new ViewportModelEvent(this, EventType.CRS, bounds, oldBounds));
+            // notifyListeners(new ViewportModelEvent(this, EventType.CRS, bounds, oldBounds));
             notifyListeners(new ViewportModelEvent(this, EventType.BOUNDS, bounds, oldBounds));
         }
     }
@@ -923,8 +934,8 @@ public class ViewportModelImpl extends EObjectImpl implements ViewportModel {
     }
 
     /**
-     * <!-- begin-user-doc -->
-     * <!-- end-user-doc -->
+     * <!-- begin-user-doc --> <!-- end-user-doc -->
+     *
      * @generated
      */
     @Override
@@ -946,8 +957,8 @@ public class ViewportModelImpl extends EObjectImpl implements ViewportModel {
     }
 
     /**
-     * <!-- begin-user-doc -->
-     * <!-- end-user-doc -->
+     * <!-- begin-user-doc --> <!-- end-user-doc -->
+     *
      * @generated
      */
     @Override
@@ -963,8 +974,8 @@ public class ViewportModelImpl extends EObjectImpl implements ViewportModel {
     }
 
     /**
-     * <!-- begin-user-doc -->
-     * <!-- end-user-doc -->
+     * <!-- begin-user-doc --> <!-- end-user-doc -->
+     *
      * @generated
      */
     @Override
@@ -978,8 +989,8 @@ public class ViewportModelImpl extends EObjectImpl implements ViewportModel {
     }
 
     /**
-     * <!-- begin-user-doc -->
-     * <!-- end-user-doc -->
+     * <!-- begin-user-doc --> <!-- end-user-doc -->
+     *
      * @generated
      */
     @Override
@@ -1010,8 +1021,8 @@ public class ViewportModelImpl extends EObjectImpl implements ViewportModel {
     }
 
     /**
-     * <!-- begin-user-doc -->
-     * <!-- end-user-doc -->
+     * <!-- begin-user-doc --> <!-- end-user-doc -->
+     *
      * @generated
      */
     @SuppressWarnings("unchecked")
@@ -1047,8 +1058,8 @@ public class ViewportModelImpl extends EObjectImpl implements ViewportModel {
     }
 
     /**
-     * <!-- begin-user-doc -->
-     * <!-- end-user-doc -->
+     * <!-- begin-user-doc --> <!-- end-user-doc -->
+     *
      * @generated
      */
     @Override
@@ -1083,8 +1094,8 @@ public class ViewportModelImpl extends EObjectImpl implements ViewportModel {
     }
 
     /**
-     * <!-- begin-user-doc -->
-     * <!-- end-user-doc -->
+     * <!-- begin-user-doc --> <!-- end-user-doc -->
+     *
      * @generated
      */
     @Override
@@ -1238,8 +1249,8 @@ public class ViewportModelImpl extends EObjectImpl implements ViewportModel {
     }
 
     /**
-     * This method will calculate the current width based on ScaleUtils and
-     * the current RenderManager.
+     * This method will calculate the current width based on ScaleUtils and the current
+     * RenderManager.
      */
     @Override
     public void setScale(double scaleDenominator) {

--- a/plugins/org.locationtech.udig.tool.edit.tests/src/org/locationtech/udig/tools/edit/behaviour/SelectGeometryBehaviourTest.java
+++ b/plugins/org.locationtech.udig.tool.edit.tests/src/org/locationtech/udig/tools/edit/behaviour/SelectGeometryBehaviourTest.java
@@ -1,7 +1,7 @@
-/*
- *    uDig - User Friendly Desktop Internet GIS client
- *    http://udig.refractions.net
- *    (C) 2012, Refractions Research Inc.
+/**
+ * uDig - User Friendly Desktop Internet GIS client
+ * http://udig.refractions.net
+ * (C) 2012, Refractions Research Inc.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -9,7 +9,6 @@
  * License v1.0 (http://udig.refractions.net/files/bsd3-v10.html).
  */
 package org.locationtech.udig.tools.edit.behaviour;
-
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
@@ -62,235 +61,289 @@ import org.opengis.filter.identity.Identifier;
 import org.opengis.filter.spatial.BBOX;
 
 public class SelectGeometryBehaviourTest extends AbstractProjectUITestCase {
-    final int none=MapMouseEvent.NONE;
-    final int ctrl = MapMouseEvent.MOD1_DOWN_MASK;
-    final int shift = MapMouseEvent.SHIFT_DOWN_MASK;
-    final int alt = MapMouseEvent.ALT_DOWN_MASK;
-    final int button1 = MapMouseEvent.BUTTON1;
-    final int button2 = MapMouseEvent.BUTTON2;
-    private org.locationtech.udig.project.internal.Map map;
-    private FeatureCollection<SimpleFeatureType, SimpleFeature>  features;
+    final int none = MapMouseEvent.NONE;
 
-    java.awt.Point SCREEN=new java.awt.Point(500,500);
+    final int ctrl = MapMouseEvent.MOD1_DOWN_MASK;
+
+    final int shift = MapMouseEvent.SHIFT_DOWN_MASK;
+
+    final int alt = MapMouseEvent.ALT_DOWN_MASK;
+
+    final int button1 = MapMouseEvent.BUTTON1;
+
+    final int button2 = MapMouseEvent.BUTTON2;
+
+    private org.locationtech.udig.project.internal.Map map;
+
+    private FeatureCollection<SimpleFeatureType, SimpleFeature> features;
+
+    java.awt.Point SCREEN = new java.awt.Point(500, 500);
+
     private TestHandler handler;
-    
+
     @Before
     public void setUp() throws Exception {
-        map=MapTests.createDefaultMap("Test",3,true,new Dimension(500,500)); //$NON-NLS-1$
-        FeatureStore<SimpleFeatureType, SimpleFeature> resource = map.getLayersInternal().get(0).getResource(FeatureStore.class, null);
-        features=resource.getFeatures();
-        GeometryFactory fac=new GeometryFactory();
-        int i=0;
-        for( FeatureIterator<SimpleFeature> iter=features.features(); iter.hasNext(); ){
+        map = MapTests.createDefaultMap("Test", 3, true, new Dimension(500, 500)); //$NON-NLS-1$
+        FeatureStore<SimpleFeatureType, SimpleFeature> resource = map.getLayersInternal().get(0)
+                .getResource(FeatureStore.class, null);
+        features = resource.getFeatures();
+        GeometryFactory fac = new GeometryFactory();
+        int i = 0;
+        for (FeatureIterator<SimpleFeature> iter = features.features(); iter.hasNext();) {
             i++;
-            SimpleFeature feature=iter.next();
-            Coordinate c=map.getViewportModel().pixelToWorld(i*10,0);
-            FilterFactory filterFactory = CommonFactoryFinder.getFilterFactory(GeoTools.getDefaultHints());
-			Set<Identifier> ids = new HashSet<Identifier>();
-			ids.add(filterFactory.featureId(feature.getID()));
-			GeometryDescriptor defaultGeometry = feature.getFeatureType().getGeometryDescriptor();
-			resource.modifyFeatures(defaultGeometry.getName(), fac.createPoint(c),
+            SimpleFeature feature = iter.next();
+            Coordinate c = map.getViewportModel().pixelToWorld(i * 10, 0);
+            FilterFactory filterFactory = CommonFactoryFinder
+                    .getFilterFactory(GeoTools.getDefaultHints());
+            Set<Identifier> ids = new HashSet<>();
+            ids.add(filterFactory.featureId(feature.getID()));
+            GeometryDescriptor defaultGeometry = feature.getFeatureType().getGeometryDescriptor();
+            resource.modifyFeatures(defaultGeometry.getName(), fac.createPoint(c),
                     filterFactory.id(ids));
         }
-        ((EditManager)map.getEditManager()).commitTransaction();
+        ((EditManager) map.getEditManager()).commitTransaction();
 
-        handler=new TestHandler();
-        ((ToolContext)handler.getContext()).setMapInternal(map);
-        ((ToolContext)handler.getContext()).setRenderManagerInternal(map.getRenderManagerInternal());
+        handler = new TestHandler();
+        ((ToolContext) handler.getContext()).setMapInternal(map);
+        ((ToolContext) handler.getContext())
+                .setRenderManagerInternal(map.getRenderManagerInternal());
     }
-    
-    /*
-     * Test method for 'org.locationtech.udig.tools.edit.mode.MoveVertexMode.isValid(EditToolHandler, MapMouseEvent, EventType)'
+
+    /**
+     * Test method for
+     * 'org.locationtech.udig.tools.edit.mode.MoveVertexMode.isValid(EditToolHandler, MapMouseEvent,
+     * EventType)'
      */
     @Test
     public void testIsValid() throws Exception {
-        SelectFeatureBehaviour mode=new SelectFeatureBehaviour(new Class[]{Polygon.class, MultiPolygon.class}, BBOX.class);
+        SelectFeatureBehaviour mode = new SelectFeatureBehaviour(
+                new Class[] { Polygon.class, MultiPolygon.class }, BBOX.class);
 
-        assertFalse(mode.isValid(handler, new MapMouseEvent(null, 0, 0, none, none, 0), EventType.DOUBLE_CLICK));
+        assertFalse(mode.isValid(handler, new MapMouseEvent(null, 0, 0, none, none, 0),
+                EventType.DOUBLE_CLICK));
 
-        assertTrue(mode.isValid(handler,  new MapMouseEvent(null, 10, 0, none, none, button1), EventType.RELEASED));
+        assertTrue(mode.isValid(handler, new MapMouseEvent(null, 10, 0, none, none, button1),
+                EventType.RELEASED));
         // not valid for drag events
-        assertFalse(mode.isValid(handler, new MapMouseEvent(null, 10, 0, none, none, button1), EventType.DRAGGED));
+        assertFalse(mode.isValid(handler, new MapMouseEvent(null, 10, 0, none, none, button1),
+                EventType.DRAGGED));
         // not valid for exit events
-        assertFalse(mode.isValid(handler, new MapMouseEvent(null, 10, 0, none, none, button1), EventType.EXITED));
+        assertFalse(mode.isValid(handler, new MapMouseEvent(null, 10, 0, none, none, button1),
+                EventType.EXITED));
         // not valid for moved events
-        assertFalse(mode.isValid(handler, new MapMouseEvent(null, 10, 0, none, none, button1), EventType.MOVED));
+        assertFalse(mode.isValid(handler, new MapMouseEvent(null, 10, 0, none, none, button1),
+                EventType.MOVED));
         // not valid for pressed events
-        assertFalse(mode.isValid(handler, new MapMouseEvent(null, 10, 0, none, none, button1), EventType.PRESSED));
+        assertFalse(mode.isValid(handler, new MapMouseEvent(null, 10, 0, none, none, button1),
+                EventType.PRESSED));
 
-        // ctl down is legal
-        assertTrue(mode.isValid(handler, new MapMouseEvent(null, 10,0, ctrl,none, button1), EventType.RELEASED));
+        // ctrl down is legal
+        assertTrue(mode.isValid(handler, new MapMouseEvent(null, 10, 0, ctrl, none, button1),
+                EventType.RELEASED));
         // shift down is legal
-        assertTrue(mode.isValid(handler, new MapMouseEvent(null, 10,0, shift, none, button1), EventType.RELEASED));
+        assertTrue(mode.isValid(handler, new MapMouseEvent(null, 10, 0, shift, none, button1),
+                EventType.RELEASED));
 
-        // ctl down is not legal
-        assertFalse(mode.isValid(handler, new MapMouseEvent(null, 10,0, alt, none, button1), EventType.RELEASED));
+        // ctrl down is not legal
+        assertFalse(mode.isValid(handler, new MapMouseEvent(null, 10, 0, alt, none, button1),
+                EventType.RELEASED));
         // only 1 modifier is legal
-        assertFalse(mode.isValid(handler, new MapMouseEvent(null, 
-                0, 0, shift|ctrl, none, button1), EventType.RELEASED));
-        
+        assertFalse(mode.isValid(handler,
+                new MapMouseEvent(null, 0, 0, shift | ctrl, none, button1), EventType.RELEASED));
+
         // button2 is not legal
-        assertFalse(mode.isValid(handler,  new MapMouseEvent(null, 10, 0, none, none, button2), EventType.RELEASED));
-        
+        assertFalse(mode.isValid(handler, new MapMouseEvent(null, 10, 0, none, none, button2),
+                EventType.RELEASED));
+
         List<EditGeom> geoms = handler.getEditBlackboard().getGeoms();
-        handler.getEditBlackboard().addPoint(10,0, geoms.get(0).getShell());
+        handler.getEditBlackboard().addPoint(10, 0, geoms.get(0).getShell());
         handler.setCurrentShape(handler.getEditBlackboard().getGeoms().get(0).getShell());
     }
 
-    /*
-     * Test method for 'org.locationtech.udig.tools.edit.mode.MoveVertexMode.run(EditToolHandler, MapMouseEvent, EventType)'
+    /**
+     * Test method for 'org.locationtech.udig.tools.edit.mode.MoveVertexMode.run(EditToolHandler,
+     * MapMouseEvent, EventType)'
      */
     @Ignore
     @Test
     public void testRun() throws Exception {
-        SelectFeatureBehaviour mode=new SelectFeatureBehaviour(new Class[]{Point.class}, BBOX.class);
-        
-        Listener l=new Listener();
+        SelectFeatureBehaviour mode = new SelectFeatureBehaviour(new Class[] { Point.class },
+                BBOX.class);
+
+        Listener l = new Listener();
         handler.getBehaviours().add(mode);
         handler.getContext().getMap().getBlackboard().addListener(l);
-        handler.setEditBlackboard(new EditBlackboard(SCREEN.x, 
-                SCREEN.y, map.getViewportModel().worldToScreenTransform(), map.getLayersInternal().get(0).layerToMapTransform()));
+        handler.setEditBlackboard(new EditBlackboard(SCREEN.x, SCREEN.y,
+                map.getViewportModel().worldToScreenTransform(),
+                map.getLayersInternal().get(0).layerToMapTransform()));
         handler.setContext(ApplicationGISInternal.createContext(map));
         handler.getEditBlackboard().getListeners().add(l);
-        
-        handler.handleEvent(new MapMouseEvent(null, 10, 0, none, none, button1), EventType.RELEASED);
-        assertEquals( org.locationtech.udig.tools.edit.support.Point.valueOf(10,0), handler.getCurrentGeom().getShell().getPoint(0));
-        assertTrue( l.set  );
-        assertNull(l.old);
-        assertEquals( handler.getCurrentGeom(), l.current);
 
-        EditGeom geom=l.added.get(l.added.size()-1);
-        handler.handleEvent(new MapMouseEvent(null, 20, 0, none, none, button1), EventType.RELEASED);
-        assertEquals( org.locationtech.udig.tools.edit.support.Point.valueOf(20,0), handler.getCurrentGeom().getShell().getPoint(0));
-        assertTrue( l.set  );
-        assertEquals(geom,l.old);
-        assertEquals( handler.getCurrentGeom(), l.current);
-        assertEquals( 1, handler.getEditBlackboard().getGeoms().size());
-        
-        // add using shift
-        handler.handleEvent(new MapMouseEvent(null, 10, 0, shift, none, button1), EventType.RELEASED);
-        geom=l.added.get(l.added.size()-1);
-        assertEquals(1, handler.getEditBlackboard().getGeoms(20,0).size());
-        assertFalse( l.set  );
-        assertEquals(geom,l.current);
-        assertEquals( geom, handler.getCurrentGeom());
-        assertEquals( 2, handler.getEditBlackboard().getGeoms().size());
-        
-        // add using ctrl
-        handler.handleEvent(new MapMouseEvent(null, 30, 0, ctrl, none, button1), EventType.RELEASED);
-        geom=l.added.get(l.added.size()-1);
-        assertEquals(1, handler.getEditBlackboard().getGeoms(30,0).size());
-        assertFalse( l.set  );
-        assertEquals( geom, handler.getCurrentGeom());
-        assertEquals( 3, handler.getEditBlackboard().getGeoms().size());
-        
-        // remove using ctrl
-        handler.handleEvent(new MapMouseEvent(null, 30, 0, ctrl, none, button1), EventType.RELEASED);
-        assertEquals(0, handler.getEditBlackboard().getGeoms(30,0).size());
-        assertEquals( 2, handler.getEditBlackboard().getGeoms().size());
-        
-        // click on nothing and all should be deselected
-        handler.handleEvent( new MapMouseEvent(null, 0, 0, none, none, button1), EventType.RELEASED);
-        assertEquals(0, handler.getEditBlackboard().getGeoms(20,0).size());
-        assertEquals( 1, handler.getEditBlackboard().getGeoms().size());
+        handler.handleEvent(new MapMouseEvent(null, 10, 0, none, none, button1),
+                EventType.RELEASED);
+        assertEquals(org.locationtech.udig.tools.edit.support.Point.valueOf(10, 0),
+                handler.getCurrentGeom().getShell().getPoint(0));
         assertTrue(l.set);
-        assertNull( handler.getCurrentGeom() );
-        
+        assertNull(l.old);
+        assertEquals(handler.getCurrentGeom(), l.current);
+
+        EditGeom geom = l.added.get(l.added.size() - 1);
+        handler.handleEvent(new MapMouseEvent(null, 20, 0, none, none, button1),
+                EventType.RELEASED);
+        assertEquals(org.locationtech.udig.tools.edit.support.Point.valueOf(20, 0),
+                handler.getCurrentGeom().getShell().getPoint(0));
+        assertTrue(l.set);
+        assertEquals(geom, l.old);
+        assertEquals(handler.getCurrentGeom(), l.current);
+        assertEquals(1, handler.getEditBlackboard().getGeoms().size());
+
+        // add using shift
+        handler.handleEvent(new MapMouseEvent(null, 10, 0, shift, none, button1),
+                EventType.RELEASED);
+        geom = l.added.get(l.added.size() - 1);
+        assertEquals(1, handler.getEditBlackboard().getGeoms(20, 0).size());
+        assertFalse(l.set);
+        assertEquals(geom, l.current);
+        assertEquals(geom, handler.getCurrentGeom());
+        assertEquals(2, handler.getEditBlackboard().getGeoms().size());
+
+        // add using ctrl
+        handler.handleEvent(new MapMouseEvent(null, 30, 0, ctrl, none, button1),
+                EventType.RELEASED);
+        geom = l.added.get(l.added.size() - 1);
+        assertEquals(1, handler.getEditBlackboard().getGeoms(30, 0).size());
+        assertFalse(l.set);
+        assertEquals(geom, handler.getCurrentGeom());
+        assertEquals(3, handler.getEditBlackboard().getGeoms().size());
+
+        // remove using ctrl
+        handler.handleEvent(new MapMouseEvent(null, 30, 0, ctrl, none, button1),
+                EventType.RELEASED);
+        assertEquals(0, handler.getEditBlackboard().getGeoms(30, 0).size());
+        assertEquals(2, handler.getEditBlackboard().getGeoms().size());
+
+        // click on nothing and all should be deselected
+        handler.handleEvent(new MapMouseEvent(null, 0, 0, none, none, button1), EventType.RELEASED);
+        assertEquals(0, handler.getEditBlackboard().getGeoms(20, 0).size());
+        assertEquals(1, handler.getEditBlackboard().getGeoms().size());
+        assertTrue(l.set);
+        assertNull(handler.getCurrentGeom());
+
     }
-    
+
     @Test
     public void testSelectMultiGeom() throws Exception {
-        SelectFeatureBehaviour mode=new SelectFeatureBehaviour(new Class[]{MultiLineString.class}, BBOX.class);
+        SelectFeatureBehaviour mode = new SelectFeatureBehaviour(
+                new Class[] { MultiLineString.class }, BBOX.class);
 
         handler.getBehaviours().add(mode);
-        handler.setEditBlackboard(new EditBlackboard(500,500, map.getViewportModel().worldToScreenTransform(), 
-                map.getLayersInternal().get(0).layerToMapTransform()));
-        
-        FeatureStore<SimpleFeatureType, SimpleFeature> resource = map.getLayersInternal().get(0).getResource(FeatureStore.class, null);
-        GeometryFactory factory=new GeometryFactory();
-        LineString line1=factory.createLineString(new Coordinate[]{
-                map.getViewportModel().pixelToWorld(10,10), map.getViewportModel().pixelToWorld(10,20)
-        });
-        LineString line2=factory.createLineString(new Coordinate[]{
-                map.getViewportModel().pixelToWorld(20,10), map.getViewportModel().pixelToWorld(20,20)
-        });
-        
-        MultiLineString multiline = factory.createMultiLineString(new LineString[]{line1, line2});
-        
-        SimpleFeature feature = SimpleFeatureBuilder.build(resource.getSchema(), 
-        		new Object[]{multiline, "multiline"}, "testGeom"); //$NON-NLS-1$
-        Set<Identifier> ids = new HashSet<Identifier>();
-        FilterFactory filterFactory = CommonFactoryFinder.getFilterFactory(GeoTools.getDefaultHints());
-        ids.add(filterFactory.featureId(features.features().next().getID()));
-		resource.modifyFeatures(feature.getFeatureType().getGeometryDescriptor().getName(), multiline,
-                filterFactory.id(ids));
-    
-        
-        handler.handleEvent(new MapMouseEvent(null, 20, 15, none, none, button1), EventType.RELEASED);
-        
-        assertTrue(handler.getCurrentShape().hasVertex(org.locationtech.udig.tools.edit.support.Point.valueOf(20,10)));
-        assertTrue(handler.getCurrentShape().hasVertex(org.locationtech.udig.tools.edit.support.Point.valueOf(20,20)));
-        assertFalse(handler.getCurrentShape().hasVertex(org.locationtech.udig.tools.edit.support.Point.valueOf(10,10)));
-        assertFalse(handler.getCurrentShape().hasVertex(org.locationtech.udig.tools.edit.support.Point.valueOf(10,20)));
+        handler.setEditBlackboard(
+                new EditBlackboard(500, 500, map.getViewportModel().worldToScreenTransform(),
+                        map.getLayersInternal().get(0).layerToMapTransform()));
 
-        handler.handleEvent(new MapMouseEvent(null, 10, 15, none, none, button1), EventType.RELEASED);
-        
-        assertTrue(handler.getCurrentShape().hasVertex(org.locationtech.udig.tools.edit.support.Point.valueOf(10,10)));
-        assertTrue(handler.getCurrentShape().hasVertex(org.locationtech.udig.tools.edit.support.Point.valueOf(10,20)));
-        assertFalse(handler.getCurrentShape().hasVertex(org.locationtech.udig.tools.edit.support.Point.valueOf(20,10)));
-        assertFalse(handler.getCurrentShape().hasVertex(org.locationtech.udig.tools.edit.support.Point.valueOf(20,20)));
-    
+        FeatureStore<SimpleFeatureType, SimpleFeature> resource = map.getLayersInternal().get(0)
+                .getResource(FeatureStore.class, null);
+        GeometryFactory factory = new GeometryFactory();
+        LineString line1 = factory
+                .createLineString(new Coordinate[] { map.getViewportModel().pixelToWorld(10, 10),
+                        map.getViewportModel().pixelToWorld(10, 20) });
+        LineString line2 = factory
+                .createLineString(new Coordinate[] { map.getViewportModel().pixelToWorld(20, 10),
+                        map.getViewportModel().pixelToWorld(20, 20) });
+
+        MultiLineString multiline = factory
+                .createMultiLineString(new LineString[] { line1, line2 });
+
+        SimpleFeature feature = SimpleFeatureBuilder.build(resource.getSchema(),
+                new Object[] { multiline, "multiline" }, "testGeom"); //$NON-NLS-1$ //$NON-NLS-2$
+        Set<Identifier> ids = new HashSet<>();
+        FilterFactory filterFactory = CommonFactoryFinder
+                .getFilterFactory(GeoTools.getDefaultHints());
+        ids.add(filterFactory.featureId(features.features().next().getID()));
+        resource.modifyFeatures(feature.getFeatureType().getGeometryDescriptor().getName(),
+                multiline, filterFactory.id(ids));
+
+        handler.handleEvent(new MapMouseEvent(null, 20, 15, none, none, button1),
+                EventType.RELEASED);
+
+        assertTrue(handler.getCurrentShape()
+                .hasVertex(org.locationtech.udig.tools.edit.support.Point.valueOf(20, 10)));
+        assertTrue(handler.getCurrentShape()
+                .hasVertex(org.locationtech.udig.tools.edit.support.Point.valueOf(20, 20)));
+        assertFalse(handler.getCurrentShape()
+                .hasVertex(org.locationtech.udig.tools.edit.support.Point.valueOf(10, 10)));
+        assertFalse(handler.getCurrentShape()
+                .hasVertex(org.locationtech.udig.tools.edit.support.Point.valueOf(10, 20)));
+
+        handler.handleEvent(new MapMouseEvent(null, 10, 15, none, none, button1),
+                EventType.RELEASED);
+
+        assertTrue(handler.getCurrentShape()
+                .hasVertex(org.locationtech.udig.tools.edit.support.Point.valueOf(10, 10)));
+        assertTrue(handler.getCurrentShape()
+                .hasVertex(org.locationtech.udig.tools.edit.support.Point.valueOf(10, 20)));
+        assertFalse(handler.getCurrentShape()
+                .hasVertex(org.locationtech.udig.tools.edit.support.Point.valueOf(20, 10)));
+        assertFalse(handler.getCurrentShape()
+                .hasVertex(org.locationtech.udig.tools.edit.support.Point.valueOf(20, 20)));
+
     }
 
-    class Listener extends EditBlackboardAdapter implements IBlackboardListener{
+    class Listener extends EditBlackboardAdapter implements IBlackboardListener {
         List<EditGeom> added;
-        boolean set=false;
+
+        boolean set = false;
+
         EditGeom old;
+
         EditGeom current;
-        
+
         @SuppressWarnings("unchecked")
         @Override
-        public void changed( EditBlackboardEvent e ) {
-            
-            switch( e.getType() ) {
+        public void changed(EditBlackboardEvent e) {
+
+            switch (e.getType()) {
             case SET_GEOMS:
-                set=true;
-                added=(List<EditGeom>) e.getNewValue();
+                set = true;
+                added = (List<EditGeom>) e.getNewValue();
                 break;
             case ADD_GEOMS:
-                set=false;
-                added=(List<EditGeom>) e.getNewValue();
+                set = false;
+                added = (List<EditGeom>) e.getNewValue();
                 break;
             case REMOVE_GEOMS:
-                set=true;
-                added=(List<EditGeom>) e.getNewValue();
+                set = true;
+                added = (List<EditGeom>) e.getNewValue();
                 break;
 
             default:
-                
+
                 break;
             }
         }
-        
+
         @Override
-        public void batchChange( List<EditBlackboardEvent> e ) {
-            for( EditBlackboardEvent event : e ) {
+        public void batchChange(List<EditBlackboardEvent> e) {
+            for (EditBlackboardEvent event : e) {
                 changed(event);
             }
         }
-        
-        public void blackBoardChanged( BlackboardEvent event ) {
-            if( event.getKey()==EditToolHandler.CURRENT_SHAPE){
-                if( event.getNewValue()==null )
-                    this.current=null;
+
+        @Override
+        public void blackBoardChanged(BlackboardEvent event) {
+            if (event.getKey() == EditToolHandler.CURRENT_SHAPE) {
+                if (event.getNewValue() == null)
+                    this.current = null;
                 else
-                    this.current=((PrimitiveShape) event.getNewValue()).getEditGeom();
-                if( event.getOldValue()!=null )
-                    this.old=((PrimitiveShape) event.getOldValue()).getEditGeom();      
+                    this.current = ((PrimitiveShape) event.getNewValue()).getEditGeom();
+                if (event.getOldValue() != null)
+                    this.old = ((PrimitiveShape) event.getOldValue()).getEditGeom();
             }
         }
 
-        public void blackBoardCleared( IBlackboard source ) {
+        @Override
+        public void blackBoardCleared(IBlackboard source) {
+
         }
 
     }

--- a/plugins/org.locationtech.udig.tool.edit.tests/src/org/locationtech/udig/tools/edit/impl/SelectionToolTest.java
+++ b/plugins/org.locationtech.udig.tool.edit.tests/src/org/locationtech/udig/tools/edit/impl/SelectionToolTest.java
@@ -1,4 +1,5 @@
-/* uDig - User Friendly Desktop Internet GIS client
+/**
+ * uDig - User Friendly Desktop Internet GIS client
  * http://udig.refractions.net
  * (C) 2004, Refractions Research Inc.
  *
@@ -25,7 +26,6 @@ import org.locationtech.jts.geom.GeometryFactory;
 import org.locationtech.jts.geom.LinearRing;
 import org.locationtech.udig.TestViewportPane;
 import org.locationtech.udig.core.internal.FeatureUtils;
-import org.locationtech.udig.project.ILayer;
 import org.locationtech.udig.project.internal.EditManager;
 import org.locationtech.udig.project.internal.render.RenderManager;
 import org.locationtech.udig.project.ui.render.displayAdapter.MapMouseEvent;
@@ -38,74 +38,82 @@ import org.opengis.feature.simple.SimpleFeatureType;
 import org.opengis.filter.FilterFactory;
 
 /**
- * Test the SelectionToolTest 
+ * Test the SelectionToolTest
+ *
  * @author jones
  * @since 1.1.0
  */
-public class SelectionToolTest extends AbstractToolTest{
+public class SelectionToolTest extends AbstractToolTest {
 
     @Before
     public void setUp() throws Exception {
-        handler=new TestHandler(3);
-        
-        FeatureStore<SimpleFeatureType, SimpleFeature> source = ((ILayer) handler.getContext().getMapLayers().get(0)).getResource(FeatureStore.class, null);
-        FilterFactory filterFac=CommonFactoryFinder.getFilterFactory(GeoTools.getDefaultHints());
-        GeometryFactory geomFac=new GeometryFactory();
-        int i=0;
-        for( FeatureIterator<SimpleFeature> iter = source.getFeatures().features(); iter.hasNext(); ){
+        handler = new TestHandler(3);
+
+        FeatureStore<SimpleFeatureType, SimpleFeature> source = handler.getContext().getMapLayers()
+                .get(0).getResource(FeatureStore.class, null);
+        FilterFactory filterFac = CommonFactoryFinder.getFilterFactory(GeoTools.getDefaultHints());
+        GeometryFactory geomFac = new GeometryFactory();
+        int i = 0;
+        for (FeatureIterator<SimpleFeature> iter = source.getFeatures().features(); iter
+                .hasNext();) {
             SimpleFeature feature = iter.next();
-            source.modifyFeatures(feature.getFeatureType().getDescriptor("name").getName(), "feature"+i, filterFac.id(FeatureUtils.stringToId(filterFac, feature.getID())));  //$NON-NLS-1$//$NON-NLS-2$
+            source.modifyFeatures(feature.getFeatureType().getDescriptor("name").getName(), //$NON-NLS-1$
+                    "feature" + i, //$NON-NLS-1$
+                    filterFac.id(FeatureUtils.stringToId(filterFac, feature.getID())));
             Geometry geom;
-            if( i==0 ){
-                geom=geomFac.createPoint(new Coordinate(0,10));
-            }else if( i==1 ){
-                geom=geomFac.createLineString(new Coordinate[]{
-                        new Coordinate( 10,10), new Coordinate(10,20)
-                });
-            }else{
-                geom=geomFac.createLinearRing(
-                        new Coordinate[]{
-                                new Coordinate( 20,10), new Coordinate(40,10),
-                                new Coordinate( 40,40), new Coordinate(20,40),
-                                new Coordinate( 20,10)
-                        }
-                );
-                geom=geomFac.createPolygon((LinearRing) geom, new LinearRing[0]);
+            if (i == 0) {
+                geom = geomFac.createPoint(new Coordinate(0, 10));
+            } else if (i == 1) {
+                geom = geomFac.createLineString(
+                        new Coordinate[] { new Coordinate(10, 10), new Coordinate(10, 20) });
+            } else {
+                geom = geomFac.createLinearRing(new Coordinate[] { new Coordinate(20, 10),
+                        new Coordinate(40, 10), new Coordinate(40, 40), new Coordinate(20, 40),
+                        new Coordinate(20, 10) });
+                geom = geomFac.createPolygon((LinearRing) geom, new LinearRing[0]);
             }
-            source.modifyFeatures(feature.getFeatureType().getGeometryDescriptor().getName(), geom, filterFac.id(FeatureUtils.stringToId(filterFac, feature.getID())));
+            source.modifyFeatures(feature.getFeatureType().getGeometryDescriptor().getName(), geom,
+                    filterFac.id(FeatureUtils.stringToId(filterFac, feature.getID())));
             i++;
         }
         ((EditManager) handler.getContext().getEditManager()).commitTransaction();
-        ((RenderManager)handler.getContext().getRenderManager()).setMapDisplay(new TestViewportPane(new Dimension(500,500)));
-        
+        ((RenderManager) handler.getContext().getRenderManager())
+                .setMapDisplay(new TestViewportPane(new Dimension(500, 500)));
+
         tool.setHandler(handler);
-        
+
         tool.testinitEventBehaviours(new EditToolConfigurationHelper(handler.getBehaviours()));
-        
+
     }
-    
+
     @Override
     protected AbstractEditTool createTool() {
         return new SelectionTool();
     }
-    
+
     @Test
-    public void testSelect1FeatureThenAnother() throws Exception{
-        
-        Point p=handler.getEditBlackboard().toPoint(new Coordinate(0,10));
-        tool.mouseReleased(new MapMouseEvent(handler.getContext().getMapDisplay(), p.getX(), p.getY(), 0,0,MapMouseEvent.BUTTON1));
-        
-        assertEquals("feature0", handler.getContext().getEditManager().getEditFeature().getAttribute("name"));  //$NON-NLS-1$//$NON-NLS-2$
+    public void testSelect1FeatureThenAnother() throws Exception {
 
-        p=handler.getEditBlackboard().toPoint(new Coordinate(10,15));
-        tool.mouseReleased(new MapMouseEvent(handler.getContext().getMapDisplay(), p.getX(), p.getY(), 0,0,MapMouseEvent.BUTTON1));
-        
-        assertEquals("feature1", handler.getContext().getEditManager().getEditFeature().getAttribute("name")); //$NON-NLS-1$ //$NON-NLS-2$
+        Point p = handler.getEditBlackboard().toPoint(new Coordinate(0, 10));
+        tool.mouseReleased(
+                new MapMouseEvent(handler.getContext().getMapDisplay(), p.getX(), p.getY(), 0, 0, MapMouseEvent.BUTTON1));
 
-        p=handler.getEditBlackboard().toPoint(new Coordinate(30,30));
-        tool.mouseReleased(new MapMouseEvent(handler.getContext().getMapDisplay(), p.getX(), p.getY(), 0,0,MapMouseEvent.BUTTON1));
-        
-        assertEquals("feature2", handler.getContext().getEditManager().getEditFeature().getAttribute("name")); //$NON-NLS-1$ //$NON-NLS-2$
+        assertEquals("feature0", //$NON-NLS-1$
+                handler.getContext().getEditManager().getEditFeature().getAttribute("name")); //$NON-NLS-1$
+
+        p = handler.getEditBlackboard().toPoint(new Coordinate(10, 15));
+        tool.mouseReleased(new MapMouseEvent(handler.getContext().getMapDisplay(), p.getX(),
+                p.getY(), 0, 0, MapMouseEvent.BUTTON1));
+
+        assertEquals("feature1", //$NON-NLS-1$
+                handler.getContext().getEditManager().getEditFeature().getAttribute("name")); //$NON-NLS-1$
+
+        p = handler.getEditBlackboard().toPoint(new Coordinate(30, 30));
+        tool.mouseReleased(new MapMouseEvent(handler.getContext().getMapDisplay(), p.getX(),
+                p.getY(), 0, 0, MapMouseEvent.BUTTON1));
+
+        assertEquals("feature2", //$NON-NLS-1$
+                handler.getContext().getEditManager().getEditFeature().getAttribute("name")); //$NON-NLS-1$
     }
-    
+
 }


### PR DESCRIPTION
Within this PR I want to remove the following functions from the interface `ILayer` which are deprecated for quite a while:

1. `public boolean isSelectable();`
2. `void setSelectable(boolean value);`
3. `CoordinateReferenceSystem getCRS(IProgressMonitor monitor);`