### PR TITLE
Add method to create a default ReferencedEnvelope

### DIFF
--- a/plugins/org.locationtech.udig.project.tests/src/org/locationtech/udig/project/internal/ViewportModelImplTest.java
+++ b/plugins/org.locationtech.udig.project.tests/src/org/locationtech/udig/project/internal/ViewportModelImplTest.java
@@ -12,6 +12,7 @@ package org.locationtech.udig.project.internal;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
 
 import java.awt.Dimension;
 import java.util.Collections;
@@ -62,9 +63,6 @@ public class ViewportModelImplTest {
         viewportModel.setBounds(-140, -120, 40, 60);
         assertEquals(1.0d, viewportModel.getBounds().getWidth() / viewportModel.getHeight(),
                 ACCURACY);
-
-        // assertEquals(calculateScale(viewportModel.getBounds(), viewportModel.getCRS(), 500,500),
-        // viewportModel.getScaleDenominator());
     }
 
     /**
@@ -84,6 +82,7 @@ public class ViewportModelImplTest {
                 250, 250);
         double viewportResults = viewportModel.getScaleDenominator();
         double d = Math.abs(trueScale - viewportResults);
+        assertTrue(d + " should be less than " + ACCURACY, d < ACCURACY); //$NON-NLS-1$
     }
 
     /**
@@ -103,7 +102,7 @@ public class ViewportModelImplTest {
                 100, 100);
         double viewportResults = viewportModel.getScaleDenominator();
         double d = Math.abs(trueScale - viewportResults);
-        // assertTrue(d+" should be less than "+ACCURACY_SCALE, d< ACCURACY_SCALE ); //$NON-NLS-1$
+        assertTrue(d + " should be less than " + ACCURACY, d < ACCURACY); //$NON-NLS-1$
     }
 
     /**
@@ -116,14 +115,14 @@ public class ViewportModelImplTest {
         ViewportModel viewportModel = map.getViewportModelInternal();
         viewportModel.setCRS(DefaultGeographicCRS.WGS84);
         viewportModel.setBounds(500, 500, 1000, 1000);
-        // assertEquals(1.0d, viewportModel.getBounds().getWidth()/viewportModel.getHeight(),
-        // ACCURACY);
+        assertEquals(1.0d, viewportModel.getBounds().getWidth() / viewportModel.getHeight(),
+                ACCURACY);
 
         double trueScale = calculateScale(new Envelope(-180, -80, -90, 10), viewportModel.getCRS(),
                 100, 100);
         double viewportResults = viewportModel.getScaleDenominator();
         double d = Math.abs(trueScale - viewportResults);
-        // assertTrue(d+" should be less than "+ACCURACY_SCALE, d< ACCURACY_SCALE ); //$NON-NLS-1$
+        assertTrue(d + " should be less than " + ACCURACY, d < ACCURACY); //$NON-NLS-1$
     }
 
     @Test
@@ -139,7 +138,7 @@ public class ViewportModelImplTest {
 
     private static double calculateScale(Envelope envelope,
             CoordinateReferenceSystem coordinateReferenceSystem, int imageWidth, int imageHeight)
-                    throws Exception {
+            throws Exception {
         ReferencedEnvelope bounds = new ReferencedEnvelope(envelope, coordinateReferenceSystem);
         bounds.transform(DefaultGeographicCRS.WGS84, true);
 

--- a/plugins/org.locationtech.udig.project/src/org/locationtech/udig/project/internal/impl/InitMapBoundsInterceptor.java
+++ b/plugins/org.locationtech.udig.project/src/org/locationtech/udig/project/internal/impl/InitMapBoundsInterceptor.java
@@ -10,12 +10,14 @@
  */
 package org.locationtech.udig.project.internal.impl;
 
+import java.util.List;
+
 import org.geotools.geometry.jts.ReferencedEnvelope;
+import org.locationtech.udig.project.ILayer;
 import org.locationtech.udig.project.interceptor.LayerInterceptor;
 import org.locationtech.udig.project.internal.Layer;
 import org.locationtech.udig.project.internal.Map;
 import org.locationtech.udig.project.internal.render.ViewportModel;
-import org.locationtech.udig.project.internal.render.impl.ViewportModelImpl;
 import org.locationtech.udig.ui.ProgressManager;
 
 /**
@@ -40,11 +42,14 @@ public class InitMapBoundsInterceptor implements LayerInterceptor {
         final ViewportModel viewportModel = map.getViewportModelInternal();
 
         ReferencedEnvelope bounds = viewportModel.getBounds();
-        // If first layer or if the CRS has been unchanged from the original BBox
-        if (map.getMapLayers().size() == 1
-                || bounds == ViewportModelImpl.getDefaultReferencedEnvelope()) {
-            bounds = map.getBounds(ProgressManager.instance().get());
-            viewportModel.setBounds(bounds);
+        // If the map has one layer and if the CRS has been unchanged from the original BBox
+        final List<ILayer> mapLayers = map.getMapLayers();
+        if (mapLayers.size() == 1 || bounds.equals(ViewportModel.getNullReferenceEnvelope())) {
+            bounds = mapLayers.get(0).getBounds(ProgressManager.instance().get(),
+                    viewportModel.getCRS());
+            if (!bounds.isNull()) {
+                viewportModel.setBounds(bounds);
+            }
         }
     }
 

--- a/plugins/org.locationtech.udig.project/src/org/locationtech/udig/project/internal/render/ViewportModel.java
+++ b/plugins/org.locationtech.udig.project/src/org/locationtech/udig/project/internal/render/ViewportModel.java
@@ -1,4 +1,5 @@
-/* uDig - User Friendly Desktop Internet GIS client
+/**
+ * uDig - User Friendly Desktop Internet GIS client
  * http://udig.refractions.net
  * (C) 2004-2012, Refractions Research Inc.
  *
@@ -52,8 +53,10 @@ public interface ViewportModel extends EObject, IMapDisplayListener, IViewportMo
     public CoordinateReferenceSystem getCRS();
 
     /**
-     * Sets the value of the '{@link org.locationtech.udig.project.internal.render.ViewportModel#getCRS <em>CRS</em>}' attribute.
-     * <!-- begin-user-doc --> <!-- end-user-doc -->
+     * Sets the value of the
+     * '{@link org.locationtech.udig.project.internal.render.ViewportModel#getCRS <em>CRS</em>}'
+     * attribute. <!-- begin-user-doc --> <!-- end-user-doc -->
+     *
      * @param value the new value of the '<em>CRS</em>' attribute.
      * @see #isSetCRS()
      * @see #unsetCRS()
@@ -68,9 +71,10 @@ public interface ViewportModel extends EObject, IMapDisplayListener, IViewportMo
      * This set is used to provide good options for a user to change the scale
      * </p>
      * <p>
-     * The values will always be present but if the object returned by {@link #getDefaultPreferredScaleDenominators()} and this method
-     * are the same <em>instance</em> then they are simply defaults and can be ignored if desired.  However if they are not the same
-     * then assume that the values are only hints and can be ignored
+     * The values will always be present but if the object returned by
+     * {@link #getDefaultPreferredScaleDenominators()} and this method are the same
+     * <em>instance</em> then they are simply defaults and can be ignored if desired. However if
+     * they are not the same then assume that the values are only hints and can be ignored
      * </p>
      *
      * @see #getScaleDenominator() for a definition of scale denominator
@@ -81,7 +85,9 @@ public interface ViewportModel extends EObject, IMapDisplayListener, IViewportMo
     public SortedSet<Double> getPreferredScaleDenominators();
 
     /**
-     * Sets the value of the '{@link org.locationtech.udig.project.internal.render.ViewportModel#getPreferredScaleDenominators <em>Preferred Scale Denominators</em>}' attribute.
+     * Sets the value of the
+     * '{@link org.locationtech.udig.project.internal.render.ViewportModel#getPreferredScaleDenominators
+     * <em>Preferred Scale Denominators</em>}' attribute.
      *
      * If set to null getPreferredScaleDenominators will return the defaults.
      *
@@ -92,8 +98,10 @@ public interface ViewportModel extends EObject, IMapDisplayListener, IViewportMo
     void setPreferredScaleDenominators(SortedSet<Double> value);
 
     /**
-     * Unsets the value of the '{@link org.locationtech.udig.project.internal.render.ViewportModel#getCRS <em>CRS</em>}' attribute.
-     * <!-- begin-user-doc --> <!-- end-user-doc -->
+     * Unsets the value of the
+     * '{@link org.locationtech.udig.project.internal.render.ViewportModel#getCRS <em>CRS</em>}'
+     * attribute. <!-- begin-user-doc --> <!-- end-user-doc -->
+     *
      * @see #isSetCRS()
      * @see #getCRS()
      * @see #setCRS(CoordinateReferenceSystem)
@@ -102,8 +110,10 @@ public interface ViewportModel extends EObject, IMapDisplayListener, IViewportMo
     void unsetCRS();
 
     /**
-     * Returns whether the value of the '{@link org.locationtech.udig.project.internal.render.ViewportModel#getCRS <em>CRS</em>}' attribute is set.
-     * <!-- begin-user-doc --> <!-- end-user-doc -->
+     * Returns whether the value of the
+     * '{@link org.locationtech.udig.project.internal.render.ViewportModel#getCRS <em>CRS</em>}'
+     * attribute is set. <!-- begin-user-doc --> <!-- end-user-doc -->
+     *
      * @return whether the value of the '<em>CRS</em>' attribute is set.
      * @see #unsetCRS()
      * @see #getCRS()
@@ -127,9 +137,10 @@ public interface ViewportModel extends EObject, IMapDisplayListener, IViewportMo
     public ReferencedEnvelope getBounds();
 
     /**
-     * Sets the value of the '{@link org.locationtech.udig.project.internal.render.ViewportModel#getBounds <em>Bounds</em>}' attribute.
-     * <!-- begin-user-doc -->
-     * <!-- end-user-doc -->
+     * Sets the value of the
+     * '{@link org.locationtech.udig.project.internal.render.ViewportModel#getBounds
+     * <em>Bounds</em>}' attribute. <!-- begin-user-doc --> <!-- end-user-doc -->
+     *
      * @param value the new value of the '<em>Bounds</em>' attribute.
      * @see #getBounds()
      * @generated
@@ -138,20 +149,23 @@ public interface ViewportModel extends EObject, IMapDisplayListener, IViewportMo
 
     /**
      * Set the bounds of the viewport model
+     *
      * @param value the new desired bounds
-     * @param forceContainBBoxZoom Whether or not the {@link #setBounds(ReferencedEnvelope)} will always contain the
-     * 				envelope after execution.  In normal execution this is not an issue but if
-     * 				{@link #setPreferredScaleDenominators(SortedSet)} has been called then this does matter because
-     * 				zoom to features will not necessary contain all the features.  When taking into account
-     * 				preferredScaleDenominators setting the bounds the closest scale to the desired scale is chosen.
-     * 				This can mean that the scale chosen will not be able to fit the entire bounds.  This is fine
-     * 				when zooming but in other cases it is not acceptable
+     * @param forceContainBBoxZoom Whether or not the {@link #setBounds(ReferencedEnvelope)} will
+     *        always contain the envelope after execution. In normal execution this is not an issue
+     *        but if {@link #setPreferredScaleDenominators(SortedSet)} has been called then this
+     *        does matter because zoom to features will not necessary contain all the features. When
+     *        taking into account preferredScaleDenominators setting the bounds the closest scale to
+     *        the desired scale is chosen. This can mean that the scale chosen will not be able to
+     *        fit the entire bounds. This is fine when zooming but in other cases it is not
+     *        acceptable
      */
     void setBounds(ReferencedEnvelope value, boolean forceContainBBoxZoom);
 
     /**
-     * Sets the value of the '{@link org.locationtech.udig.project.internal.render.ViewportModel#getBounds <em>Bounds</em>}'
-     * attribute. <!-- begin-user-doc -->
+     * Sets the value of the
+     * '{@link org.locationtech.udig.project.internal.render.ViewportModel#getBounds
+     * <em>Bounds</em>}' attribute. <!-- begin-user-doc -->
      * <p>
      * The bbox must have a positive width and height and must have a aspect ratio within 0.0000001
      * units of the value returned by {@linkplain #getAspectRatio()} .
@@ -159,7 +173,7 @@ public interface ViewportModel extends EObject, IMapDisplayListener, IViewportMo
      * <p>
      * It is recommended that setHeight() or setWidth() methods are used since they preserve the
      * aspect ratio of the Viewport
-     * <p>
+     * </p>
      * <!-- end-user-doc -->
      *
      * @param value the new value of the '<em>Bounds</em>' attribute.
@@ -169,8 +183,8 @@ public interface ViewportModel extends EObject, IMapDisplayListener, IViewportMo
     void setBounds(Envelope value);
 
     /**
-     * Sets the viewport's bounding box. The bounding box will be fit to the window based on the MapDisplay so
-     * the bounds provided here may not be the final bounds.
+     * Sets the viewport's bounding box. The bounding box will be fit to the window based on the
+     * MapDisplay so the bounds provided here may not be the final bounds.
      *
      * @param minx the minimum x value of the new bounding box.
      * @param maxx the maximum x value of the new bounding box.
@@ -193,8 +207,10 @@ public interface ViewportModel extends EObject, IMapDisplayListener, IViewportMo
     public Coordinate getCenter();
 
     /**
-     * Sets the value of the '{@link org.locationtech.udig.project.internal.render.ViewportModel#getCenter <em>Center</em>}' attribute.
-     * <!-- begin-user-doc --> <!-- end-user-doc -->
+     * Sets the value of the
+     * '{@link org.locationtech.udig.project.internal.render.ViewportModel#getCenter
+     * <em>Center</em>}' attribute. <!-- begin-user-doc --> <!-- end-user-doc -->
+     *
      * @param value the new value of the '<em>Center</em>' attribute.
      * @see #getCenter()
      * @generated
@@ -212,8 +228,10 @@ public interface ViewportModel extends EObject, IMapDisplayListener, IViewportMo
     public double getHeight();
 
     /**
-     * Sets the value of the '{@link org.locationtech.udig.project.internal.render.ViewportModel#getHeight <em>Height</em>}' attribute.
-     * <!-- begin-user-doc --> <!-- end-user-doc -->
+     * Sets the value of the
+     * '{@link org.locationtech.udig.project.internal.render.ViewportModel#getHeight
+     * <em>Height</em>}' attribute. <!-- begin-user-doc --> <!-- end-user-doc -->
+     *
      * @param value the new value of the '<em>Height</em>' attribute.
      * @see #getHeight()
      * @generated
@@ -231,8 +249,10 @@ public interface ViewportModel extends EObject, IMapDisplayListener, IViewportMo
     public double getWidth();
 
     /**
-     * Sets the value of the '{@link org.locationtech.udig.project.internal.render.ViewportModel#getWidth <em>Width</em>}' attribute.
-     * <!-- begin-user-doc --> <!-- end-user-doc -->
+     * Sets the value of the
+     * '{@link org.locationtech.udig.project.internal.render.ViewportModel#getWidth <em>Width</em>}'
+     * attribute. <!-- begin-user-doc --> <!-- end-user-doc -->
+     *
      * @param value the new value of the '<em>Width</em>' attribute.
      * @see #getWidth()
      * @generated
@@ -257,8 +277,10 @@ public interface ViewportModel extends EObject, IMapDisplayListener, IViewportMo
     public Map getMapInternal();
 
     /**
-     * Sets the value of the '{@link org.locationtech.udig.project.internal.render.ViewportModel#getMapInternal <em>Map Internal</em>}' container reference.
-     * <!-- begin-user-doc --> <!-- end-user-doc -->
+     * Sets the value of the
+     * '{@link org.locationtech.udig.project.internal.render.ViewportModel#getMapInternal <em>Map
+     * Internal</em>}' container reference. <!-- begin-user-doc --> <!-- end-user-doc -->
+     *
      * @param value the new value of the '<em>Map Internal</em>' container reference.
      * @see #getMapInternal()
      * @generated
@@ -266,14 +288,16 @@ public interface ViewportModel extends EObject, IMapDisplayListener, IViewportMo
     void setMapInternal(Map value);
 
     /**
-     * Returns the value of the '<em><b>Render Manager Internal</b></em>' reference.
-     * It is bidirectional and its opposite is '{@link org.locationtech.udig.project.internal.render.RenderManager#getViewportModelInternal <em>Viewport Model Internal</em>}'.
-     * <!-- begin-user-doc -->
+     * Returns the value of the '<em><b>Render Manager Internal</b></em>' reference. It is
+     * bidirectional and its opposite is
+     * '{@link org.locationtech.udig.project.internal.render.RenderManager#getViewportModelInternal
+     * <em>Viewport Model Internal</em>}'. <!-- begin-user-doc -->
      * <p>
-     * If the meaning of the '<em>Render Manager</em>' reference isn't clear, there really
-     * should be more of a description here...
+     * If the meaning of the '<em>Render Manager</em>' reference isn't clear, there really should be
+     * more of a description here...
      * </p>
      * <!-- end-user-doc -->
+     *
      * @return the value of the '<em>Render Manager Internal</em>' reference.
      * @see #setRenderManagerInternal(RenderManager)
      * @see org.locationtech.udig.project.internal.render.RenderPackage#getViewportModel_RenderManagerInternal()
@@ -284,8 +308,10 @@ public interface ViewportModel extends EObject, IMapDisplayListener, IViewportMo
     RenderManager getRenderManagerInternal();
 
     /**
-     * Sets the value of the '{@link org.locationtech.udig.project.internal.render.ViewportModel#getRenderManagerInternal <em>Render Manager Internal</em>}' reference.
-     * <!-- begin-user-doc --> <!-- end-user-doc -->
+     * Sets the value of the
+     * '{@link org.locationtech.udig.project.internal.render.ViewportModel#getRenderManagerInternal
+     * <em>Render Manager Internal</em>}' reference. <!-- begin-user-doc --> <!-- end-user-doc -->
+     *
      * @param value the new value of the '<em>Render Manager Internal</em>' reference.
      * @see #getRenderManagerInternal()
      * @generated
@@ -325,9 +351,10 @@ public interface ViewportModel extends EObject, IMapDisplayListener, IViewportMo
 
     /**
      * Returns the size of a pixel in world units.
-     * <p>For example if the world is in WGS 84(lat long) then
-     * the size will be in degrees
+     * <p>
+     * For example if the world is in WGS 84(lat long) then the size will be in degrees
      * </p>
+     *
      * @return the size of a pixel in world units.
      * @model volatile="true" changeable="false" transient="true"
      */
@@ -423,27 +450,32 @@ public interface ViewportModel extends EObject, IMapDisplayListener, IViewportMo
     public void setInitialized(boolean initialized);
 
     /**
-     * Sets the zoom level of the viewport so that the scale denominator will be equal to
-     * scale
+     * Sets the zoom level of the viewport so that the scale denominator will be equal to scale
      *
      * @param scaleDenominator desired scale denominator
      */
     public void setScale(double scaleDenominator);
 
     /**
-     * Sets the zoom level of the viewport so that the scale denominator will be equal to
-     * scale
+     * Sets the zoom level of the viewport so that the scale denominator will be equal to scale
      *
      * @param scaleDenominator desired scale denominator
      */
     public void setScale(double scaleDenominator, int dpi, int displayWidth, int displayHeight);
 
     /**
-     * The attribute indicates that any upcoming changes to the value
-     * of the model should be consider a single event.
+     * The attribute indicates that any upcoming changes to the value of the model should be
+     * consider a single event.
      *
      * @param changing
      */
     public void setIsBoundsChanging(boolean changing);
 
+    /**
+     * @return reverence envelope with BAD_DEFAULT CRS and zero width and zero height for the
+     *         envelope at position 0/0.
+     */
+    static ReferencedEnvelope getNullReferenceEnvelope() {
+        return new ReferencedEnvelope(0, 0, 0, 0, BAD_DEFAULT);
+    }
 }

--- a/plugins/org.locationtech.udig.project/src/org/locationtech/udig/project/render/IViewportModel.java
+++ b/plugins/org.locationtech.udig.project/src/org/locationtech/udig/project/render/IViewportModel.java
@@ -1,4 +1,5 @@
-/* uDig - User Friendly Desktop Internet GIS client
+/**
+ * uDig - User Friendly Desktop Internet GIS client
  * http://udig.refractions.net
  * (C) 2004-2012, Refractions Research Inc.
  *
@@ -14,14 +15,11 @@ import java.awt.Point;
 import java.awt.geom.AffineTransform;
 import java.util.SortedSet;
 
-import org.locationtech.udig.project.IMap;
-import org.locationtech.udig.project.internal.render.impl.ViewportModelImpl;
-
 import org.geotools.geometry.jts.ReferencedEnvelope;
-import org.opengis.referencing.crs.CoordinateReferenceSystem;
-
 import org.locationtech.jts.geom.Coordinate;
 import org.locationtech.jts.geom.Envelope;
+import org.locationtech.udig.project.IMap;
+import org.opengis.referencing.crs.CoordinateReferenceSystem;
 
 /**
  * Models the Viewport on the map.
@@ -30,11 +28,6 @@ import org.locationtech.jts.geom.Envelope;
  * @since 0.5
  */
 public interface IViewportModel {
-
-    /**
-     * A Default setting to use for the viewport CRS.
-     */
-    public static final CoordinateReferenceSystem DEFAULT_CRS = ViewportModelImpl.DEFAULT_CRS;
 
     /**
      * Returns the local coordinate system. The local coordinate system is the CRS that all the


### PR DESCRIPTION
New method is part of `ViewportModel.java` on the bottom of the file. This ReferencedEnvelope is used in other places also.

Additionally I refactored the `ViewportModel` a little bit according to the changes made in the project I am working in.