### PR TITLE
Fix most of the SonarQube issues in class 'FeaturePropertySource'

### DIFF
--- a/plugins/org.locationtech.udig.project.ui/src/org/locationtech/udig/project/ui/internal/properties/FeaturePropertySource.java
+++ b/plugins/org.locationtech.udig.project.ui/src/org/locationtech/udig/project/ui/internal/properties/FeaturePropertySource.java
@@ -1,7 +1,7 @@
-/*
- *    uDig - User Friendly Desktop Internet GIS client
- *    http://udig.refractions.net
- *    (C) 2004, Refractions Research Inc.
+/**
+ * uDig - User Friendly Desktop Internet GIS client
+ * http://udig.refractions.net
+ * (C) 2004, Refractions Research Inc.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -41,112 +41,117 @@ import org.opengis.util.CodeList;
 /**
  * An adapter that allows features to act as a property source for a property sheet. The sheet
  * allows the victim's attributes to be edited and viewed.
- * 
+ *
  * @author jeichar
  * @since 0.3
  */
 public class FeaturePropertySource implements IPropertySource2 {
     private static final String ID = "ID"; //$NON-NLS-1$
+
     private static final String DEFAULT_GEOM = "DEFAULT_GEOM"; //$NON-NLS-1$
+
     private static final String BOUNDING_BOX = "BOUNDING_BOX"; //$NON-NLS-1$
+
     private static final String FEATURE = "FEATURE"; //$NON-NLS-1$
-    
+
     private SimpleFeature feature = null;
+
     private SimpleFeature old = null;
-    
-    private Map<Geometry, Object> geomProperties = new HashMap<Geometry, Object>();
-    private Map<AttributeDescriptor,Object> attrProperties = new HashMap<AttributeDescriptor,Object>();
+
+    private Map<Geometry, Object> geomProperties = new HashMap<>();
+
+    private Map<AttributeDescriptor, Object> attrProperties = new HashMap<>();
+
     private List<AttributeDescriptor> attrs;
+
     private IPropertyDescriptor[] descriptors;
+
     private boolean attribute;
-    
-    /** Are the attributes editable in cell editors. */ 
+
+    /** Are the attributes editable in cell editors. */
     private boolean editable = true;
+
     private IMap map;
 
     /**
      * Creates a new instance of FeaturePropertySource
-     * 
+     *
      * @param feature The feature that this property source refers to.
      */
-    public FeaturePropertySource( SimpleFeature feature ) {
+    public FeaturePropertySource(SimpleFeature feature) {
         this(feature, false);
     }
+
     /**
      * Creates a new instance of FeaturePropertySource
-     * 
+     *
      * @param feature2
      * @param attribute
      */
-    public FeaturePropertySource( SimpleFeature feature2, boolean attribute ) {
-        boolean editable=false;
-        if( feature2 instanceof IAdaptable ){
-            IAdaptable adaptable = (IAdaptable)feature2;
-            if( adaptable.getAdapter(ILayer.class)!=null 
-                    || adaptable.getAdapter(IMap.class)!=null ){
-                editable=true;
+    public FeaturePropertySource(SimpleFeature feature2, boolean attribute) {
+        boolean local_editable = false;
+        if (feature2 instanceof IAdaptable) {
+            IAdaptable adaptable = (IAdaptable) feature2;
+            if (adaptable.getAdapter(ILayer.class) != null
+                    || adaptable.getAdapter(IMap.class) != null) {
+                local_editable = true;
             }
         }
-    	init( feature2, attribute, editable);
+        init(feature2, attribute, local_editable);
 
     }
-    
-    public FeaturePropertySource( SimpleFeature feature2, boolean attribute, boolean editable ){
+
+    public FeaturePropertySource(SimpleFeature feature2, boolean attribute, boolean editable) {
         init(feature2, attribute, editable);
     }
-    
-    private void init( SimpleFeature feature2, boolean attribute, boolean editable ) {
+
+    private void init(SimpleFeature feature2, boolean attribute, boolean editable) {
         this.feature = feature2;
         try {
-            if (feature2 != null)
+            if (feature2 != null) {
                 old = SimpleFeatureBuilder.copy(feature);
+            }
         } catch (Exception e) {
             e.printStackTrace();
         }
         this.attribute = attribute;
         this.editable = editable;
-        if( editable ){
-            IAdaptable adaptable = (IAdaptable)feature2;
-            if( adaptable.getAdapter(ILayer.class)!=null ){
-                ILayer layer=(ILayer) adaptable.getAdapter(ILayer.class);
-                map=layer.getMap();
-            }else if( adaptable.getAdapter(IMap.class)!=null ){
-                map = (IMap) adaptable.getAdapter(IMap.class);
-            }else{
-                map=ApplicationGIS.getActiveMap();
+        if (editable) {
+            IAdaptable adaptable = (IAdaptable) feature2;
+            if (adaptable != null && adaptable.getAdapter(ILayer.class) != null) {
+                ILayer layer = adaptable.getAdapter(ILayer.class);
+                map = layer.getMap();
+            } else if (adaptable != null && adaptable.getAdapter(IMap.class) != null) {
+                map = adaptable.getAdapter(IMap.class);
+            } else {
+                map = ApplicationGIS.getActiveMap();
             }
 
         }
     }
-    
-    /**
-     * @see org.eclipse.ui.views.properties.IPropertySource#getEditableValue()
-     */
+
+    @Override
     public Object getEditableValue() {
         return ""; //$NON-NLS-1$
     }
-    
-    /**
-     * @see org.eclipse.ui.views.properties.IPropertySource#getPropertyDescriptors()
-     */
+
+    @Override
     public IPropertyDescriptor[] getPropertyDescriptors() {
         if (descriptors == null) {
             boolean hasAttrs = false;
-            List<IPropertyDescriptor> descrps = new ArrayList<IPropertyDescriptor>();
+            List<IPropertyDescriptor> descrps = new ArrayList<>();
             PropertyDescriptor d = new PropertyDescriptor(ID, "ID"); //$NON-NLS-1$
-            d.setCategory(Messages.FeaturePropertySource_feature); 
+            d.setCategory(Messages.FeaturePropertySource_feature);
             descrps.add(d);
-            d = new GeometryPropertyDescriptor(DEFAULT_GEOM, 
-            		Messages.FeaturePropertySource_defaultGeometry);
-            d.setCategory(Messages.FeaturePropertySource_geometries); 
+            d = new GeometryPropertyDescriptor(DEFAULT_GEOM,
+                    Messages.FeaturePropertySource_defaultGeometry);
+            d.setCategory(Messages.FeaturePropertySource_geometries);
             descrps.add(d);
-            d = new PropertyDescriptor(BOUNDING_BOX, Messages.FeaturePropertySource_bounds); 
-            d.setCategory(Messages.FeaturePropertySource_feature); 
-            d.setLabelProvider(new LabelProvider(){
-                /**
-                 * @see org.eclipse.jface.viewers.LabelProvider#getText(java.lang.Object)
-                 */
-                public String getText( Object element ) {
+            d = new PropertyDescriptor(BOUNDING_BOX, Messages.FeaturePropertySource_bounds);
+            d.setCategory(Messages.FeaturePropertySource_feature);
+            d.setLabelProvider(new LabelProvider() {
+                @Override
+                public String getText(Object element) {
                     Envelope bbox = (Envelope) element;
                     String minx = String.valueOf(bbox.getMinX());
                     minx = minx.substring(0, Math.min(10, minx.length()));
@@ -165,14 +170,15 @@ public class FeaturePropertySource implements IPropertySource2 {
                 attrs = ft.getAttributeDescriptors();
                 int i = -1;
                 for (AttributeDescriptor at : attrs) {
-                	i++;
+                    i++;
                     String name = at.getName().getLocalPart().toLowerCase();
                     name = name.substring(0, 1).toUpperCase() + name.substring(1);
-                    if ( at instanceof GeometryDescriptor ) {
-                        if (feature.getAttribute(at.getLocalName()) != feature.getDefaultGeometry()) {
-                            d = new GeometryPropertyDescriptor(Integer.valueOf(i), name
-                                    + Messages.FeaturePropertySource_geometry); 
-                            d.setCategory(Messages.FeaturePropertySource_geometries); 
+                    if (at instanceof GeometryDescriptor) {
+                        if (feature.getAttribute(at.getLocalName()) != feature
+                                .getDefaultGeometry()) {
+                            d = new GeometryPropertyDescriptor(Integer.valueOf(i),
+                                    name + Messages.FeaturePropertySource_geometry);
+                            d.setCategory(Messages.FeaturePropertySource_geometries);
                             descrps.add(d);
                         }
                     } else {
@@ -181,50 +187,37 @@ public class FeaturePropertySource implements IPropertySource2 {
                         } else if (Collection.class.isAssignableFrom(at.getType().getBinding()))
                             d = new PropertyDescriptor(Integer.valueOf(i), name);
                         else {
-                            d = new AttributePropertyDescriptor(Integer.valueOf(i), name, at, ft, editable);
-                            // if (String.class.isAssignableFrom(at.getType()))
-                            // d = new TextPropertyDescriptor(Integer.valueOf(i), name);
-                            // if (Integer.class.isAssignableFrom(at.getType()))
-                            // d = new TextPropertyDescriptor(Integer.valueOf(i), name);
-                            // if (Double.class.isAssignableFrom(at.getType()))
-                            // d = new TextPropertyDescriptor(Integer.valueOf(i), name);
-                            // if (Boolean.class.isAssignableFrom(at.getType()))
-                            // d = new ComboBoxPropertyDescriptor(Integer.valueOf(i), name,
-                            // new String[]{"true","false"});
-                            // if (Float.class.isAssignableFrom(at.getType()))
-                            // d = new TextPropertyDescriptor(Integer.valueOf(i), name);
+                            d = new AttributePropertyDescriptor(Integer.valueOf(i), name, at, ft,
+                                    editable);
                         }
-                        // d.setValidator(new AttributeValidator(at));
 
                         if (name.equalsIgnoreCase("name")) { //$NON-NLS-1$
-                            d.setCategory(Messages.FeaturePropertySource_feature); 
+                            d.setCategory(Messages.FeaturePropertySource_feature);
                             descrps.add(0, d);
                         } else {
                             hasAttrs = true;
-                            d.setCategory(Messages.FeaturePropertySource_featureAttributes); 
+                            d.setCategory(Messages.FeaturePropertySource_featureAttributes);
                             descrps.add(d);
                         }
                     }
                 }
             }
             if (!hasAttrs) {
-                d = new PropertyDescriptor(
-                        "", Messages.FeaturePropertySource_noOtherAttributes);   //$NON-NLS-1$
-                d.setCategory(Messages.FeaturePropertySource_featureAttributes); 
+                d = new PropertyDescriptor("", Messages.FeaturePropertySource_noOtherAttributes); //$NON-NLS-1$
+                d.setCategory(Messages.FeaturePropertySource_featureAttributes);
                 descrps.add(d);
             }
             descriptors = new IPropertyDescriptor[descrps.size()];
             descrps.toArray(descriptors);
         }
 
-        IPropertyDescriptor[] c=new IPropertyDescriptor[descriptors.length];
+        IPropertyDescriptor[] c = new IPropertyDescriptor[descriptors.length];
         System.arraycopy(descriptors, 0, c, 0, c.length);
         return c;
     }
-    /**
-     * @see org.eclipse.ui.views.properties.IPropertySource#getPropertyValue(java.lang.Object)
-     */
-    public Object getPropertyValue( Object id ) {
+
+    @Override
+    public Object getPropertyValue(Object id) {
         if (id instanceof String) {
             String sid = (String) id;
             if (sid.equals(ID))
@@ -241,22 +234,26 @@ public class FeaturePropertySource implements IPropertySource2 {
         if (id instanceof Integer) {
             Integer i = (Integer) id;
             AttributeDescriptor attrType = attrs.get(i.intValue());
-            if ( attrType instanceof GeometryDescriptor ) 
+            if (attrType instanceof GeometryDescriptor) {
                 return getGeomProperty((Geometry) feature.getAttribute(i.intValue()));
-            if (Collection.class.isAssignableFrom(attrType.getType().getBinding()))
+            }
+            if (Collection.class.isAssignableFrom(attrType.getType().getBinding())) {
                 return getAttrProperty(attrType, feature.getAttribute(i.intValue()));
-            // return feature.getAttribute(i.intValue()).toString();
+            }
+
             Object attr = feature.getAttribute(i.intValue());
 
             if (!(attr instanceof Boolean) && !(attr instanceof CodeList)) {
-                if (attr != null)
+                if (attr != null) {
                     return attr.toString();
+                }
                 return ""; //$NON-NLS-1$
             }
 
             if (attr instanceof Boolean) {
-                if (((Boolean) attr).booleanValue())
+                if (((Boolean) attr).booleanValue()) {
                     return Integer.valueOf(1);
+                }
                 return Integer.valueOf(0);
             }
             if (attr instanceof CodeList) {
@@ -266,86 +263,91 @@ public class FeaturePropertySource implements IPropertySource2 {
         }
         return null;
     }
-    
+
     public SimpleFeature getFeature() {
         return feature;
     }
-    
-    /**
-     * @see org.eclipse.ui.views.properties.IPropertySource#isPropertySet(java.lang.Object)
-     */
-    public boolean isPropertySet( Object id ) {
-        if (id.equals(ID))
+
+    @Override
+    public boolean isPropertySet(Object id) {
+        if (id.equals(ID)) {
             return feature.getID() == old.getID();
-        if (id.equals(DEFAULT_GEOM))
+        }
+        if (id.equals(DEFAULT_GEOM)) {
             return feature.getDefaultGeometry() == old.getDefaultGeometry();
-        if (id.equals(BOUNDING_BOX))
+        }
+        if (id.equals(BOUNDING_BOX)) {
             return feature.getBounds() == old.getBounds();
+        }
         if (id instanceof Integer) {
             int i = ((Integer) id).intValue();
             Object attr = feature.getAttribute(i);
             if (attr instanceof String || attr instanceof Integer || attr instanceof Double
-                    || attr instanceof Float || attr instanceof Boolean)
+                    || attr instanceof Float || attr instanceof Boolean) {
                 return attr.equals(old.getAttribute(i));
+            }
         }
         return false;
     }
-    /**
-     * @see org.eclipse.ui.views.properties.IPropertySource#resetPropertyValue(java.lang.Object)
-     */
-    public void resetPropertyValue( Object id ) {
+
+    @Override
+    public void resetPropertyValue(Object id) {
         try {
             if (id instanceof Integer) {
                 int i = ((Integer) id).intValue();
                 Object attr = feature.getAttribute(i);
                 if (attr instanceof String || attr instanceof Integer || attr instanceof Double
-                        || attr instanceof Float || attr instanceof Boolean)
+                        || attr instanceof Float || attr instanceof Boolean) {
                     feature.setAttribute(i, old.getAttribute(i));
+                }
             }
         } catch (Exception e) {
             e.printStackTrace();
         }
     }
 
-    public void setPropertyValue( Object id, Object value ) {
+    @Override
+    public void setPropertyValue(Object id, Object value) {
         try {
             if (id instanceof Integer) {
                 int i = ((Integer) id).intValue();
                 Object attr = feature.getAttribute(i);
-                //for String check and nullify if empty
+                // for String check and nullify if empty
                 if (attr instanceof String) {
                     value = StringUtils.trimToNull((String) value);
                 }
                 if (hasValueChanged(value, attr)) {
-                    EditCommand command = (EditCommand) EditCommandFactory.getInstance().createSetAttributeCommand(
-                            attrs.get(i).getName().getLocalPart(), value);
+                    EditCommand command = (EditCommand) EditCommandFactory.getInstance()
+                            .createSetAttributeCommand(attrs.get(i).getName().getLocalPart(),
+                                    value);
                     map.sendCommandASync(command);
                 }
                 if (attr instanceof String) {
                     feature.setAttribute(i, value);
                 } else if (attr instanceof Integer) {
-                    feature.setAttribute(i, (Integer)value);
-                }else if (attr instanceof Long) {
-                    feature.setAttribute(i, (Long) value);
+                    feature.setAttribute(i, value);
+                } else if (attr instanceof Long) {
+                    feature.setAttribute(i, value);
                 } else if (attr instanceof Double) {
-                    feature.setAttribute(i, (Double) value);
+                    feature.setAttribute(i, value);
                 } else if (attr instanceof Float) {
-                    feature.setAttribute(i, (Float) value);
+                    feature.setAttribute(i, value);
                 } else if (attr instanceof Boolean) {
-                    feature.setAttribute(i, Boolean.valueOf(((Integer) value).intValue() == 0
-                            ? true : false));
+                    feature.setAttribute(i,
+                            Boolean.valueOf(((Integer) value).intValue() == 0 ? true : false));
                 } else if (attr == null) {
-                    //if attr value is initially null the feature.getAttribute(i) 
-                    //will return null. In this case, set the value by obtaining its name 
-                    //from the AttributeDescriptor list
+                    // if attr value is initially null the feature.getAttribute(i)
+                    // will return null. In this case, set the value by obtaining its name
+                    // from the AttributeDescriptor list
                     feature.setAttribute(attrs.get(i).getName().getLocalPart(), value);
                 }
             }
             if (value instanceof Geometry) {
-                if (id.equals(DEFAULT_GEOM)){
-                    feature.setDefaultGeometry((Geometry) value);
+                if (id.equals(DEFAULT_GEOM)) {
+                    feature.setDefaultGeometry(value);
 
-                    EditCommand command = (EditCommand) EditCommandFactory.getInstance().createSetGeometryCommand((Geometry) value);
+                    EditCommand command = (EditCommand) EditCommandFactory.getInstance()
+                            .createSetGeometryCommand((Geometry) value);
                     map.sendCommandASync(command);
                 }
             }
@@ -356,14 +358,15 @@ public class FeaturePropertySource implements IPropertySource2 {
 
     private boolean hasValueChanged(Object newValue, Object currentValue) {
         if (newValue == null && currentValue == null) {
-                return false;
-        } if (newValue != null && newValue.equals(currentValue)) {
-                return false;
+            return false;
+        }
+        if (newValue != null && newValue.equals(currentValue)) {
+            return false;
         }
         return true;
     }
-    
-    private Object getGeomProperty( Geometry id ) {
+
+    private Object getGeomProperty(Geometry id) {
         Object geom = geomProperties.get(id);
         if (geom == null) {
             geom = new GeomPropertySource(id);
@@ -371,7 +374,8 @@ public class FeaturePropertySource implements IPropertySource2 {
         }
         return geom;
     }
-    private Object getAttrProperty( AttributeDescriptor id, Object value ) {
+
+    private Object getAttrProperty(AttributeDescriptor id, Object value) {
         Object attr = attrProperties.get(id);
         if (attr == null) {
             attr = new AttributePropertySource(id, value);
@@ -381,10 +385,8 @@ public class FeaturePropertySource implements IPropertySource2 {
 
     }
 
-    /**
-     * @see org.eclipse.ui.views.properties.IPropertySource2#isPropertyResettable(java.lang.Object)
-     */
-    public boolean isPropertyResettable( Object id ) {
+    @Override
+    public boolean isPropertyResettable(Object id) {
         return true;
     }
 }


### PR DESCRIPTION
Issues are ...
- Use of diamond operator <>
- Add annotation `@Override`
- Add curly-braces to if (and else)
- Add null-check
- Rename local variable in order to separate class variables with method variables
- Removal of unnecessary casts